### PR TITLE
feat: Add hook output visibility to Copilot and Cursor settings

### DIFF
--- a/ai-agents/settings/copilot/hooks/goimports.sh
+++ b/ai-agents/settings/copilot/hooks/goimports.sh
@@ -10,5 +10,8 @@ if [[ "$FILE_PATH" != *.go ]]; then
 	exit 0
 fi
 
-# goimportsを実行
-goimports -w "$FILE_PATH"
+if ! goimports -w "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[goimports] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi

--- a/ai-agents/settings/copilot/hooks/markdown-format.sh
+++ b/ai-agents/settings/copilot/hooks/markdown-format.sh
@@ -10,5 +10,16 @@ if [[ "$FILE_PATH" != *.md ]]; then
 	exit 0
 fi
 
-markdownlint-cli2 --config "$SCRIPT_DIR/.markdownlint-cli2.yaml" --fix "$FILE_PATH"
-prettier --write "$FILE_PATH"
+# markdownlint-cli2
+if ! markdownlint-cli2 --config "$SCRIPT_DIR/.markdownlint-cli2.yaml" --fix "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[markdownlint] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi
+
+# prettier
+if ! prettier --write "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[prettier:md] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi

--- a/ai-agents/settings/copilot/hooks/prettier.sh
+++ b/ai-agents/settings/copilot/hooks/prettier.sh
@@ -7,6 +7,10 @@ FILE_PATH=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/get_file_path.py")
 
 case "$FILE_PATH" in
 *.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
-	prettier --write "$FILE_PATH"
+	if ! prettier --write "$FILE_PATH" 2>&1; then
+		rc=$?
+		echo "[prettier] fail: $FILE_PATH" >&2
+		exit "$rc"
+	fi
 	;;
 esac

--- a/ai-agents/settings/copilot/hooks/shfmt.sh
+++ b/ai-agents/settings/copilot/hooks/shfmt.sh
@@ -9,4 +9,8 @@ if [[ "$FILE_PATH" != *.sh ]]; then
 	exit 0
 fi
 
-shfmt -w "$FILE_PATH"
+if ! shfmt -w "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[shfmt] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi

--- a/ai-agents/settings/cursor/hooks/goimports.sh
+++ b/ai-agents/settings/cursor/hooks/goimports.sh
@@ -10,5 +10,8 @@ if [[ "$FILE_PATH" != *.go ]]; then
 	exit 0
 fi
 
-# goimportsを実行
-goimports -w "$FILE_PATH"
+if ! goimports -w "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[goimports] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi

--- a/ai-agents/settings/cursor/hooks/markdown-format.sh
+++ b/ai-agents/settings/cursor/hooks/markdown-format.sh
@@ -10,5 +10,16 @@ if [[ "$FILE_PATH" != *.md ]]; then
 	exit 0
 fi
 
-markdownlint-cli2 --config "$HOME/.claude/hooks/.markdownlint-cli2.yaml" --fix "$FILE_PATH"
-prettier --write "$FILE_PATH"
+# markdownlint-cli2
+if ! markdownlint-cli2 --config "$SCRIPT_DIR/.markdownlint-cli2.yaml" --fix "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[markdownlint] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi
+
+# prettier
+if ! prettier --write "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[prettier:md] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi

--- a/ai-agents/settings/cursor/hooks/prettier.sh
+++ b/ai-agents/settings/cursor/hooks/prettier.sh
@@ -7,6 +7,10 @@ FILE_PATH=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/get_file_path.py")
 
 case "$FILE_PATH" in
 *.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
-	prettier --write "$FILE_PATH"
+	if ! prettier --write "$FILE_PATH" 2>&1; then
+		rc=$?
+		echo "[prettier] fail: $FILE_PATH" >&2
+		exit "$rc"
+	fi
 	;;
 esac

--- a/ai-agents/settings/cursor/hooks/shfmt.sh
+++ b/ai-agents/settings/cursor/hooks/shfmt.sh
@@ -9,4 +9,8 @@ if [[ "$FILE_PATH" != *.sh ]]; then
 	exit 0
 fi
 
-shfmt -w "$FILE_PATH"
+if ! shfmt -w "$FILE_PATH" 2>&1; then
+	rc=$?
+	echo "[shfmt] fail: $FILE_PATH" >&2
+	exit "$rc"
+fi


### PR DESCRIPTION
## 実装経緯の説明

Claude hooks に実装済み（#386）のエラーハンドリング・失敗時ログ出力機能を、Copilot と Cursor の hooks にも適用した改善です。

## 補足

### 主な変更内容

- 各 hook に `if ! cmd 2>&1; then ... fi` を追加してエラーハンドリング強化
- 失敗時に stderr に `[hook名] fail: <file_path>` を出力し、ユーザーフィードバックを向上
- cursor/hooks/markdown-format.sh のバグ修正：`$HOME/.claude/hooks/.markdownlint-cli2.yaml` → `$SCRIPT_DIR/.markdownlint-cli2.yaml`

### 技術的な詳細

- **8ファイル変更**: ai-agents/settings/copilot/hooks/ と cursor/hooks/ の 4 hook スクリプトずつ
- **統一フォーマット**: エラーメッセージを `[hook名] fail: <file_path>` で統一
- **shellcheck 合格**: すべてのシェルスクリプトが静的解析を通過

### 確認事項

- [x] Copilot でテキストファイル Edit してログが表示されることを確認
- [x] Cursor でテキストファイル Edit してログが表示されることを確認
- [x] 各ツールで失敗時ログが stderr に出ることを確認