### PR TITLE
fix: ai-bridge launcher で bash -l をやめて cursor-agent の TUI 起動を許可する

### DIFF
--- a/scripts/ai-bridge/internal/launcher/tmux.go
+++ b/scripts/ai-bridge/internal/launcher/tmux.go
@@ -13,8 +13,11 @@ func shellQuote(s string) string {
 }
 
 // args returns the command-line arguments for tmux new-window.
+// Bash is intentionally invoked WITHOUT `-l` (login shell): some interactive
+// AI CLIs (e.g. cursor-agent) detect the login-shell context and refuse to
+// enter their TUI mode, causing the spawned window to exit immediately.
 func (t *Tmux) args(cwd, scriptPath string) []string {
-	shellCmd := "bash -l " + shellQuote(scriptPath)
+	shellCmd := "bash " + shellQuote(scriptPath)
 	return []string{"new-window", "-c", cwd, shellCmd}
 }
 

--- a/scripts/ai-bridge/internal/launcher/tmux_test.go
+++ b/scripts/ai-bridge/internal/launcher/tmux_test.go
@@ -18,13 +18,13 @@ func TestTmux_Args(t *testing.T) {
 			name:       "basic",
 			cwd:        "/home/user/project",
 			scriptPath: "/tmp/ai-bridge-12345.sh",
-			want:       []string{"new-window", "-c", "/home/user/project", "bash -l '/tmp/ai-bridge-12345.sh'"},
+			want:       []string{"new-window", "-c", "/home/user/project", "bash '/tmp/ai-bridge-12345.sh'"},
 		},
 		{
 			name:       "path with single quote",
 			cwd:        "/tmp",
 			scriptPath: "/tmp/ai-bridge-it's.sh",
-			want:       []string{"new-window", "-c", "/tmp", "bash -l '/tmp/ai-bridge-it'\"'\"'s.sh'"},
+			want:       []string{"new-window", "-c", "/tmp", "bash '/tmp/ai-bridge-it'\"'\"'s.sh'"},
 		},
 	}
 
@@ -53,14 +53,14 @@ func TestTmux_Launch(t *testing.T) {
 			cwd:        "/tmp",
 			scriptPath: "/tmp/script.sh",
 			wantName:   "tmux",
-			wantArgs:   []string{"new-window", "-c", "/tmp", "bash -l '/tmp/script.sh'"},
+			wantArgs:   []string{"new-window", "-c", "/tmp", "bash '/tmp/script.sh'"},
 		},
 		{
 			name:       "path with single quote is shell-quoted correctly",
 			cwd:        "/home/user/project",
 			scriptPath: "/tmp/ai-bridge-it's.sh",
 			wantName:   "tmux",
-			wantArgs:   []string{"new-window", "-c", "/home/user/project", "bash -l '/tmp/ai-bridge-it'\"'\"'s.sh'"},
+			wantArgs:   []string{"new-window", "-c", "/home/user/project", "bash '/tmp/ai-bridge-it'\"'\"'s.sh'"},
 		},
 	}
 

--- a/scripts/ai-bridge/internal/launcher/wezterm.go
+++ b/scripts/ai-bridge/internal/launcher/wezterm.go
@@ -6,8 +6,11 @@ type WezTerm struct {
 }
 
 // args returns the command-line arguments for wezterm cli spawn.
+// Bash is intentionally invoked WITHOUT `-l` (login shell): some interactive
+// AI CLIs (e.g. cursor-agent) detect the login-shell context and refuse to
+// enter their TUI mode, causing the spawned tab to exit immediately.
 func (w *WezTerm) args(cwd, scriptPath string) []string {
-	return []string{"cli", "spawn", "--cwd", cwd, "--", "bash", "-l", scriptPath}
+	return []string{"cli", "spawn", "--cwd", cwd, "--", "bash", scriptPath}
 }
 
 // Launch opens a new WezTerm tab and runs the script.

--- a/scripts/ai-bridge/internal/launcher/wezterm_test.go
+++ b/scripts/ai-bridge/internal/launcher/wezterm_test.go
@@ -18,13 +18,13 @@ func TestWezTerm_Args(t *testing.T) {
 			name:       "basic",
 			cwd:        "/home/user/project",
 			scriptPath: "/tmp/ai-bridge-12345.sh",
-			want:       []string{"cli", "spawn", "--cwd", "/home/user/project", "--", "bash", "-l", "/tmp/ai-bridge-12345.sh"},
+			want:       []string{"cli", "spawn", "--cwd", "/home/user/project", "--", "bash", "/tmp/ai-bridge-12345.sh"},
 		},
 		{
 			name:       "path with spaces",
 			cwd:        "/home/user/my project",
 			scriptPath: "/tmp/ai-bridge-99999.sh",
-			want:       []string{"cli", "spawn", "--cwd", "/home/user/my project", "--", "bash", "-l", "/tmp/ai-bridge-99999.sh"},
+			want:       []string{"cli", "spawn", "--cwd", "/home/user/my project", "--", "bash", "/tmp/ai-bridge-99999.sh"},
 		},
 	}
 
@@ -53,14 +53,14 @@ func TestWezTerm_Launch(t *testing.T) {
 			cwd:        "/tmp",
 			scriptPath: "/tmp/script.sh",
 			wantName:   "wezterm",
-			wantArgs:   []string{"cli", "spawn", "--cwd", "/tmp", "--", "bash", "-l", "/tmp/script.sh"},
+			wantArgs:   []string{"cli", "spawn", "--cwd", "/tmp", "--", "bash", "/tmp/script.sh"},
 		},
 		{
 			name:       "path with spaces is passed correctly",
 			cwd:        "/home/user/my project",
 			scriptPath: "/tmp/ai-bridge-99999.sh",
 			wantName:   "wezterm",
-			wantArgs:   []string{"cli", "spawn", "--cwd", "/home/user/my project", "--", "bash", "-l", "/tmp/ai-bridge-99999.sh"},
+			wantArgs:   []string{"cli", "spawn", "--cwd", "/home/user/my project", "--", "bash", "/tmp/ai-bridge-99999.sh"},
 		},
 	}
 


### PR DESCRIPTION
## 実装経緯の説明

`AI_BRIDGE_CLI=cursor-agent` で利用した際、WezTerm の新規タブが開いてすぐ閉じる事象が発生していた。
切り分けの結果、launcher 側が `bash -l <script>`（ログインシェル）で起動していたことが原因と判明。
cursor-agent は親シェルの login_shell コンテキストを検知すると TUI 対話モードに入らずに即終了する挙動を持っており、
これがタブの即時クローズに繋がっていた（claude では同じ事象は出ない）。

ai-bridge としてはログインシェルである必要は元々なく、生成スクリプトを実行できれば十分なため、
WezTerm / tmux 両 launcher から `-l` を削除する。

## チケット

N/A（事象発生から切り分け・修正までセッション内で完結）

## 補足

### 主な変更内容

- `scripts/ai-bridge/internal/launcher/wezterm.go`: `bash -l <script>` を `bash <script>` に変更
- `scripts/ai-bridge/internal/launcher/tmux.go`: 同上（tmux 側も挙動を揃える）
- 各 `_test.go`: 期待値を更新
- 両 launcher に「なぜ `-l` を付けないか」をコメントで明記し、将来の再混入を防止

### 技術的な詳細

- 切り分けで以下を確認済み:
  - `bash /tmp/test.sh` → cursor-agent が TUI 起動 ✅
  - `bash --noprofile --norc /tmp/test.sh` → TUI 起動 ✅
  - `bash -l /tmp/test.sh` → 即終了 ❌
  - `bash -lc "cursor-agent 'test'"` → 即終了 ❌
- `bash -lxc 'true'` のトレースで `/etc/profile` 系の初期化は無害であることを確認。
  つまりログインシェルというフラグ自体が cursor-agent の挙動を変えている。
- PATH は launchd plist の `EnvironmentVariables` 経由で渡しているため、
  ログインシェルを使わなくても CLI 解決に影響はなし。

### 確認事項

- [x] `make ai-bridge-test` パス
- [x] `make ai-bridge-build` パス
- [x] 実機で `AI_BRIDGE_CLI=cursor-agent` 起動時に WezTerm タブが TUI のまま残ることを確認
- [ ] tmux ランチャー利用時に同様に動作すること（必要な人がいれば確認）


Made with [Cursor](https://cursor.com)