### PR TITLE
chore: weztermの背景グラデーション色を調整

### DIFF
--- a/dotfiles/wezterm/appearance.lua
+++ b/dotfiles/wezterm/appearance.lua
@@ -72,7 +72,9 @@ return function(config)
 		{
 			source = {
 				Gradient = {
-					colors = { "#11111b", "#11111b" },
+					-- colors = { "#1e1e2e", "#1e1e2e" },
+					colors = { "#181825", "#181825" },
+					-- colors = { "#11111b", "#11111b" },
 					orientation = {
 						Linear = { angle = -30.0 },
 					},


### PR DESCRIPTION
## 実装経緯の説明

WezTermの背景グラデーションのベースカラーが暗すぎたため、Catppuccin Mocha のパレットに沿って階調を調整した。

## チケット

なし

## 補足

### 主な変更内容

- 背景グラデーションのベースカラーを `#11111b` から `#181825`（Catppuccin Mocha の Mantle 相当）に変更
- 将来の色調整を容易にするため、`#1e1e2e` と `#11111b` を候補としてコメントで残した

### 技術的な詳細

- `dotfiles/wezterm/appearance.lua` の `config.background` 内、Gradient ソースの `colors` を更新
- 見た目のみの変更でロジックへの影響はない

### 確認事項

- WezTerm を再起動し、背景グラデーションが意図した明るさになっているか
- タブバー背景（`#1e1e2e`）との階調が自然に見えるか