### PR TITLE
feat: Cursorに推論完了のmacOS通知フックを追加

### DIFF
--- a/ai-agents/settings/cursor/hooks.json
+++ b/ai-agents/settings/cursor/hooks.json
@@ -8,6 +8,7 @@
       { "command": "~/.cursor/hooks/prettier.sh" },
       { "command": "~/.cursor/hooks/stylua.sh" },
       { "command": "~/.cursor/hooks/tombi.sh" }
-    ]
+    ],
+    "stop": [{ "command": "~/.cursor/hooks/notify-macos.sh" }]
   }
 }

--- a/ai-agents/settings/cursor/hooks/notify-macos.sh
+++ b/ai-agents/settings/cursor/hooks/notify-macos.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# stdin から JSON を読み込む
+INPUT=$(cat)
+
+# stop イベントの status で通知本文を切り替える
+STATUS=$(echo "$INPUT" | jq -r '.status // ""')
+case "$STATUS" in
+aborted)
+	MESSAGE="処理が中断されたよ"
+	;;
+error)
+	MESSAGE="エラーで停止したよ"
+	;;
+*)
+	MESSAGE="推論が完了したよ"
+	;;
+esac
+
+# AppleScript の文字列を壊さないよう二重引用符を除去して通知
+osascript -e "display notification \"${MESSAGE//\"/}\" with title \"Cursor\"" 2>/dev/null || true


### PR DESCRIPTION
## 実装経緯の説明

Cursorで推論が完了したタイミングを見逃さないよう、macOSの通知を出したいという要望に対応する。Claude Code側には既に同等の通知フック(`notify-macos.sh`)があるため、Cursorにも同じ構成で追加した。

## チケット

なし(個人PDE改善)

## 補足

### 主な変更内容

- `ai-agents/settings/cursor/hooks/notify-macos.sh` を新規追加。Cursorの `stop` イベントの payload から `status` を読み取り、`completed`/`aborted`/`error` に応じて通知文言を切り替えて `osascript` で通知する
- `ai-agents/settings/cursor/hooks.json` に `stop` エントリを追加(既存の `afterFileEdit` フックは維持)

### 技術的な詳細

- stdin の JSON を `jq` でパースし、`status` で文言を分岐(`completed`→「推論が完了したよ」など)
- AppleScript 文字列を壊さないよう二重引用符をサニタイズし、`|| true` で fail open
- スクリプトは実行ビット付き(`100755`)。`copy-entries.sh` は `cp -p` するためデプロイ時も実行権限が保持される
- Cursorにはユーザー入力待ち専用イベントが存在しないため、今回は確実に取得できる `stop`(推論完了)のみを対象とした。許可待ち通知が必要になった場合は `beforeShellExecution`/`beforeMCPExecution` で別途対応する

### 確認事項

- `make cursor-settings-copy`(または `make settings-copy`)で `~/.cursor/` へ反映すること
- 反映後、Hooks設定タブ/Hooks出力チャンネルで `Loaded ... stop` がロードされること
- macOSの通知設定/集中モードで通知がブロックされていないこと

Made with [Cursor](https://cursor.com)