### PR TITLE
feat(nvim): カーソル行の診断を virtual_lines でインライン表示する

### DIFF
--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -94,11 +94,14 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
 -- Diagnostic 設定
 -- - virtual_text は無効、float で詳細を確認する
+-- - virtual_lines = { current_line = true } でカーソル行の診断だけを直下にインライン表示する
+--   (0.11 で追加。全行に出さず現在行に限定するので「普段はクリーン、必要な行だけ詳細」を維持できる)
 -- - ]d/[d でジャンプした際に on_jump コールバックから open_float を呼び、
 --   DiagnosticRelatedInformation も含めてその場で確認できるようにする
 --   (0.12 で `jump.float` は deprecated)
 vim.diagnostic.config({
 	virtual_text = false,
+	virtual_lines = { current_line = true },
 	jump = {
 		on_jump = function(_, bufnr)
 			vim.diagnostic.open_float({ bufnr = bufnr })


### PR DESCRIPTION
Closes #431

## 何を

`nvim/config/lua/lsp/init.lua` の `vim.diagnostic.config({...})` に `virtual_lines = { current_line = true }` を追加した。`virtual_text = false` は維持。

## なぜ

従来は `virtual_text = false` で、診断の詳細は `]d`/`[d` でジャンプした時の `open_float` でのみ確認できた。これだとカーソルをエラー行に置いただけでは内容が見えない。Neovim 0.11 で追加された `virtual_lines = { current_line = true }` を使うと、**カーソル行の診断だけ**を該当コードの直下に表示でき、「普段はクリーン、必要な行だけ詳細」という本設定の方針と整合する。新規プラグイン不要でコア機能のみで実現できる（本リポジトリは 0.12 前提）。

## 変更内容

- `virtual_lines = { current_line = true }` を 1 行追加（最小差分）
- 意図が分かるようコメントを併記

## 検証結果

- この実行環境には Lua ランタイム / stylua / nvim が無いため自動フォーマット・起動確認は未実施
- 差分はタブインデント・`{ key = value }` の空白入り波括弧など既存 stylua スタイルに準拠
- 反映後は `nvim` でカーソルをエラー行に移動し、直下に診断が表示されること、`virtual_text` と二重表示にならないことを手元で確認してほしい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee49CyAyHFAPypPzDpUcT3)_