### PR TITLE
feat(nvim): LSP インレイヒントを有効化し gopls の hints を設定

### DIFF
--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -32,6 +32,17 @@ vim.lsp.config("gopls", {
 				run_govulncheck = true,
 				gc_details = true,
 			},
+			-- gopls は hints を明示指定しないとインレイヒントを一切返さないため、
+			-- エディタ側の有効化 (LspAttach) と合わせてここで表示対象を指定する。
+			hints = {
+				assignVariableTypes = true,
+				compositeLiteralFields = true,
+				compositeLiteralTypes = true,
+				constantValues = true,
+				functionTypeParameters = true,
+				parameterNames = true,
+				rangeVariableTypes = true,
+			},
 		},
 	},
 })
@@ -88,6 +99,16 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		local client = vim.lsp.get_client_by_id(ev.data.client_id)
 		if client and client:supports_method("textDocument/codeLens") then
 			vim.lsp.codelens.enable(true, { bufnr = ev.buf })
+		end
+
+		-- Inlay hint (vim.lsp.inlay_hint) を対応サーバーで常時有効化する。
+		-- 変数の推論型・関数の引数名などをソースを書き換えずに仮想テキストで補足表示する。
+		-- ノイズに感じる場合は下の <space>h でバッファ単位にトグルできる。
+		if client and client:supports_method("textDocument/inlayHint") then
+			vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
+			vim.keymap.set("n", "<space>h", function()
+				vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = 0 }), { bufnr = 0 })
+			end, opts)
 		end
 	end,
 })


### PR DESCRIPTION
Closes #432

## 何を

`nvim/config/lua/lsp/init.lua` に LSP インレイヒント（`vim.lsp.inlay_hint`）を導入する。

1. **gopls の hint 設定を追加**: `settings.gopls.hints` に `assignVariableTypes` / `compositeLiteralFields` / `compositeLiteralTypes` / `constantValues` / `functionTypeParameters` / `parameterNames` / `rangeVariableTypes` を指定。
2. **LspAttach でインレイヒントを有効化**: 既存の codelens 有効化の直後に、`textDocument/inlayHint` をサポートするサーバーで `vim.lsp.inlay_hint.enable(true, ...)` を呼ぶ。
3. **トグルキーマップを追加**: バッファ単位でインレイヒントを ON/OFF する `<space>h` を追加。

## なぜ

Neovim 0.10 でコア標準となったインレイヒントが未活用だった。型推論（`:=`）を多用する Go (gopls) などで、定義元へジャンプせずに推論型・引数名・複合リテラルのフィールド名をその場で確認できるようになる。gopls は `settings.gopls.hints` を明示しないとヒントを返さないため、サーバー設定とエディタ側有効化の両方を入れている。新規プラグインは不要でコア API のみで完結する。

## Issue 提案からの差分（意図的な変更）

Issue の任意トグル案ではキーが素の `h` だったが、これは Normal モードの左移動（builtin motion）を潰してしまう。本設定既存の `<space>e` / `<space>q` / `<space>f` の慣習に合わせ、より安全な `<space>h` を採用した。Issue 本文でも「`h` は衝突しないか確認すること」と注意喚起されていた点への対応。

## 検証

- 変更は `nvim/config/lua/lsp/init.lua` の 1 ファイルのみ、最小差分。
- 既存の codelens 有効化・diagnostic 設定はそのまま、同じ tab インデント／記述スタイルに合わせて追記。
- ローカル環境に stylua / lua ランタイムが無いため自動フォーマット・構文チェックは未実行。差分は手動でインデント（tab）と括弧の対応を確認済み。CI のフォーマットチェックに委ねる。


---
_Generated by [Claude Code](https://claude.ai/code/session_01A2aZcyZYZMGsXNMQDtdi6p)_