### PR TITLE
chore: Neovim トレンドスキャンを毎日実行に変更

### DIFF
--- a/routines/daily-neovim-trend-scan.json
+++ b/routines/daily-neovim-trend-scan.json
@@ -1,9 +1,9 @@
 {
-  "name": "Weekly Neovim Trend Scan",
+  "name": "Daily Neovim Trend Scan",
   "trigger_id": "trig_01UdqdcQV6FGQkkbTvp3BJ3S",
   "enabled": true,
-  "cron_expression": "0 23 * * 5",
-  "schedule_note": "金 23:00 UTC = 毎週土曜 8:00 JST",
+  "cron_expression": "0 23 * * *",
+  "schedule_note": "毎日 23:00 UTC = 毎日 8:00 JST",
   "job_config": {
     "model": "claude-opus-4-8",
     "repository": "https://github.com/hodanov/my-pde",
@@ -16,7 +16,7 @@
     "リポジトリ構成:",
     "- Neovim 設定は nvim/config/ 配下。init.lua がエントリ、プラグインは lazy.nvim (nvim/config/lua/lazy_nvim.lua, plugins.lua) で管理。LSP 設定は nvim/config/lua/lsp/。主なプラグイン: blink.cmp, conform, nvim-lint, treesitter, telescope, gitsigns, lualine, nvim-dap, indent-blankline, textlint。",
     "",
-    "今週のタスク:",
+    "今日のタスク:",
     "1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の2つを両方取得する:",
     "   (1) 提案済みの Open Issue: gh issue list --state open --label \"scan:nvim\" --json number,title,body --limit 50",
     "   (2) 不採用となった Close 済み Issue: gh issue list --state closed --label \"scan:nvim\" --label \"rejected\" --json number,title,body --limit 50",


### PR DESCRIPTION
## 実装経緯の説明

Neovim 設定改善のトレンドスキャン用ルーチンを、週一(金 23:00 UTC = 毎週土 8:00 JST)から毎日実行に変更したい、という要望に対応。改善提案サイクルを早めるのが目的。

## 補足

### 主な変更内容

- cron を `0 23 * * 5` → `0 23 * * *` に変更（毎日 23:00 UTC = 毎日 8:00 JST）
- ルーチン名を `Weekly Neovim Trend Scan` → `Daily Neovim Trend Scan` に変更
- プロンプト内の「今週のタスク」を「今日のタスク」に修正
- 設定ファイルを `weekly-neovim-trend-scan.json` → `daily-neovim-trend-scan.json` にリネーム

### 技術的な詳細

- claude.ai 側のライブルーチン(`trig_01UdqdcQV6FGQkkbTvp3BJ3S`)も RemoteTrigger 経由で同内容に更新済み。本 PR はリポジトリ内の設定ファイルを実体に追従させるもの。
- next_run は 2026-06-28 08:00 JST 以降、毎朝。

### 確認事項

- [x] 毎日回すことで提案ネタが枯渇しやすくなる懸念あり（「起票せず終了」が増える可能性）。運用しながら頻度の再調整を検討。
- [x] ファイル名・ルーチン名・プロンプト文言が日次表現で揃っているか