### PR TITLE
feat: skill observation を Stop hook で自動記録する

### DIFF
--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -7,4 +7,4 @@ paths:
 
 - Required SKILL.md frontmatter: `name`, `description` (include the trigger phrases that should invoke it), and `metadata.version`. Add `argument-hint` for argument-taking skills, and `disable-model-invocation: true` (boolean, not the string `"true"`) for orchestrator-only skills.
 - Keep SKILL.md focused on the procedure. Move long reference material into a `references/` subdirectory so it loads only when needed (progressive disclosure).
-- Improvements flow through the Observe → Inspect → Amend → Evaluate loop (`/skill-observe`, `/skill-improve`). Bump `metadata.version` when amending a skill.
+- Improvements flow through the Observe → Inspect → Amend → Evaluate loop (`/skill-observe`, `/skill-improve`). The Observe phase is auto-captured by the `skill-observe-nudge.sh` Stop hook (Claude records observations on session end); `/skill-observe` remains for manual/supplementary recording. Bump `metadata.version` when amending a skill.

--- a/ai-agents/settings/claude/hooks/skill-observe-nudge.sh
+++ b/ai-agents/settings/claude/hooks/skill-observe-nudge.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Stop hook: detect repository skills used this session that have no observation
+# yet, and block once so Claude auto-records them (Observe phase automation).
+# Non-destructive — it only nudges; the observation content is written by Claude.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+
+TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""')
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""')
+STOP_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false')
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
+
+# Loop guard 1: we are already in a hook-triggered continuation.
+[ "$STOP_ACTIVE" = "true" ] && exit 0
+
+[ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || exit 0
+
+# Locate the repository and its skills directory.
+[ -n "$CWD" ] || CWD=$(pwd)
+ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+SKILLS_DIR="$ROOT/ai-agents/skills"
+[ -d "$SKILLS_DIR" ] || exit 0
+
+# Skills extracted from this session's transcript (Skill tool invocations).
+used=$(
+	jq -r 'select(.message.content != null)
+		| .message.content[]?
+		| select(.type == "tool_use" and .name == "Skill")
+		| .input.skill // empty' "$TRANSCRIPT" 2>/dev/null | sort -u
+)
+[ -n "$used" ] || exit 0
+
+# Session state: skills already nudged in this session (loop guard 2).
+state_dir="${TMPDIR:-/tmp}/claude-skill-observe-nudge"
+mkdir -p "$state_dir" 2>/dev/null || exit 0
+[ -n "$SESSION_ID" ] || SESSION_ID="default"
+state_file="$state_dir/$SESSION_ID"
+[ -f "$state_file" ] || : >"$state_file"
+
+pending=""
+while IFS= read -r skill; do
+	[ -n "$skill" ] || continue
+	# Only repository skills, excluding the improvement-loop skills themselves.
+	[ -f "$SKILLS_DIR/$skill/SKILL.md" ] || continue
+	case "$skill" in
+	skill-observe | skill-improve) continue ;;
+	esac
+	# Skip if already nudged this session.
+	if grep -qxF "$skill" "$state_file" 2>/dev/null; then
+		continue
+	fi
+	pending="${pending}${skill}"$'\n'
+	printf '%s\n' "$skill" >>"$state_file"
+done <<EOF
+$used
+EOF
+
+[ -n "$pending" ] || exit 0
+
+# Build a comma-separated list for the reason text.
+list=$(printf '%s' "$pending" | sed '/^$/d' | paste -sd ',' -)
+
+reason=$(
+	cat <<REASON
+今セッションで次のリポジトリスキルを使用したが observation が未記録です: ${list}
+
+各スキルについて、直近の使用結果を会話文脈から success / partial / failure で判定し、
+ai-agents/skills/<スキル名>/observations/$(date +%Y-%m-%d)_NNN_obs.md を作成してください。
+
+- 形式は ai-agents/skills/skill-observe/SKILL.md の6フィールド（タスク / スキル / 結果 /
+  問題 / フィードバック / コンテキスト）に従う。
+- NNN は当日連番。同日の既存ファイルと重複しないよう採番する。
+- 当日同スキルの observation が既にあればスキップしてよい。
+- ユーザーへの確認は不要。淡々と記録し、作成したファイルを1行で報告して終了する。
+- markdownlint を通すため、既存 observation ファイルの体裁に合わせる。
+REASON
+)
+
+jq -n --arg r "$reason" '{decision: "block", reason: $r}'
+exit 0

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -96,6 +96,10 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/skill-observe-nudge.sh"
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/notify-macos.sh"
           }
         ]

--- a/ai-agents/skills/skill-observe/SKILL.md
+++ b/ai-agents/skills/skill-observe/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   使用後に `/skill-observe <スキル名> <結果> [問題/フィードバック]` で呼び出す。
 argument-hint: "<スキル名> <success|partial|failure> [問題やフィードバック]"
 metadata:
-  version: 1
+  version: 2
 ---
 
 # /skill-observe スキル
@@ -85,6 +85,7 @@ date: YYYY-MM-DD
 
 ## Notes
 
+- observation は Stop hook（`ai-agents/settings/claude/hooks/skill-observe-nudge.sh`）が**自動記録**する。リポジトリスキルを使ったセッション終了時に、Claude がその場の文脈から結果を判定して observation を書き出す。本スキルは手動・補足記録およびバッチモード（引数なし）用として残る
 - observation ファイルは git 管理下に置く。`make claude-skills-copy` でローカル環境にもコピーされる
 - `/skill-improve` がこれらの observation を分析し、SKILL.md の改善提案を生成する
 - 1 日に複数回同じスキルの observation を記録しても問題ない（連番で区別）

--- a/docs/plan/2026-06-28_skill-observe-stop-hook-auto-capture.md
+++ b/docs/plan/2026-06-28_skill-observe-stop-hook-auto-capture.md
@@ -1,0 +1,143 @@
+# Plan: skill-observe を Stop hook で自動化する（方向A）
+
+## Context
+
+**なぜやるか**: `skill-observe` / `skill-improve` は改善ループ（Observe → Inspect →
+Amend → Evaluate）のために用意したが、実運用で回っていない。原因は **Observe の摩擦**:
+スキルを使うたびに手動で `/skill-observe` を起動し、結果と問題を毎回言語化する必要があり、
+面倒で続かない。結果として observation が溜まらず（現状 `credential-leak-prevention` の
+1 件のみ）、`skill-improve` も分析対象がなく回らない。
+
+「スキル使用後に毎回・決定論的に走る記録のトリガー」はまさに hook の領域（手動 skill
+ではなく）。本変更で **Observe の起動を hook に自動化** し、observation の中身は会話文脈を
+持つ Claude がその場で自動生成する。これで「トリガーの手間」と「内容を伝える手間」の両方を
+ゼロにする。`skill-improve`（Inspect/Amend）は人間承認が要る設計のため**手動のまま**。
+
+**決定事項（ユーザー確認済み）**:
+
+- 記録の主体: **Claude が自動で全部書く**（hook は検知して `decision:block` で差し戻し、
+  Claude が success/partial/failure 判定＋6フィールドを埋めて書き出す。ユーザー操作なし）。
+- 記録対象: **全結果（success 含む）**・`ai-agents/skills/` 配下の全リポジトリスキル。
+  ただし `skill-observe` / `skill-improve` 自身は除外。
+
+## 動作確認済みの前提
+
+- Claude Code の Stop hook は stdin で `transcript_path` / `session_id` / `cwd` /
+  `hook_event_name` を受け取る（公式ドキュメントで確認）。
+- transcript は JSONL。スキル起動は `tool_use` エントリ `name=="Skill"` として記録され、
+  `.input.skill` にスキル名が入る（実 transcript で確認済み）。
+  抽出: `jq -r '.message.content[]? | select(.type=="tool_use" and .name=="Skill") | .input.skill'`
+- Stop hook は `{"decision":"block","reason":"..."}` を stdout に返すと停止をブロックして
+  `reason` を Claude に差し戻し、会話を継続させられる（公式で確認）。
+- Stop hook は Claude Code 固有機能。Cursor/Copilot に Stop 相当はなく、既存の
+  `lint-changed.sh` / `notify-macos.sh` も Claude 専用。**よって本 hook も Claude のみ**で、
+  cursor/copilot 配下の変更は不要。
+
+## 変更内容
+
+### 1. 新規: `ai-agents/settings/claude/hooks/skill-observe-nudge.sh`
+
+Stop hook。既存 `lint-changed.sh` / `notify-macos.sh` の bash 3.2 互換・`jq` 利用・graceful
+exit のイディオムに合わせる。ロジック:
+
+1. `INPUT=$(cat)`。`command -v jq` が無ければ `exit 0`。
+2. `transcript_path` / `session_id` / `stop_hook_active` / `cwd` を `jq` で抽出。
+3. **ループガード①**: `stop_hook_active == "true"` なら `exit 0`（継続中の再発火を抑止）。
+4. `transcript_path` が空 or ファイル無しなら `exit 0`。
+5. リポジトリルートを `git -C "$cwd" rev-parse --show-toplevel` で特定。`ai-agents/skills`
+   が無ければ `exit 0`。
+6. **対象スキル集合**を構築: `ai-agents/skills/*/SKILL.md` の親ディレクトリ名一覧から
+   `skill-observe` / `skill-improve` を除外。
+7. **使用スキル**を transcript から抽出（上記 jq）→ ユニーク化 → 対象スキル集合と積集合 =
+   `used_skills`。
+8. **セッション状態ファイル**: `${TMPDIR:-/tmp}/claude-skill-observe-nudge/<session_id>`。
+   既に nudge 済みのスキルを読み、`pending = used_skills − 既 nudge` を計算。
+9. `pending` が空なら `exit 0`。
+10. **ループガード②（主防御）**: `pending` を状態ファイルに追記（`stop_hook_active` の有無に
+    関わらず、同一セッション・同一スキルは二度と nudge しない）。
+11. stdout に `{"decision":"block","reason":"<指示文>"}` を出力して `exit 0`。
+
+`reason` の指示文（日本語）の要点:
+
+- 「今セッションで次のリポジトリスキルを使用したが observation 未記録: `<pending一覧>`」
+- 各スキルについて、直近の使用結果を会話文脈から `success`/`partial`/`failure` で判定し、
+  `ai-agents/skills/<name>/observations/YYYY-MM-DD_NNN_obs.md` を
+  **`skill-observe` SKILL.md の6フィールド形式**（タスク/スキル/結果/問題/フィードバック/
+  コンテキスト）で作成せよ。`NNN` は当日連番、既存と重複しないよう採番。
+- 当日同スキルの observation が既にあればスキップ可。
+- **ユーザーへの確認は不要**。淡々と記録し、作成ファイルを1行で報告して終了せよ。
+- markdownlint を通すため既存 observation ファイルの体裁に合わせること
+  （Stop の `lint-changed.sh` が .md を検査するため）。
+
+**ループ安全性**: ブロック → Claude が obs を書く → 再 Stop。このときガード①
+（`stop_hook_active`）かガード②（状態ファイルに記録済みで `pending` 空）のいずれかで必ず
+`exit 0`。二重防御で無限ループしない。別セッションでは `session_id` が変わり状態ファイルも
+新規になるため、必要なら再度1回だけ nudge される（意図どおり）。
+
+ファイルは `chmod +x` で実行権限を付与（`copy-entries.sh` は `cp -p` で権限を維持するため）。
+
+### 2. 編集: `ai-agents/settings/claude/settings.json`
+
+`hooks.Stop[0].hooks` 配列に新 hook を追加（`notify-macos.sh` より前に置き、ブロック判定を
+先に行う）:
+
+```json
+"Stop": [
+  { "hooks": [
+      { "type": "command", "command": "~/.claude/hooks/lint-changed.sh" },
+      { "type": "command", "command": "~/.claude/hooks/skill-observe-nudge.sh" },
+      { "type": "command", "command": "~/.claude/hooks/notify-macos.sh" }
+  ] }
+]
+```
+
+### 3. 編集: `ai-agents/skills/skill-observe/SKILL.md`
+
+- `## Notes` に追記: 「observation は Stop hook（`skill-observe-nudge.sh`）が**自動記録**する
+  ようになった。本スキルは手動・補足記録およびバッチモード（引数なし）用として残る」。
+- skill-authoring ルールに従い `metadata.version` を 1 → 2 にバンプ。
+
+### 4. 編集: `.claude/rules/skill-authoring.md`（任意・軽微）
+
+改善ループの記述に「Observe フェーズは Stop hook により自動記録される（手動は補足用）」の
+一文を追加し、実態と整合させる。
+
+## デプロイ
+
+ソースは `ai-agents/settings/claude/` のみ変更。配布は既存ターゲットにそのまま乗る:
+
+```sh
+make claude-settings-copy   # 新 hook と settings.json を ~/.claude/ へ配布
+```
+
+（`make settings-copy` は cursor/copilot も含むが、本変更は claude 配下のみなので
+`claude-settings-copy` で十分。）
+
+## 検証
+
+**静的チェック**:
+
+- `shellcheck ai-agents/settings/claude/hooks/skill-observe-nudge.sh`
+- `jq . ai-agents/settings/claude/settings.json`（JSON 妥当性）
+
+**検知ロジックの単体確認**（実セッション前）:
+
+- scratchpad に「リポジトリスキル（例 `/review`）を使った合成 transcript JSONL」を作り、
+  `{"transcript_path":"...","session_id":"test","cwd":"<repo>"}` を stdin で渡して実行 →
+  `decision:block` と `pending` に該当スキルが出ることを確認。
+- `/schedule` など非リポジトリスキルだけの transcript では何も出力しない（`exit 0`）ことを確認。
+- 同じ stdin を2回流し、2回目は状態ファイルにより無出力（再 nudge しない）ことを確認。
+
+**E2E**（`make claude-settings-copy` 後、実セッション）:
+
+1. `/review` 等のリポジトリスキルを使ってターンを終える → hook がブロックし、Claude が
+   `ai-agents/skills/review/observations/<日付>_001_obs.md` を自動生成することを確認。
+2. 生成ファイルが6フィールド形式かつ markdownlint を通ることを確認。
+3. もう一度ターンを終える → 再ブロックされず通知のみ（ループしない）ことを確認。
+4. `/skill-improve review` が新しい observation を読めることを確認。
+
+## スコープ外
+
+- `skill-improve`（Inspect/Amend）の自動化はしない（人間承認が必要な設計のため手動維持）。
+- eval/benchmark 駆動の改善（公式 skill-creator 相当）は本 Issue では扱わない。
+- issue #443 の `skill-scaffold`（Create フェーズ）は別タスク。


### PR DESCRIPTION
## 実装経緯の説明

`skill-observe` / `skill-improve` で構成した改善ループ（Observe → Inspect → Amend → Evaluate）が実運用で回っていなかった。原因は **Observe フェーズの摩擦**で、スキルを使うたびに手動で `/skill-observe` を起動し結果を言語化する必要があり、面倒で続かず observation が溜まらず（現状 `credential-leak-prevention` の1件のみ）、`skill-improve` も分析対象を持てなかった。

「スキル使用後に毎回・決定論的に走る記録のトリガー」は hook の領域と判断し、**Observe の起動を Stop hook に自動化**する。observation の中身は会話文脈を持つ Claude がその場で自動生成するため、トリガーの手間も内容を伝える手間もゼロになる。

## 補足

### 主な変更内容

- **新規 Stop hook `skill-observe-nudge.sh`**: transcript から今セッションで使ったリポジトリスキル（`ai-agents/skills/` 配下、`skill-observe` / `skill-improve` は除外）を検出し、未記録があれば `decision:block` で差し戻す。Claude が success/partial/failure を判定して6フィールド形式の observation を自動生成する。
- `settings.json` の `Stop` に hook を配線（lint-changed → skill-observe-nudge → notify-macos）。
- `skill-observe/SKILL.md` に自動記録の旨を追記し `metadata.version` を 2 に更新。
- `.claude/rules/skill-authoring.md` に Observe 自動化の方針を追記。

### 技術的な詳細

- スキル起動は transcript JSONL の `tool_use`（`name=="Skill"`, `.input.skill`）から `jq` で抽出。
- **無限ループ二重ガード**: (1) `stop_hook_active` で継続中の再発火を抑止、(2) セッション状態ファイル（`$TMPDIR/claude-skill-observe-nudge/<session_id>`）で同一セッション・同一スキルの再 nudge を抑止。
- `Stop` / `transcript_path` / `decision:block` は Claude Code 固有のため、本 hook は `claude` 配下のみに追加（既存の `lint-changed.sh` / `notify-macos.sh` と同様 cursor/copilot は対象外）。
- `skill-improve`（Amend）は人間承認が必要な設計のため手動のまま据え置き。

### 確認事項

- `shellcheck` / `jq`(settings.json) / `markdownlint` green、検知ロジックの単体テスト5本パス（repo skill 検出ブロック・除外・二重ループガード・非リポスキル無反応・transcript 欠損 graceful）を確認済み。
- `make claude-settings-copy` で `~/.claude` へ配備し、実行権限と Stop 配線を確認済み。
- E2E: リポジトリスキルを使ってセッションを終え、observation が自動生成されること／再ブロックされないことを実セッションで確認したい。