### PR TITLE
feat(lsp): LspAttach で document highlight を有効化する

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -28,6 +28,7 @@ vim.opt.conceallevel = 0 -- Show double quotations in json file and so on.
 vim.g.mapleader = " " -- Set a space key to a leader.
 vim.opt.mouse = "" -- Don't use a mouse.
 vim.opt.signcolumn = "yes" -- Always show signcolumn to prevent rattling.
+vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
 
 -- ----------------------------------------
 -- Neovim 0.12 で追加された UI オプション

--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -110,6 +110,26 @@ vim.api.nvim_create_autocmd("LspAttach", {
 				vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = 0 }), { bufnr = 0 })
 			end, opts)
 		end
+
+		-- Document highlight (textDocument/documentHighlight) を対応サーバーで有効化する。
+		-- カーソルが一定時間止まったら (CursorHold) カーソル下シンボルの参照箇所をハイライトし、
+		-- カーソル移動 (CursorMoved) でクリアする。codelens / inlay hint と同じくコア機能のみで実現。
+		-- augroup を clear = false で保持しつつ当該バッファ分の autocmd だけ消してから貼り直すことで、
+		-- 同一バッファに複数 LSP がアタッチした際の CursorHold/CursorMoved 多重登録を防ぐ。
+		if client and client:supports_method("textDocument/documentHighlight") then
+			local hl_group = vim.api.nvim_create_augroup("UserLspDocumentHighlight", { clear = false })
+			vim.api.nvim_clear_autocmds({ group = hl_group, buffer = ev.buf })
+			vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+				group = hl_group,
+				buffer = ev.buf,
+				callback = vim.lsp.buf.document_highlight,
+			})
+			vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+				group = hl_group,
+				buffer = ev.buf,
+				callback = vim.lsp.buf.clear_references,
+			})
+		end
 	end,
 })
 


### PR DESCRIPTION
Closes #438

## 何を

`nvim/config/lua/lsp/init.lua` の `LspAttach` autocmd に、`textDocument/documentHighlight` を対応サーバーで有効化するブロックを追加した。あわせて `nvim/config/init.lua` に `vim.opt.updatetime = 300` を追加した。

- `CursorHold` / `CursorHoldI` で `vim.lsp.buf.document_highlight()` を呼び、カーソル下シンボルの参照箇所をハイライト。
- `CursorMoved` / `CursorMovedI` で `vim.lsp.buf.clear_references()` を呼びクリア。
- `augroup` は `clear = false` で保持しつつ、`nvim_clear_autocmds` で当該バッファ分の autocmd だけ消してから貼り直し、複数 LSP アタッチ時の多重登録を防止。

## なぜ

`LspAttach` は既に codelens / inlay hint を有効化しているが、同じく LSP コア機能の document highlight が未活用だった。カーソル下シンボルの読み書き箇所を `grr` でリストを開かずに一目で把握できる。新規プラグイン不要・既存の `supports_method` 分岐に1ブロック追加するだけで、設定の一貫性も保てる。

`updatetime` は既定 4000ms のままだと `CursorHold` が4秒後にしか発火せずハイライトが効かないように見えるため、300ms に調整（スワップ書き出し間隔も兼ねるため極端に小さくはしない）。

## 検証

- 変更は Lua 2ファイルのみ。最小差分で、既存ブロックのインデント（タブ）に合わせて追加。
- ローカルに stylua / Lua インタプリタが無いため CI（lint_stylua）での確認に委ねる。提案コードは issue 記載のコア API 慣用句に沿っており、既存の inlay hint ブロックと同一スタイル。

要 Neovim 0.11+（`client:supports_method`）。本設定は 0.12 前提のため問題なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_015LU1gGGerMx2w7j3eqFuPK)_