### PR TITLE
feat(skills): 新規スキルの雛形を生成する skill-scaffold を追加する

### DIFF
--- a/ai-agents/skills/skill-scaffold/SKILL.md
+++ b/ai-agents/skills/skill-scaffold/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: skill-scaffold
+description: >-
+  新しいスキルの雛形（ディレクトリ + SKILL.md）を本リポジトリの規約どおりに生成する。
+  frontmatter（name / description / 任意の argument-hint・disable-model-invocation・metadata.version）と
+  本文（# /SKILL_NAME スキル → Goal / Workflow / Notes）を対話的に埋め、
+  ai-agents/skills/SKILL_NAME/SKILL.md に配置する。
+  新しいスキルを新規作成・立ち上げたいときに `/skill-scaffold <スキル名> [用途の一言]` で呼び出す。
+disable-model-invocation: true
+argument-hint: "<スキル名> [用途の一言]"
+metadata:
+  version: 1
+---
+
+# /skill-scaffold スキル
+
+## Goal
+
+規約準拠のスキル雛形（ディレクトリ + SKILL.md）を最小手数で生成し、`skill-improve` が扱いやすい綺麗な初期状態を作る。
+改善サイクル（Observe → Inspect → Amend → Evaluate）の手前にある「Create（新規スキルの立ち上げ）」フェーズを担う。
+
+## Workflow
+
+### Step 1: 引数パース
+
+`$ARGUMENTS` を以下のように解釈する:
+
+- **第1引数**: 生成するスキル名（以降 `SKILL_NAME`）
+- **第2引数以降**: そのスキルの用途の一言（自由記述、省略可）
+
+引数なしの場合は対話でスキル名と用途を尋ねる。
+
+### Step 2: スキル名のバリデーション
+
+`SKILL_NAME` が以下を満たすか検証する。満たさない場合は修正案を提示して確認する。
+
+- lowercase + ハイフン（`a-z`, `0-9`, `-`）のみ
+- 64 文字以内
+- 予約語（`claude` / `anthropic`）を含まない
+
+### Step 3: 衝突チェック（最重要）
+
+`ai-agents/skills/SKILL_NAME/` が **存在しないこと** を必ず確認する。
+
+- 既存の場合は **作成せず中断** し、既存スキルへの追記または `/skill-improve` を案内する（既存 SKILL.md を絶対に上書きしない）。
+
+### Step 4: description のドラフト
+
+ベストプラクティスに沿った `description` をドラフトしてユーザー確認を取る。
+
+- **「何をするか」＋「いつ使うか（トリガー）」** を必ず両方含める（モデルの自動起動判断に必要）。
+- 1024 文字以内、簡潔に。
+
+### Step 5: frontmatter の確定
+
+- `argument-hint`（引数を取るスキルのみ）と `disable-model-invocation`（明示呼び出し専用にするか）の要否を確認する。
+- `metadata.version: 1` を付与する。
+
+### Step 6: 本文の生成
+
+`# /SKILL_NAME スキル` を見出しに、`## Goal` / `## Workflow` / `## Notes` の骨組みを生成する。
+
+- 各セクションはプレースホルダ＋最小限の骨組みに留め、中身の作り込みはユーザーに委ねる（SKILL.md は簡潔さが重要）。
+
+### Step 7: 書き出しとデプロイ案内
+
+`ai-agents/skills/SKILL_NAME/SKILL.md` に書き出し、内容をユーザーに表示して確認する。
+
+- デプロイは自動実行せず、`make skills-copy` で 4 エージェント（codex / claude / cursor / copilot）へ配布される旨を案内するに留める。
+
+## Notes
+
+- **既存スキルの上書き防止が最重要**。Step 3 の非存在確認を必ず先に行い、衝突時は作成せず中断する。
+- 本スキルは「新規作成（Create）」専任。既存スキルの改善（Inspect / Amend）には踏み込まず、`/skill-improve` と役割を分担する。
+- skills は 4 エージェントへ配布されるため、特定エディタ依存の機能やスクリプトは使わず、モデル駆動の純 Markdown 手順に留める（移植性確保）。
+- 新規 skill のため hook 配線（settings.json / 3 エディタ分の `.sh`）は不要。`scripts/copy-entries.sh` の skills モードが `skills/` 直下を総当りでコピーするため、ディレクトリを置くだけで `make skills-copy` にそのまま乗る。
+- 雛形は最小限に留め、過剰生成を避ける。スコープを「スキル作成」に絞り、hook 雛形生成などへ広げない。


### PR DESCRIPTION
Closes #443

## 何を

`ai-agents/skills/skill-scaffold/SKILL.md` を 1 ファイル追加した。新しいスキルの雛形（ディレクトリ + SKILL.md）を本リポジトリの規約どおりに対話的に生成するスキル。

- frontmatter: `name` / `description`（「何をするか＋いつ使うか」を含む）/ `argument-hint` / `disable-model-invocation: true` / `metadata.version: 1`
- 本文: `## Goal` / `## Workflow`（引数パース → 名前バリデーション → 衝突チェック → description ドラフト → frontmatter 確定 → 本文生成 → 書き出し・デプロイ案内）/ `## Notes`

## なぜ

新規スキルの雛形を生成する手段が無く、毎回既存スキルを手でコピペしていたため、`name` の規約逸脱・`description` のトリガー欠落・`metadata.version` 付け忘れ・見出しのばらつきが起きやすかった。改善ループ（Observe → Inspect → Amend → Evaluate）は `skill-observe` / `skill-improve` で揃っているが、その手前の **Create（新規スキルの立ち上げ）** が欠けていた。skill-scaffold はこのエントリポイントを埋め、最初から規約準拠・`skill-improve` が読みやすい状態でスキルを生む。

hook ではなく skill を選んだ理由: 人間が内容を確認・調整しながら進める対話的・手続き的ワークフローであり、ライフサイクルイベントで決定論的に強制する hook には当てはまらないため。既存の `skill-observe` / `skill-improve` と同じ系列に並ぶ。

## どこにどう置くか

- 新規 skill のため hook 配線（settings.json / 3 エディタ分の `.sh`）は **不要**。
- `scripts/copy-entries.sh` の skills モードが `skills/` 直下のディレクトリを総当りでコピーするため、ディレクトリを置くだけで既存の `make skills-copy`（codex / claude / cursor / copilot 4 配布）にそのまま乗る。Makefile 変更不要。

## 検証

- `markdownlint-cli2`（ai-agents/.markdownlint-cli2.yaml 適用）: 0 error。
- `prettier --check`: pass。
- frontmatter は `.claude/rules/skill-authoring.md` の必須項目（`name` / `description` / `metadata.version`、引数ありなので `argument-hint`、orchestrator 専用なので `disable-model-invocation: true` をブール値で）を満たす。

## リスク・留意点

- 生成前に対象ディレクトリの非存在を必ず確認し、衝突時は作成せず中断する設計（既存 SKILL.md の上書き防止）。
- 役割は「新規作成」専任で `skill-improve`（改善）と重複しない。雛形は最小限に留め過剰生成を避ける。

---
_Generated by [Claude Code](https://claude.ai/code/session_015LU1gGGerMx2w7j3eqFuPK)_