### PR TITLE
feat: skill observation をクロスリポで my-pde に集約する

### DIFF
--- a/ai-agents/settings/claude/hooks/skill-observe-nudge.sh
+++ b/ai-agents/settings/claude/hooks/skill-observe-nudge.sh
@@ -18,11 +18,29 @@ CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
 
 [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || exit 0
 
-# Locate the repository and its skills directory.
+# Resolve where observations live. Prefer SKILL_OBSERVE_HOME (the my-pde checkout)
+# so skill usage in ANY repo is captured into the git-tracked observations tree;
+# fall back to the current repo when the env var is unset (e.g. working in my-pde).
 [ -n "$CWD" ] || CWD=$(pwd)
-ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
-SKILLS_DIR="$ROOT/ai-agents/skills"
-[ -d "$SKILLS_DIR" ] || exit 0
+OBS_HOME=""
+# Expand a leading ~ ourselves; settings.json env values are not shell-expanded,
+# so SKILL_OBSERVE_HOME="~/workspace/my-pde" stays portable across machines.
+observe_home="${SKILL_OBSERVE_HOME:-}"
+# shellcheck disable=SC2088  # intentionally matching/stripping a literal ~, not expanding
+case "$observe_home" in
+"~") observe_home="$HOME" ;;
+"~/"*) observe_home="$HOME/${observe_home#"~/"}" ;;
+esac
+if [ -n "$observe_home" ] && [ -d "$observe_home/ai-agents/skills" ]; then
+	OBS_HOME="$observe_home"
+else
+	ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+	if [ -n "$ROOT" ] && [ -d "$ROOT/ai-agents/skills" ]; then
+		OBS_HOME="$ROOT"
+	fi
+fi
+[ -n "$OBS_HOME" ] || exit 0
+SKILLS_DIR="$OBS_HOME/ai-agents/skills"
 
 # Skills extracted from this session's transcript (Skill tool invocations).
 used=$(
@@ -68,10 +86,12 @@ reason=$(
 今セッションで次のリポジトリスキルを使用したが observation が未記録です: ${list}
 
 各スキルについて、直近の使用結果を会話文脈から success / partial / failure で判定し、
-ai-agents/skills/<スキル名>/observations/$(date +%Y-%m-%d)_NNN_obs.md を作成してください。
+${SKILLS_DIR}/<スキル名>/observations/$(date +%Y-%m-%d)_NNN_obs.md を作成してください
+（上記は絶対パス。現在の作業リポジトリと異なっても必ずこのパスに書く）。
 
-- 形式は ai-agents/skills/skill-observe/SKILL.md の6フィールド（タスク / スキル / 結果 /
+- 形式は ${SKILLS_DIR}/skill-observe/SKILL.md の6フィールド（タスク / スキル / 結果 /
   問題 / フィードバック / コンテキスト）に従う。
+- 「コンテキスト」には実際の作業リポジトリ（cwd: ${CWD}）を必ず記録する。
 - NNN は当日連番。同日の既存ファイルと重複しないよう採番する。
 - 当日同スキルの observation が既にあればスキップしてよい。
 - ユーザーへの確認は不要。淡々と記録し、作成したファイルを1行で報告して終了する。

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -55,6 +55,9 @@
     ]
   },
   "model": "opus",
+  "env": {
+    "SKILL_OBSERVE_HOME": "~/workspace/my-pde"
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/ai-agents/skills/skill-observe/SKILL.md
+++ b/ai-agents/skills/skill-observe/SKILL.md
@@ -86,6 +86,7 @@ date: YYYY-MM-DD
 ## Notes
 
 - observation は Stop hook（`ai-agents/settings/claude/hooks/skill-observe-nudge.sh`）が**自動記録**する。リポジトリスキルを使ったセッション終了時に、Claude がその場の文脈から結果を判定して observation を書き出す。本スキルは手動・補足記録およびバッチモード（引数なし）用として残る
+- 保存先は環境変数 `SKILL_OBSERVE_HOME`（my-pde のクローンパス。`settings.json` の `env` で `~/workspace/my-pde` を設定。先頭の `~` は hook 側で `$HOME` に展開するので別 PC でも動く）で決まる。これにより**どのリポジトリで作業していてもスキル使用が my-pde の git 管理下に集約**される。`SKILL_OBSERVE_HOME` 未設定時は現在の git リポジトリ直下の `ai-agents/skills` にフォールバックし、それも無ければ何もしない
 - observation ファイルは git 管理下に置く。`make claude-skills-copy` でローカル環境にもコピーされる
 - `/skill-improve` がこれらの observation を分析し、SKILL.md の改善提案を生成する
 - 1 日に複数回同じスキルの observation を記録しても問題ない（連番で区別）

--- a/docs/plan/2026-06-28_skill-observe-stop-hook-auto-capture.md
+++ b/docs/plan/2026-06-28_skill-observe-stop-hook-auto-capture.md
@@ -44,8 +44,10 @@ exit のイディオムに合わせる。ロジック:
 2. `transcript_path` / `session_id` / `stop_hook_active` / `cwd` を `jq` で抽出。
 3. **ループガード①**: `stop_hook_active == "true"` なら `exit 0`（継続中の再発火を抑止）。
 4. `transcript_path` が空 or ファイル無しなら `exit 0`。
-5. リポジトリルートを `git -C "$cwd" rev-parse --show-toplevel` で特定。`ai-agents/skills`
-   が無ければ `exit 0`。
+5. **保存先 `OBS_HOME` を解決**: 環境変数 `SKILL_OBSERVE_HOME`（my-pde のクローンパス、
+   `settings.json` の `env` で設定）に `ai-agents/skills` があればそれを採用。未設定なら
+   `git -C "$cwd" rev-parse --show-toplevel` の直下にフォールバック。どちらも該当しなければ
+   `exit 0`。これにより**他リポで作業していてもスキル使用を my-pde に集約**できる。
 6. **対象スキル集合**を構築: `ai-agents/skills/*/SKILL.md` の親ディレクトリ名一覧から
    `skill-observe` / `skill-improve` を除外。
 7. **使用スキル**を transcript から抽出（上記 jq）→ ユニーク化 → 対象スキル集合と積集合 =
@@ -61,9 +63,10 @@ exit のイディオムに合わせる。ロジック:
 
 - 「今セッションで次のリポジトリスキルを使用したが observation 未記録: `<pending一覧>`」
 - 各スキルについて、直近の使用結果を会話文脈から `success`/`partial`/`failure` で判定し、
-  `ai-agents/skills/<name>/observations/YYYY-MM-DD_NNN_obs.md` を
-  **`skill-observe` SKILL.md の6フィールド形式**（タスク/スキル/結果/問題/フィードバック/
-  コンテキスト）で作成せよ。`NNN` は当日連番、既存と重複しないよう採番。
+  `<OBS_HOME>/ai-agents/skills/<name>/observations/YYYY-MM-DD_NNN_obs.md`（**絶対パス**。
+  現在の作業リポと異なっても必ずここに書く）を **`skill-observe` SKILL.md の6フィールド形式**
+  （タスク/スキル/結果/問題/フィードバック/コンテキスト）で作成せよ。`NNN` は当日連番、既存と
+  重複しないよう採番。「コンテキスト」には実際の作業リポ（`cwd`）を記録。
 - 当日同スキルの observation が既にあればスキップ可。
 - **ユーザーへの確認は不要**。淡々と記録し、作成ファイルを1行で報告して終了せよ。
 - markdownlint を通すため既存 observation ファイルの体裁に合わせること


### PR DESCRIPTION
## 実装経緯の説明

PR #445（誤って先にマージ済み）で導入した Stop hook による observation 自動記録は、書き込み先が「現在の git リポジトリ直下の `ai-agents/skills`」だったため、**記録されるのは my-pde リポでの作業時のみ**だった。スキルは4エージェントにグローバル配布されてどのリポでも使えるのに、他リポの開発中に使っても観測されず、`skill-improve` が見たい「実プロジェクト開発中の生の使用感」が届かないサンプリングの偏りがあった。

本 PR は保存先を環境変数 `SKILL_OBSERVE_HOME`（my-pde のクローンパス）で解決するようにし、**どのリポジトリで作業していてもスキル使用を my-pde の git 管理下に集約**する。

## 補足

### 主な変更内容

- **hook**: `OBS_HOME` を `SKILL_OBSERVE_HOME` 優先で解決。env に `ai-agents/skills` があればそれを採用、未設定なら現在の git リポ直下にフォールバック、どちらも無ければ no-op（他リポを汚さない）。
- `reason` の observation 書き込み先を**絶対パス化**し、「コンテキスト」に実際の作業リポ（`cwd`）を記録するよう指示。
- `settings.json` の `env` に `SKILL_OBSERVE_HOME` を追加（グローバル配備で全リポのセッションに有効）。
- `skill-observe/SKILL.md` と plan に挙動を追記。

### 技術的な詳細

- `SKILL_OBSERVE_HOME` は personal repo 前提で絶対パス直書き（このリポ自体が単一ユーザー専用のため許容）。
- 後方互換: env 未設定でも従来どおり my-pde 内では git-root フォールバックで動作する。

### 確認事項

- `shellcheck` / `jq`(settings.json) / `markdownlint` green。
- 単体テスト: 他リポ + env 設定 → my-pde 絶対パスへ書き込み・cwd をコンテキスト記録／他リポ + env 未設定 → no-op／my-pde + env 未設定 → git-root フォールバックで動作／env 不正パス → フォールバック。
- `make claude-settings-copy` で再配備し、配備先の `env` と hook を確認済み。