### PR TITLE
fix: インレイヒントをデフォルトOFFにする

### DIFF
--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -101,11 +101,11 @@ vim.api.nvim_create_autocmd("LspAttach", {
 			vim.lsp.codelens.enable(true, { bufnr = ev.buf })
 		end
 
-		-- Inlay hint (vim.lsp.inlay_hint) を対応サーバーで常時有効化する。
-		-- 変数の推論型・関数の引数名などをソースを書き換えずに仮想テキストで補足表示する。
-		-- ノイズに感じる場合は下の <space>h でバッファ単位にトグルできる。
+		-- Inlay hint (vim.lsp.inlay_hint) を対応サーバーで使えるようにする。
+		-- 変数の推論型・関数の引数名などをソースを書き換えずに仮想テキストで補足表示するが、
+		-- 常時表示は視覚的ノイズが大きいためデフォルトは OFF とし、
+		-- 必要なときだけ <space>h でバッファ単位に ON/OFF をトグルする。
 		if client and client:supports_method("textDocument/inlayHint") then
-			vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
 			vim.keymap.set("n", "<space>h", function()
 				vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = 0 }), { bufnr = 0 })
 			end, opts)


### PR DESCRIPTION
## 実装経緯の説明

PR #434 で LSP インレイヒント（`vim.lsp.inlay_hint`）を `LspAttach` で常時有効化したが、推論型・引数名・複合リテラルのフィールド名などの仮想テキストが対象バッファの全行に表示され、視覚的ノイズが大きかった。常時表示をやめ、必要なときだけ手動で ON にできる方式へ変更する。

## チケット

- 関連: #434

## 補足

### 主な変更内容

- `nvim/config/lua/lsp/init.lua` の `LspAttach` から `vim.lsp.inlay_hint.enable(true, ...)` を削除し、インレイヒントをデフォルト OFF にした。
- 既存の `<space>h` トグルキーマップはそのまま残し、必要なときだけバッファ単位で ON/OFF できるようにした。
- コメントを「常時有効化」から「デフォルト OFF・`<space>h` でトグル」へ更新した。

### 技術的な詳細

- `gopls` の `settings.gopls.hints` はトグル ON 時に gopls がどのヒントを返すかを決める設定のため残している（消すとトグルしても何も表示されなくなる）。デフォルト OFF の挙動には影響しない。
- 変更は1ファイル・4行のみの最小差分。`stylua --check` 通過済み。

### 確認事項

- Go ファイルを開いた状態でデフォルトではインレイヒントが表示されないこと。
- `<space>h` でインレイヒントが ON になり、再度押すと OFF に戻ること（バッファ単位）。
- codelens / document highlight など他のコア機能の挙動が変わっていないこと。