### PR TITLE
feat: gitsigns でハンク移動とプレビューを有効化

### DIFF
--- a/nvim/config/lua/gitsigns_nvim.lua
+++ b/nvim/config/lua/gitsigns_nvim.lua
@@ -1,1 +1,28 @@
-require("gitsigns").setup()
+require("gitsigns").setup({
+	on_attach = function(bufnr)
+		local gs = require("gitsigns")
+		local function map(mode, l, r, desc)
+			vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
+		end
+
+		-- ハンク移動（diff モード時はネイティブの ]c/[c に委譲）
+		map("n", "]c", function()
+			if vim.wo.diff then
+				vim.cmd.normal({ "]c", bang = true })
+			else
+				gs.nav_hunk("next")
+			end
+		end, "Next hunk")
+		map("n", "[c", function()
+			if vim.wo.diff then
+				vim.cmd.normal({ "[c", bang = true })
+			else
+				gs.nav_hunk("prev")
+			end
+		end, "Prev hunk")
+
+		-- プレビュー（<leader> = <space>。<space>h を避けて <leader>g 系に）
+		map("n", "<leader>gp", gs.preview_hunk, "Preview hunk")
+		map("n", "<leader>gi", gs.preview_hunk_inline, "Preview hunk inline")
+	end,
+})


### PR DESCRIPTION
## 実装経緯の説明

`nvim/config/lua/gitsigns_nvim.lua` は `require("gitsigns").setup()` の一行のみで、サインカラム表示しか活用できていなかった。gitsigns 本来の価値であるハンク単位の操作のうち、まずは「ハンク移動」と「差分プレビュー」を `on_attach` で有効化した。

## チケット

https://github.com/hodanov/my-pde/issues/435

## 補足

### 主な変更内容

- `]c` / `[c` で次/前のハンクへ移動（`:diffthis` 中は Vim ネイティブの変更箇所移動へ委譲）
- `<leader>gp` でハンク差分をポップアップ表示、`<leader>gi` でインラインプレビュー

### 技術的な詳細

- `mapleader` がスペースで、既存の `<space>h`（inlay hint トグル）と前方一致するため、git 系は `<leader>g` プレフィックスに振り分けた（`<leader>g` は既存マッピングと衝突なしを確認済み）
- `vim.wo.diff` を見てネイティブ動作へフォールバックするので `:diffthis` 中も壊れない
- API は新しめのバージョン前提（`nav_hunk` / `preview_hunk_inline`）。本リポジトリは lazy.nvim 管理で最新追従のため通常問題なし

### 確認事項

- 変更のあるファイル上で `]c` / `[c` によるハンク移動が動くこと
- `<space>gp` / `<space>gi` で差分プレビューが表示されること
- `:diffthis` 中に `]c` / `[c` がネイティブ動作になること

### スコープ外（将来対応）

issue #435 ではこのほかに stage/reset・blame・テキストオブジェクトも提案されているが、本 PR は「ハンク移動とプレビュー」に絞っている。