### PR TITLE
feat(nvim): nvim-dap-virtual-text でデバッグ中の変数値をインライン表示する

### DIFF
--- a/nvim/config/lua/nvim_dap.lua
+++ b/nvim/config/lua/nvim_dap.lua
@@ -2,6 +2,18 @@ require("dap-go").setup()
 require("dap-python").setup("python")
 require("dap-python").test_runner = "pytest"
 
+require("nvim-dap-virtual-text").setup({
+	-- 直前のステップから変化した変数を強調する
+	highlight_changed_variables = true,
+	-- 例外などで停止した理由を表示する
+	show_stop_reason = true,
+	-- 値を行末ではなく変数の直後（行内）に出す。Neovim 0.10+ で利用可。
+	virt_text_pos = "inline",
+	-- 同名変数が複数定義されている場合、最初の定義だけに出す（ノイズ抑制）
+	only_first_definition = true,
+	all_references = false,
+})
+
 -- nvim-dap: keymap
 vim.keymap.set("n", "<Leader>5", function()
 	require("dap").continue()

--- a/nvim/config/lua/plugins.lua
+++ b/nvim/config/lua/plugins.lua
@@ -89,6 +89,11 @@ return {
 				lazy = true,
 				event = { "BufRead", "BufNewFile" },
 			},
+			{
+				"theHamsta/nvim-dap-virtual-text",
+				lazy = true,
+				event = { "BufRead", "BufNewFile" },
+			},
 		},
 		config = function()
 			require("nvim_dap")


### PR DESCRIPTION
Closes #446

## 何を

`theHamsta/nvim-dap-virtual-text` を導入し、デバッグ中に各変数の現在値を、その変数が書かれているコード行へ仮想テキストで自動表示する。

- `nvim/config/lua/plugins.lua`: nvim-dap の `dependencies` に `theHamsta/nvim-dap-virtual-text` を追加（既存の dap-go / dap-python と同じ lazy + `BufRead`/`BufNewFile` イベントに揃える）。
- `nvim/config/lua/nvim_dap.lua`: dap-go / dap-python の setup 直後に `require("nvim-dap-virtual-text").setup({...})` を1ブロック追加。
  - `highlight_changed_variables = true`（直前のステップから変化した変数を強調）
  - `show_stop_reason = true`
  - `virt_text_pos = "inline"`（変数直後に表示。Neovim 0.10+、本設定は 0.12 前提）
  - `only_first_definition = true` / `all_references = false`（ノイズ抑制）

## なぜ

既存 DAP 設定は変数値の確認手段が `dh`(hover)/`dp`(preview)/`ds`(scopes) の手動ウィジェットに限られていた。インライン表示でステップ実行ごとに値・変化を行を眺めるだけで追える。デバッグ対象の go/python は treesitter parser 導入済みで噛み合う。新規キーマップは追加せず（自動表示、必要時 `:DapVirtualTextToggle`）、既存マッピング体系は不変。

## 検証

- `stylua --check nvim/config/lua/nvim_dap.lua nvim/config/lua/plugins.lua` → パス（CI `lint_stylua` 相当）。

最小差分。既存の hover/preview/scopes ウィジェットとは補完関係で共存する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BctLw3niPaHj9uyzsPNAvF)_