### PR TITLE
feat(ai-bridge): リクエスト履歴の永続化と history/replay サブコマンドを追加

### DIFF
--- a/scripts/ai-bridge/README.md
+++ b/scripts/ai-bridge/README.md
@@ -72,6 +72,21 @@ docker cp nvim/config/lua/ai_bridge.lua nvim-dev:/root/.config/nvim/lua/ai_bridg
 4. プロンプトを確認・編集する
 5. `<CR>`（Enter）で送信 → ホスト側のターミナルタブでAI CLIが起動する
 
+### 履歴と再送（history / replay）
+
+デーモンは正常に受理したリクエスト（プロンプト・cwd・タイムスタンプ）を `~/.ai-bridge/history.jsonl` に追記する。Neovim を開かずホスト側だけで過去のプロンプトを確認・再送できる。
+
+```bash
+# 直近の履歴を一覧（既定 20 件、-n で件数指定）
+./scripts/ai-bridge/ai-bridge history
+./scripts/ai-bridge/ai-bridge history -n 5
+
+# 直前のプロンプトを再送（request.json を書き出し、稼働中のデーモンが起動する）
+./scripts/ai-bridge/ai-bridge replay --last
+```
+
+プロンプト全文が平文で `history.jsonl` に残る点に注意する（`~/.ai-bridge/` 配下に閉じる）。
+
 ### フローティングウィンドウのキーマップ
 
 | キー    | 動作                                               |

--- a/scripts/ai-bridge/cmd/ai-bridge/main.go
+++ b/scripts/ai-bridge/cmd/ai-bridge/main.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"ai-bridge/internal/daemon"
+	"ai-bridge/internal/history"
 	"ai-bridge/internal/launchd"
 	"ai-bridge/internal/launcher"
 )
@@ -28,6 +31,10 @@ func main() {
 		err = runDaemon()
 	case "install-launchd":
 		err = runInstallLaunchd()
+	case "history":
+		err = runHistory()
+	case "replay":
+		err = runReplay()
 	default:
 		usage()
 		os.Exit(1)
@@ -44,6 +51,60 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  daemon            Start the ai-bridge daemon")
 	fmt.Fprintln(os.Stderr, "  install-launchd   Install and load the launchd agent")
+	fmt.Fprintln(os.Stderr, "  history [-n N]    List recent requests (default 20)")
+	fmt.Fprintln(os.Stderr, "  replay [--last]   Re-send the most recent request")
+}
+
+func runHistory() error {
+	fs := flag.NewFlagSet("history", flag.ContinueOnError)
+	n := fs.Int("n", 20, "number of recent entries to show")
+	if parseErr := fs.Parse(os.Args[2:]); parseErr != nil {
+		return parseErr
+	}
+
+	cfg, loadConfigErr := daemon.LoadConfig()
+	if loadConfigErr != nil {
+		return loadConfigErr
+	}
+
+	records, loadErr := history.Load(history.Path(cfg.BridgeDir))
+	if loadErr != nil {
+		return loadErr
+	}
+	fmt.Print(history.FormatList(records, *n))
+	return nil
+}
+
+func runReplay() error {
+	fs := flag.NewFlagSet("replay", flag.ContinueOnError)
+	// --last is accepted for explicitness; the most recent request is replayed.
+	_ = fs.Bool("last", false, "replay the most recent request")
+	if parseErr := fs.Parse(os.Args[2:]); parseErr != nil {
+		return parseErr
+	}
+
+	cfg, loadConfigErr := daemon.LoadConfig()
+	if loadConfigErr != nil {
+		return loadConfigErr
+	}
+
+	records, loadErr := history.Load(history.Path(cfg.BridgeDir))
+	if loadErr != nil {
+		return loadErr
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("no history to replay")
+	}
+
+	rec := records[0]
+	rec.Timestamp = time.Now().Unix()
+	reqPath := filepath.Join(cfg.BridgeDir, "request.json")
+	if writeErr := history.WriteRequest(reqPath, rec); writeErr != nil {
+		return fmt.Errorf("write request: %w", writeErr)
+	}
+
+	slog.Info("ai-bridge: replayed request", "cwd", rec.CWD)
+	return nil
 }
 
 func runDaemon() error {

--- a/scripts/ai-bridge/internal/daemon/daemon.go
+++ b/scripts/ai-bridge/internal/daemon/daemon.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"ai-bridge/internal/history"
 	"ai-bridge/internal/launcher"
 	"ai-bridge/internal/watcher"
 	"context"
@@ -139,8 +140,9 @@ func Run(ctx context.Context, cfg *Config, l launcher.Launcher) error {
 		return fmt.Errorf("start watcher: %w", watchErr)
 	}
 
+	historyPath := history.Path(cfg.BridgeDir)
 	for consumedPath := range ch {
-		if processErr := processRequest(consumedPath, cfg.CLI, l); processErr != nil {
+		if processErr := processRequest(consumedPath, cfg.CLI, historyPath, l); processErr != nil {
 			slog.Warn("request failed", "error", processErr)
 		}
 	}
@@ -148,11 +150,21 @@ func Run(ctx context.Context, cfg *Config, l launcher.Launcher) error {
 	return nil
 }
 
-func processRequest(consumedPath, cli string, l launcher.Launcher) error {
+func processRequest(consumedPath, cli, historyPath string, l launcher.Launcher) error {
 	req, parseErr := parseRequest(consumedPath)
 	_ = os.Remove(consumedPath)
 	if parseErr != nil {
 		return fmt.Errorf("invalid request: %w", parseErr)
+	}
+
+	// Persist the request before launching. A history failure must not block
+	// the launch, so log and continue.
+	if appendErr := history.Append(historyPath, history.Record{
+		Prompt:    req.Prompt,
+		CWD:       req.CWD,
+		Timestamp: req.Timestamp,
+	}); appendErr != nil {
+		slog.Warn("history append failed", "error", appendErr)
 	}
 
 	info, statErr := os.Stat(req.CWD)

--- a/scripts/ai-bridge/internal/history/history.go
+++ b/scripts/ai-bridge/internal/history/history.go
@@ -1,0 +1,152 @@
+// Package history persists ai-bridge requests and supports replaying them.
+//
+// The daemon appends every successfully parsed request to an append-only JSONL
+// file. The history and replay subcommands read that file to list past prompts
+// or re-inject one as a new request, reusing the existing watcher/launcher path.
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const fileName = "history.jsonl"
+
+// Record is one persisted request. Fields mirror the daemon request format so a
+// record can be written back out as request.json without transformation.
+type Record struct {
+	Prompt    string `json:"prompt"`
+	CWD       string `json:"cwd"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// Path returns the history file path inside bridgeDir.
+func Path(bridgeDir string) string {
+	return filepath.Join(bridgeDir, fileName)
+}
+
+// Append writes one record as a JSON line to the history file at path.
+// The file is created if it does not exist. A single O_APPEND write keeps
+// concurrent lines from interleaving.
+func Append(path string, rec Record) error {
+	f, openErr := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if openErr != nil {
+		return fmt.Errorf("open history: %w", openErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, marshalErr := json.Marshal(rec)
+	if marshalErr != nil {
+		return fmt.Errorf("marshal record: %w", marshalErr)
+	}
+	if _, writeErr := f.Write(append(data, '\n')); writeErr != nil {
+		return fmt.Errorf("write history: %w", writeErr)
+	}
+	return nil
+}
+
+// Load reads all records newest-first. A missing file yields an empty slice and
+// no error. Corrupt (unparseable) lines are skipped so one bad row cannot block
+// the whole history.
+func Load(path string) ([]Record, error) {
+	f, openErr := os.Open(path)
+	if openErr != nil {
+		if os.IsNotExist(openErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open history: %w", openErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	var records []Record
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec Record
+		if unmarshalErr := json.Unmarshal(line, &rec); unmarshalErr != nil {
+			continue // skip corrupt line
+		}
+		records = append(records, rec)
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, fmt.Errorf("read history: %w", scanErr)
+	}
+
+	// Reverse to newest-first.
+	for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
+		records[i], records[j] = records[j], records[i]
+	}
+	return records, nil
+}
+
+// WriteRequest atomically writes rec as a request file at path. It writes to a
+// temp file in the same directory and renames it into place so the daemon never
+// observes a partially written request.json.
+func WriteRequest(path string, rec Record) (retErr error) {
+	data, marshalErr := json.Marshal(rec)
+	if marshalErr != nil {
+		return fmt.Errorf("marshal request: %w", marshalErr)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, createTempErr := os.CreateTemp(dir, ".request-*.tmp")
+	if createTempErr != nil {
+		return fmt.Errorf("create temp request: %w", createTempErr)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, writeErr := tmp.Write(data); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp request: %w", writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp request: %w", closeErr)
+	}
+	if renameErr := os.Rename(tmpName, path); renameErr != nil {
+		return fmt.Errorf("rename temp request: %w", renameErr)
+	}
+	return nil
+}
+
+// FormatList renders records (already newest-first) as a human-readable list.
+// limit > 0 caps the number of rows shown; limit <= 0 shows all.
+func FormatList(records []Record, limit int) string {
+	if limit > 0 && limit < len(records) {
+		records = records[:limit]
+	}
+	if len(records) == 0 {
+		return "(no history)\n"
+	}
+	var b strings.Builder
+	for i, r := range records {
+		ts := time.Unix(r.Timestamp, 0).Format("2006-01-02 15:04:05")
+		fmt.Fprintf(&b, "%3d  %s  %s\n     %s\n", i, ts, r.CWD, firstLine(r.Prompt))
+	}
+	return b.String()
+}
+
+// firstLine returns the first line of s, truncated to keep list rows compact.
+func firstLine(s string) string {
+	const maxLen = 100
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = s[:idx]
+	}
+	if len(s) > maxLen {
+		return s[:maxLen] + "…"
+	}
+	return s
+}

--- a/scripts/ai-bridge/internal/history/history_test.go
+++ b/scripts/ai-bridge/internal/history/history_test.go
@@ -1,0 +1,182 @@
+package history
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendAndLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	records := []Record{
+		{Prompt: "first", CWD: "/a", Timestamp: 1},
+		{Prompt: "second", CWD: "/b", Timestamp: 2},
+		{Prompt: "third", CWD: "/c", Timestamp: 3},
+	}
+	for _, rec := range records {
+		if appendErr := Append(path, rec); appendErr != nil {
+			t.Fatalf("Append(%q): %v", rec.Prompt, appendErr)
+		}
+	}
+
+	got, loadErr := Load(path)
+	if loadErr != nil {
+		t.Fatalf("Load: %v", loadErr)
+	}
+	if len(got) != len(records) {
+		t.Fatalf("got %d records, want %d", len(got), len(records))
+	}
+	// newest-first
+	if got[0].Prompt != "third" || got[2].Prompt != "first" {
+		t.Errorf("unexpected order: %q ... %q", got[0].Prompt, got[2].Prompt)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string // nil sentinel handled via write flag
+		write   bool
+		wantLen int
+		wantErr bool
+	}{
+		{name: "missing file", write: false, wantLen: 0},
+		{name: "empty file", write: true, content: "", wantLen: 0},
+		{name: "blank lines skipped", write: true, content: "\n\n", wantLen: 0},
+		{
+			name:    "corrupt line skipped",
+			write:   true,
+			content: `{"prompt":"ok","cwd":"/x","timestamp":1}` + "\nnot json\n" + `{"prompt":"ok2","cwd":"/y","timestamp":2}` + "\n",
+			wantLen: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "history.jsonl")
+			if tt.write {
+				if writeErr := os.WriteFile(path, []byte(tt.content), 0o600); writeErr != nil {
+					t.Fatalf("setup: %v", writeErr)
+				}
+			}
+			got, loadErr := Load(path)
+			if (loadErr != nil) != tt.wantErr {
+				t.Fatalf("Load error = %v, wantErr %v", loadErr, tt.wantErr)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("got %d records, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestWriteRequest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "request.json")
+	rec := Record{Prompt: "replay me", CWD: "/work", Timestamp: 42}
+	if writeErr := WriteRequest(path, rec); writeErr != nil {
+		t.Fatalf("WriteRequest: %v", writeErr)
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	var got Record
+	if unmarshalErr := json.Unmarshal(data, &got); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
+	}
+	if got != rec {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, rec)
+	}
+
+	// No leftover temp files in the directory.
+	entries, readDirErr := os.ReadDir(dir)
+	if readDirErr != nil {
+		t.Fatalf("readdir: %v", readDirErr)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestFormatList(t *testing.T) {
+	t.Parallel()
+	records := []Record{
+		{Prompt: "newest\nsecond line", CWD: "/a", Timestamp: 100},
+		{Prompt: "older", CWD: "/b", Timestamp: 50},
+	}
+	tests := []struct {
+		name     string
+		records  []Record
+		limit    int
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "all",
+			records:  records,
+			limit:    0,
+			contains: []string{"newest", "older", "/a", "/b", "  0  ", "  1  "},
+			excludes: []string{"second line"},
+		},
+		{
+			name:     "limit 1",
+			records:  records,
+			limit:    1,
+			contains: []string{"newest", "/a"},
+			excludes: []string{"older", "/b"},
+		},
+		{
+			name:     "empty",
+			records:  nil,
+			limit:    0,
+			contains: []string{"(no history)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out := FormatList(tt.records, tt.limit)
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, no := range tt.excludes {
+				if strings.Contains(out, no) {
+					t.Errorf("output unexpectedly contains %q:\n%s", no, out)
+				}
+			}
+		})
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 150)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single line", in: "hello", want: "hello"},
+		{name: "multi line", in: "a\nb", want: "a"},
+		{name: "truncated", in: long, want: long[:100] + "…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := firstLine(tt.in); got != tt.want {
+				t.Errorf("firstLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #456

## 何を

ai-bridge にリクエスト履歴の永続化と再送を追加し、過去のプロンプトを Neovim を経由せずホスト側から確認・再投入できるようにする。

- 新規 `internal/history/`（`history.go` / `history_test.go`）
  - `Record`（prompt/cwd/timestamp、request 形式と一致）、`Append`（O_APPEND で JSONL 追記）、`Load`（新しい順・壊れた行はスキップ・欠損ファイルは空）、`WriteRequest`（temp+rename で request.json を原子的に書き出し）、`FormatList`（一覧整形）。
- `internal/daemon/daemon.go`: `processRequest` が parse 成功後に `history.Append` を呼ぶ（**append のみ**追加、起動経路 watcher/launcher は不変。履歴失敗は warn ログのみで起動を妨げない）。
- `cmd/ai-bridge/main.go`: `switch` に `history` / `replay`、`usage()`、`runHistory()`（`-n N`、既定 20 件）/ `runReplay()`（`--last`、直前を選び timestamp を更新して request.json を書き出し）。
- `README.md`: 履歴と再送の使い方を追記。

最小スコープ（issue 記載どおり）: ① daemon 側 `Append` ② `history` 一覧 ③ `replay --last`。`--index N`・件数ローテーション・prompt 全文表示は後続。

## なぜ

現状の ai-bridge は送ったプロンプトを consume 後に破棄しており、再送も監査もできない。履歴を残し `replay` で既存経路へ再投入することで、Neovim/Docker の往復を 1 コマンドに短縮し記録欠落を解消する。

## 設計上のポイント

- 再送は **request.json を書き出すだけ**。稼働中の daemon が既存の watcher → launcher 経路でそのまま consume するため、再送ロジックを二重実装しない。
- request.json は temp+rename で原子的に書き出し、daemon が部分書き込みを観測しない。
- `Append` は単一 `O_APPEND` 書き込みで行の混在を防止。

## 検証

- `goimports -d`（差分なし）/ `go build ./...` / `go vet ./...` → パス。
- `golangci-lint run ./...` → **0 issues**。
- `go test ./internal/history/... ./internal/daemon/...` → パス（Append↔Load ラウンドトリップ、空/欠損/壊れた JSON 行、newest-first 順、WriteRequest の round-trip と temp 残骸なし。table-driven + `t.Parallel()`・`t.TempDir()`）。
- README: `prettier --check` / `markdownlint-cli2` → パス。

## プライバシー留意

プロンプト全文が平文で `~/.ai-bridge/history.jsonl` に残る点を README に明記。件数上限ローテーションは後続。

注: 既存 `internal/launchd` / `internal/watcher` にローカル root 実行時のみ落ちる権限系テストがあるが本変更と無関係（CI は非 root のためパス）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BctLw3niPaHj9uyzsPNAvF)_