### PR TITLE
feat(nvim-sync): nvim 設定をコンテナへ即時同期するウォッチャを追加

### DIFF
--- a/.github/workflows/lint_nvim_sync.yml
+++ b/.github/workflows/lint_nvim_sync.yml
@@ -1,0 +1,38 @@
+name: Lint nvim-sync
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "scripts/nvim-sync/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts/nvim-sync
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: scripts/nvim-sync/go.mod
+
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+
+      - name: Check goimports formatting
+        run: |
+          diff=$(find . -name '*.go' -exec goimports -d {} +)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            exit 1
+          fi
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          working-directory: scripts/nvim-sync

--- a/.github/workflows/test_nvim_sync.yml
+++ b/.github/workflows/test_nvim_sync.yml
@@ -1,0 +1,79 @@
+name: Test nvim-sync
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - "scripts/nvim-sync/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts/nvim-sync
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: scripts/nvim-sync/go.mod
+
+      - name: Run tests with coverage
+        run: go test ./... -v -count=1 -coverprofile=coverage.out
+
+      - name: Generate coverage report
+        id: coverage
+        run: |
+          COVER_OUTPUT=$(go tool cover -func=coverage.out)
+          TOTAL=$(echo "$COVER_OUTPUT" | grep '^total:' | awk '{print $NF}')
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "report<<${EOF}"
+            echo "$COVER_OUTPUT"
+            echo "${EOF}"
+            echo "total=${TOTAL}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request'
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          MARKER="<!-- coverage-nvim-sync -->"
+          BODY="${MARKER}
+          ## 📊 Go Test Coverage: nvim-sync
+
+          **Total coverage: ${{ steps.coverage.outputs.total }}**
+
+          <details>
+          <summary>Per-package / per-function breakdown</summary>
+
+          \`\`\`
+          ${{ steps.coverage.outputs.report }}
+          \`\`\`
+
+          </details>"
+
+          EXISTING_COMMENT_ID=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          )
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
+              -f body="${BODY}"
+          else
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="${BODY}"
+          fi

--- a/scripts/nvim-sync/.gitignore
+++ b/scripts/nvim-sync/.gitignore
@@ -1,0 +1,2 @@
+/nvim-sync
+coverage.out

--- a/scripts/nvim-sync/Makefile
+++ b/scripts/nvim-sync/Makefile
@@ -1,0 +1,13 @@
+BINARY := nvim-sync
+CMD    := ./cmd/nvim-sync
+
+.PHONY: build test clean
+
+build:
+	go build -o $(BINARY) $(CMD)
+
+test:
+	go test ./...
+
+clean:
+	rm -f $(BINARY) coverage.out

--- a/scripts/nvim-sync/README.md
+++ b/scripts/nvim-sync/README.md
@@ -1,0 +1,50 @@
+# nvim-sync: Neovim 設定をコンテナへ即時同期する
+
+ホスト側の `nvim/config/` を監視し、変更された Lua ファイルを稼働中の `nvim-dev` コンテナへ `docker cp` で自動転送する常駐ウォッチャ。
+
+## 背景
+
+この PDE では Neovim 設定はイメージビルド時に `COPY` で焼き込まれており、bind mount されていない。そのため `nvim/config/**` を 1 行直すたびに、イメージのリビルドか手作業の `docker cp` が必要だった（`scripts/ai-bridge/README.md` の「セットアップ 5」「トラブルシューティング」を参照）。`nvim-sync` はこの手作業をループから消す。
+
+## ビルド
+
+```bash
+cd scripts/nvim-sync
+go build -o nvim-sync ./cmd/nvim-sync
+```
+
+## 使い方
+
+リポジトリのルートから実行する（`NVIM_SYNC_SRC` の既定が `nvim/config` のため）。
+
+```bash
+# 起動時に全ファイルを一度コピー（初期同期）
+./scripts/nvim-sync/nvim-sync sync
+
+# 変更を監視して逐次同期（常駐）
+./scripts/nvim-sync/nvim-sync watch
+```
+
+`watch` は再帰的にディレクトリを監視し、`*.lua` の作成・更新を検知して、短時間の連続保存はデバウンスで束ねてから `docker cp` する。コピー先はソースルートからの相対パスを保つ（例: `nvim/config/lua/ai_bridge.lua` → `nvim-dev:/root/.config/nvim/lua/ai_bridge.lua`）。
+
+## 設定
+
+| 環境変数              | デフォルト           | 説明                         |
+| --------------------- | -------------------- | ---------------------------- |
+| `NVIM_SYNC_CONTAINER` | `nvim-dev`           | 転送先コンテナ名             |
+| `NVIM_SYNC_SRC`       | `nvim/config`        | 監視するホスト側ディレクトリ |
+| `NVIM_SYNC_DEST`      | `/root/.config/nvim` | コンテナ側の配置先ルート     |
+
+## スコープと今後
+
+最小構成として `watch` / `sync` と構造化ログまでを実装している。変更後の Neovim への `:source` 自動再読込、`--json` ログ、polling フォールバックは後続。`docker cp` の配置先は Dockerfile の `COPY` 先（`/root/.config/nvim/`）と一致させている。
+
+## テスト
+
+```bash
+go test ./...
+```
+
+`docker` 実行は `syncer.Runner` 注入でスタブ化しており、実 Docker・ネットワークに依存しない。相対パス算出・コピー先パス組み立て・デバウンス束ねをテーブル駆動で検証する。
+
+> 注: 既存の Go CI（`.github/workflows/lint_ai_bridge.yml` / `test_ai_bridge.yml`）は `paths: scripts/ai-bridge/**` 限定のため、本モジュールは現状 CI 対象外。CI へ載せる場合は両ワークフローの path を一般化するか、本モジュール用の同等ワークフローを追加する（本モジュールのスコープ外）。

--- a/scripts/nvim-sync/README.md
+++ b/scripts/nvim-sync/README.md
@@ -47,4 +47,4 @@ go test ./...
 
 `docker` 実行は `syncer.Runner` 注入でスタブ化しており、実 Docker・ネットワークに依存しない。相対パス算出・コピー先パス組み立て・デバウンス束ねをテーブル駆動で検証する。
 
-> 注: 既存の Go CI（`.github/workflows/lint_ai_bridge.yml` / `test_ai_bridge.yml`）は `paths: scripts/ai-bridge/**` 限定のため、本モジュールは現状 CI 対象外。CI へ載せる場合は両ワークフローの path を一般化するか、本モジュール用の同等ワークフローを追加する（本モジュールのスコープ外）。
+本モジュール専用の CI として `.github/workflows/lint_nvim_sync.yml`（goimports / golangci-lint）と `.github/workflows/test_nvim_sync.yml`（`go test` + カバレッジ PR コメント）を用意しており、いずれも `paths: scripts/nvim-sync/**` の変更で起動する。

--- a/scripts/nvim-sync/cmd/nvim-sync/main.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main.go
@@ -1,0 +1,155 @@
+// Command nvim-sync mirrors host-side Neovim config changes into a running
+// nvim container, removing the manual `docker cp` step from the config edit
+// loop documented in scripts/ai-bridge/README.md.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"nvim-sync/internal/syncer"
+	"nvim-sync/internal/watcher"
+)
+
+const (
+	defaultContainer = "nvim-dev"
+	defaultSrc       = "nvim/config"
+	defaultDest      = "/root/.config/nvim"
+	debounceWindow   = 300 * time.Millisecond
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "watch":
+		err = runWatch()
+	case "sync":
+		err = runSync()
+	default:
+		usage()
+		os.Exit(1)
+	}
+
+	if err != nil {
+		slog.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "Usage: nvim-sync <command>")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  watch   Watch nvim config and docker cp changes into the container")
+	fmt.Fprintln(os.Stderr, "  sync    Copy all nvim config files into the container once")
+	fmt.Fprintln(os.Stderr, "Environment:")
+	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_CONTAINER  target container (default nvim-dev)")
+	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_SRC        host config dir (default nvim/config)")
+	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_DEST       container config dir (default /root/.config/nvim)")
+}
+
+// getenv returns the env var value or def when unset/empty.
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// newSyncer builds a Syncer from the environment, resolving SrcRoot to an
+// absolute path so relative-path computation is stable.
+func newSyncer() (*syncer.Syncer, error) {
+	src := getenv("NVIM_SYNC_SRC", defaultSrc)
+	absSrc, absErr := filepath.Abs(src)
+	if absErr != nil {
+		return nil, fmt.Errorf("resolve src %q: %w", src, absErr)
+	}
+	if info, statErr := os.Stat(absSrc); statErr != nil || !info.IsDir() {
+		return nil, fmt.Errorf("src is not a directory: %s", absSrc)
+	}
+	return &syncer.Syncer{
+		Container: getenv("NVIM_SYNC_CONTAINER", defaultContainer),
+		SrcRoot:   absSrc,
+		DestRoot:  getenv("NVIM_SYNC_DEST", defaultDest),
+		Run:       defaultRunner,
+	}, nil
+}
+
+// defaultRunner executes a command, surfacing combined output on failure.
+func defaultRunner(name string, args ...string) error {
+	out, runErr := exec.Command(name, args...).CombinedOutput()
+	if runErr != nil {
+		return fmt.Errorf("%w: %s", runErr, string(out))
+	}
+	return nil
+}
+
+func runWatch() error {
+	s, syncerErr := newSyncer()
+	if syncerErr != nil {
+		return syncerErr
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	w := watcher.New(s.SrcRoot, debounceWindow)
+	ch, watchErr := w.Watch(ctx)
+	if watchErr != nil {
+		return fmt.Errorf("start watcher: %w", watchErr)
+	}
+
+	slog.Info("nvim-sync: watching", "container", s.Container, "src", s.SrcRoot, "dest", s.DestRoot)
+	for changed := range ch {
+		for _, file := range changed {
+			if copyErr := s.Copy(file); copyErr != nil {
+				slog.Warn("sync failed", "file", file, "error", copyErr)
+				continue
+			}
+			slog.Info("synced", "file", file)
+		}
+	}
+	return nil
+}
+
+func runSync() error {
+	s, syncerErr := newSyncer()
+	if syncerErr != nil {
+		return syncerErr
+	}
+
+	slog.Info("nvim-sync: initial sync", "container", s.Container, "src", s.SrcRoot, "dest", s.DestRoot)
+	count := 0
+	walkErr := filepath.WalkDir(s.SrcRoot, func(p string, d os.DirEntry, walkDirErr error) error {
+		if walkDirErr != nil {
+			return walkDirErr
+		}
+		if d.IsDir() || filepath.Ext(p) != ".lua" {
+			return nil
+		}
+		if copyErr := s.Copy(p); copyErr != nil {
+			return copyErr
+		}
+		slog.Info("synced", "file", p)
+		count++
+		return nil
+	})
+	if walkErr != nil {
+		return fmt.Errorf("sync: %w", walkErr)
+	}
+	slog.Info("nvim-sync: done", "files", count)
+	return nil
+}

--- a/scripts/nvim-sync/cmd/nvim-sync/main.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -28,37 +30,53 @@ const (
 func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
-	if len(os.Args) < 2 {
-		usage()
-		os.Exit(1)
-	}
-
-	var err error
-	switch os.Args[1] {
-	case "watch":
-		err = runWatch()
-	case "sync":
-		err = runSync()
-	default:
-		usage()
-		os.Exit(1)
-	}
-
-	if err != nil {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
 		slog.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func usage() {
-	fmt.Fprintln(os.Stderr, "Usage: nvim-sync <command>")
-	fmt.Fprintln(os.Stderr, "Commands:")
-	fmt.Fprintln(os.Stderr, "  watch   Watch nvim config and docker cp changes into the container")
-	fmt.Fprintln(os.Stderr, "  sync    Copy all nvim config files into the container once")
-	fmt.Fprintln(os.Stderr, "Environment:")
-	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_CONTAINER  target container (default nvim-dev)")
-	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_SRC        host config dir (default nvim/config)")
-	fmt.Fprintln(os.Stderr, "  NVIM_SYNC_DEST       container config dir (default /root/.config/nvim)")
+// errUsage signals that the command line was invalid and usage was printed.
+var errUsage = errors.New("invalid command")
+
+// run dispatches a subcommand and returns an error instead of exiting so it can
+// be exercised from tests. main() is the only place that calls os.Exit.
+func run(args []string, stderr io.Writer) error {
+	if len(args) < 1 {
+		usage(stderr)
+		return errUsage
+	}
+
+	switch args[0] {
+	case "watch":
+		s, err := newSyncer()
+		if err != nil {
+			return err
+		}
+		return runWatch(s)
+	case "sync":
+		s, err := newSyncer()
+		if err != nil {
+			return err
+		}
+		return runSync(s)
+	default:
+		usage(stderr)
+		return errUsage
+	}
+}
+
+func usage(w io.Writer) {
+	const msg = `Usage: nvim-sync <command>
+Commands:
+  watch   Watch nvim config and docker cp changes into the container
+  sync    Copy all nvim config files into the container once
+Environment:
+  NVIM_SYNC_CONTAINER  target container (default nvim-dev)
+  NVIM_SYNC_SRC        host config dir (default nvim/config)
+  NVIM_SYNC_DEST       container config dir (default /root/.config/nvim)
+`
+	_, _ = fmt.Fprint(w, msg)
 }
 
 // getenv returns the env var value or def when unset/empty.
@@ -97,15 +115,15 @@ func defaultRunner(name string, args ...string) error {
 	return nil
 }
 
-func runWatch() error {
-	s, syncerErr := newSyncer()
-	if syncerErr != nil {
-		return syncerErr
-	}
-
+func runWatch(s *syncer.Syncer) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
+	return watchLoop(ctx, s)
+}
 
+// watchLoop watches s.SrcRoot and syncs debounced batches until ctx is
+// cancelled. Split from runWatch so the loop is testable without OS signals.
+func watchLoop(ctx context.Context, s *syncer.Syncer) error {
 	w := watcher.New(s.SrcRoot, debounceWindow)
 	ch, watchErr := w.Watch(ctx)
 	if watchErr != nil {
@@ -114,23 +132,24 @@ func runWatch() error {
 
 	slog.Info("nvim-sync: watching", "container", s.Container, "src", s.SrcRoot, "dest", s.DestRoot)
 	for changed := range ch {
-		for _, file := range changed {
-			if copyErr := s.Copy(file); copyErr != nil {
-				slog.Warn("sync failed", "file", file, "error", copyErr)
-				continue
-			}
-			slog.Info("synced", "file", file)
-		}
+		syncBatch(s, changed)
 	}
 	return nil
 }
 
-func runSync() error {
-	s, syncerErr := newSyncer()
-	if syncerErr != nil {
-		return syncerErr
+// syncBatch copies a debounced batch of changed files, logging per-file results
+// and continuing past individual failures.
+func syncBatch(s *syncer.Syncer, changed []string) {
+	for _, file := range changed {
+		if copyErr := s.Copy(file); copyErr != nil {
+			slog.Warn("sync failed", "file", file, "error", copyErr)
+			continue
+		}
+		slog.Info("synced", "file", file)
 	}
+}
 
+func runSync(s *syncer.Syncer) error {
 	slog.Info("nvim-sync: initial sync", "container", s.Container, "src", s.SrcRoot, "dest", s.DestRoot)
 	count := 0
 	walkErr := filepath.WalkDir(s.SrcRoot, func(p string, d os.DirEntry, walkDirErr error) error {

--- a/scripts/nvim-sync/cmd/nvim-sync/main_test.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main_test.go
@@ -42,18 +42,22 @@ func (r *recordingRunner) sources() []string {
 }
 
 func TestGetenv(t *testing.T) {
-	t.Run("returns default when unset", func(t *testing.T) {
-		t.Setenv("NVIM_SYNC_TEST_KEY", "")
-		if got := getenv("NVIM_SYNC_TEST_KEY", "fallback"); got != "fallback" {
-			t.Errorf("getenv = %q, want %q", got, "fallback")
-		}
-	})
-	t.Run("returns value when set", func(t *testing.T) {
-		t.Setenv("NVIM_SYNC_TEST_KEY", "explicit")
-		if got := getenv("NVIM_SYNC_TEST_KEY", "fallback"); got != "explicit" {
-			t.Errorf("getenv = %q, want %q", got, "explicit")
-		}
-	})
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "returns default when unset", value: "", want: "fallback"},
+		{name: "returns value when set", value: "explicit", want: "explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NVIM_SYNC_TEST_KEY", tt.value)
+			if got := getenv("NVIM_SYNC_TEST_KEY", "fallback"); got != tt.want {
+				t.Errorf("getenv = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestUsage(t *testing.T) {
@@ -70,14 +74,22 @@ func TestUsage(t *testing.T) {
 
 func TestDefaultRunner(t *testing.T) {
 	t.Parallel()
-	if err := defaultRunner("true"); err != nil {
-		t.Errorf("defaultRunner(true) = %v, want nil", err)
+	tests := []struct {
+		name    string
+		command string
+		wantErr bool
+	}{
+		{name: "successful command", command: "true", wantErr: false},
+		{name: "failing command", command: "false", wantErr: true},
+		{name: "missing binary", command: "nvim-sync-no-such-binary", wantErr: true},
 	}
-	if err := defaultRunner("false"); err == nil {
-		t.Error("defaultRunner(false) = nil, want error")
-	}
-	if err := defaultRunner("nvim-sync-no-such-binary"); err == nil {
-		t.Error("defaultRunner(missing) = nil, want error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := defaultRunner(tt.command); (err != nil) != tt.wantErr {
+				t.Errorf("defaultRunner(%q) error = %v, wantErr %v", tt.command, err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -146,26 +158,25 @@ func TestNewSyncer(t *testing.T) {
 
 func TestSyncBatch(t *testing.T) {
 	t.Parallel()
-	t.Run("copies every file on success", func(t *testing.T) {
-		t.Parallel()
-		rec := &recordingRunner{}
-		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: "/src", DestRoot: "/dest", Run: rec.run}
-		syncBatch(s, []string{"/src/a.lua", "/src/b.lua"})
-		if got := len(rec.calls); got != 2 {
-			t.Fatalf("calls = %d, want 2", got)
-		}
-	})
-
-	t.Run("continues past a failing copy", func(t *testing.T) {
-		t.Parallel()
-		rec := &recordingRunner{err: errors.New("boom")}
-		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: "/src", DestRoot: "/dest", Run: rec.run}
+	tests := []struct {
+		name   string
+		runErr error
+	}{
+		{name: "copies every file on success", runErr: nil},
 		// Should not panic and should attempt both files despite errors.
-		syncBatch(s, []string{"/src/a.lua", "/src/b.lua"})
-		if got := len(rec.calls); got != 2 {
-			t.Fatalf("calls = %d, want 2 (must continue past failures)", got)
-		}
-	})
+		{name: "continues past a failing copy", runErr: errors.New("boom")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingRunner{err: tt.runErr}
+			s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: "/src", DestRoot: "/dest", Run: rec.run}
+			syncBatch(s, []string{"/src/a.lua", "/src/b.lua"})
+			if got := len(rec.calls); got != 2 {
+				t.Fatalf("calls = %d, want 2 (must attempt every file)", got)
+			}
+		})
+	}
 }
 
 func TestRunSync(t *testing.T) {
@@ -270,42 +281,63 @@ func TestWatchLoop(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	t.Run("no args prints usage and errors", func(t *testing.T) {
-		var buf bytes.Buffer
-		if err := run(nil, &buf); !errors.Is(err, errUsage) {
-			t.Errorf("run(nil) error = %v, want errUsage", err)
-		}
-		if !strings.Contains(buf.String(), "Usage") {
-			t.Error("run(nil) did not print usage")
-		}
-	})
-
-	t.Run("unknown command prints usage and errors", func(t *testing.T) {
-		var buf bytes.Buffer
-		if err := run([]string{"bogus"}, &buf); !errors.Is(err, errUsage) {
-			t.Errorf("run(bogus) error = %v, want errUsage", err)
-		}
-		if !strings.Contains(buf.String(), "Usage") {
-			t.Error("run(bogus) did not print usage")
-		}
-	})
-
-	t.Run("sync over empty dir succeeds without docker", func(t *testing.T) {
-		t.Setenv("NVIM_SYNC_SRC", t.TempDir())
-		var buf bytes.Buffer
-		// Empty dir => no .lua files => runSync makes no docker calls.
-		if err := run([]string{"sync"}, &buf); err != nil {
-			t.Errorf("run(sync) error = %v, want nil", err)
-		}
-	})
-
-	t.Run("sync with invalid src errors", func(t *testing.T) {
-		t.Setenv("NVIM_SYNC_SRC", filepath.Join(t.TempDir(), "missing"))
-		var buf bytes.Buffer
-		if err := run([]string{"sync"}, &buf); err == nil {
-			t.Error("run(sync) = nil, want error for invalid src")
-		}
-	})
+	tests := []struct {
+		name string
+		args []string
+		// src resolves the NVIM_SYNC_SRC value for the case; nil leaves it unset.
+		src          func(t *testing.T) string
+		wantUsageErr bool // err must be errUsage and usage must be printed
+		wantErr      bool // err must be non-nil
+	}{
+		{
+			name:         "no args prints usage and errors",
+			args:         nil,
+			wantUsageErr: true,
+		},
+		{
+			name:         "unknown command prints usage and errors",
+			args:         []string{"bogus"},
+			wantUsageErr: true,
+		},
+		{
+			name: "sync over empty dir succeeds without docker",
+			args: []string{"sync"},
+			// Empty dir => no .lua files => runSync makes no docker calls.
+			src: func(t *testing.T) string { return t.TempDir() },
+		},
+		{
+			name:    "sync with invalid src errors",
+			args:    []string{"sync"},
+			src:     func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") },
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.src != nil {
+				t.Setenv("NVIM_SYNC_SRC", tt.src(t))
+			}
+			var buf bytes.Buffer
+			err := run(tt.args, &buf)
+			switch {
+			case tt.wantUsageErr:
+				if !errors.Is(err, errUsage) {
+					t.Errorf("run(%v) error = %v, want errUsage", tt.args, err)
+				}
+				if !strings.Contains(buf.String(), "Usage") {
+					t.Errorf("run(%v) did not print usage", tt.args)
+				}
+			case tt.wantErr:
+				if err == nil {
+					t.Errorf("run(%v) = nil, want error", tt.args)
+				}
+			default:
+				if err != nil {
+					t.Errorf("run(%v) error = %v, want nil", tt.args, err)
+				}
+			}
+		})
+	}
 }
 
 // mustWrite creates an empty file, making parent dirs as needed.

--- a/scripts/nvim-sync/cmd/nvim-sync/main_test.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main_test.go
@@ -94,66 +94,82 @@ func TestDefaultRunner(t *testing.T) {
 }
 
 func TestNewSyncer(t *testing.T) {
-	t.Run("env overrides resolve to absolute src", func(t *testing.T) {
-		dir := t.TempDir()
-		t.Setenv("NVIM_SYNC_SRC", dir)
-		t.Setenv("NVIM_SYNC_CONTAINER", "custom-box")
-		t.Setenv("NVIM_SYNC_DEST", "/custom/dest")
+	// srcKind selects how the NVIM_SYNC_SRC path is materialised per case.
+	tests := []struct {
+		name          string
+		srcKind       string // "dir", "file", or "missing"
+		container     string
+		dest          string
+		wantErr       bool
+		wantContainer string
+		wantDest      string
+	}{
+		{
+			name:          "env overrides resolve to absolute src",
+			srcKind:       "dir",
+			container:     "custom-box",
+			dest:          "/custom/dest",
+			wantContainer: "custom-box",
+			wantDest:      "/custom/dest",
+		},
+		{
+			name:          "defaults apply when env unset",
+			srcKind:       "dir",
+			container:     "",
+			dest:          "",
+			wantContainer: defaultContainer,
+			wantDest:      defaultDest,
+		},
+		{
+			name:    "non-directory src is rejected",
+			srcKind: "file",
+			wantErr: true,
+		},
+		{
+			name:    "missing src is rejected",
+			srcKind: "missing",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var src string
+			switch tt.srcKind {
+			case "dir":
+				src = t.TempDir()
+			case "file":
+				src = filepath.Join(t.TempDir(), "not-a-dir")
+				if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "missing":
+				src = filepath.Join(t.TempDir(), "does-not-exist")
+			}
+			t.Setenv("NVIM_SYNC_SRC", src)
+			t.Setenv("NVIM_SYNC_CONTAINER", tt.container)
+			t.Setenv("NVIM_SYNC_DEST", tt.dest)
 
-		s, err := newSyncer()
-		if err != nil {
-			t.Fatalf("newSyncer() error = %v", err)
-		}
-		if s.Container != "custom-box" {
-			t.Errorf("Container = %q, want %q", s.Container, "custom-box")
-		}
-		if s.DestRoot != "/custom/dest" {
-			t.Errorf("DestRoot = %q, want %q", s.DestRoot, "/custom/dest")
-		}
-		if !filepath.IsAbs(s.SrcRoot) {
-			t.Errorf("SrcRoot = %q, want absolute", s.SrcRoot)
-		}
-		if s.Run == nil {
-			t.Error("Run is nil, want defaultRunner")
-		}
-	})
-
-	t.Run("defaults apply when env unset", func(t *testing.T) {
-		dir := t.TempDir()
-		t.Setenv("NVIM_SYNC_SRC", dir)
-		t.Setenv("NVIM_SYNC_CONTAINER", "")
-		t.Setenv("NVIM_SYNC_DEST", "")
-
-		s, err := newSyncer()
-		if err != nil {
-			t.Fatalf("newSyncer() error = %v", err)
-		}
-		if s.Container != defaultContainer {
-			t.Errorf("Container = %q, want %q", s.Container, defaultContainer)
-		}
-		if s.DestRoot != defaultDest {
-			t.Errorf("DestRoot = %q, want %q", s.DestRoot, defaultDest)
-		}
-	})
-
-	t.Run("non-directory src is rejected", func(t *testing.T) {
-		file := filepath.Join(t.TempDir(), "not-a-dir")
-		if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		t.Setenv("NVIM_SYNC_SRC", file)
-
-		if _, err := newSyncer(); err == nil {
-			t.Error("newSyncer() = nil error, want error for non-directory src")
-		}
-	})
-
-	t.Run("missing src is rejected", func(t *testing.T) {
-		t.Setenv("NVIM_SYNC_SRC", filepath.Join(t.TempDir(), "does-not-exist"))
-		if _, err := newSyncer(); err == nil {
-			t.Error("newSyncer() = nil error, want error for missing src")
-		}
-	})
+			s, err := newSyncer()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("newSyncer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if s.Container != tt.wantContainer {
+				t.Errorf("Container = %q, want %q", s.Container, tt.wantContainer)
+			}
+			if s.DestRoot != tt.wantDest {
+				t.Errorf("DestRoot = %q, want %q", s.DestRoot, tt.wantDest)
+			}
+			if !filepath.IsAbs(s.SrcRoot) {
+				t.Errorf("SrcRoot = %q, want absolute", s.SrcRoot)
+			}
+			if s.Run == nil {
+				t.Error("Run is nil, want defaultRunner")
+			}
+		})
+	}
 }
 
 func TestSyncBatch(t *testing.T) {
@@ -181,41 +197,57 @@ func TestSyncBatch(t *testing.T) {
 
 func TestRunSync(t *testing.T) {
 	t.Parallel()
-	t.Run("copies only lua files recursively", func(t *testing.T) {
-		t.Parallel()
-		root := t.TempDir()
-		mustWrite(t, filepath.Join(root, "init.lua"))
-		mustWrite(t, filepath.Join(root, "notes.txt"))
-		mustWrite(t, filepath.Join(root, "lua", "ai_bridge.lua"))
-
-		rec := &recordingRunner{}
-		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
-		if err := runSync(s); err != nil {
-			t.Fatalf("runSync() error = %v", err)
-		}
-		want := []string{filepath.Join(root, "init.lua"), filepath.Join(root, "lua", "ai_bridge.lua")}
-		sort.Strings(want)
-		got := rec.sources()
-		if len(got) != len(want) {
-			t.Fatalf("copied %v, want %v", got, want)
-		}
-		for i := range want {
-			if got[i] != want[i] {
-				t.Errorf("copied[%d] = %q, want %q", i, got[i], want[i])
+	tests := []struct {
+		name        string
+		files       []string // empty files created under the temp root
+		runErr      error
+		wantErr     bool
+		wantSources []string // paths relative to root; checked only when wantErr is false
+	}{
+		{
+			name:        "copies only lua files recursively",
+			files:       []string{"init.lua", "notes.txt", filepath.Join("lua", "ai_bridge.lua")},
+			wantSources: []string{"init.lua", filepath.Join("lua", "ai_bridge.lua")},
+		},
+		{
+			name:    "propagates copy failure",
+			files:   []string{"init.lua"},
+			runErr:  errors.New("boom"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			for _, f := range tt.files {
+				mustWrite(t, filepath.Join(root, f))
 			}
-		}
-	})
-
-	t.Run("propagates copy failure", func(t *testing.T) {
-		t.Parallel()
-		root := t.TempDir()
-		mustWrite(t, filepath.Join(root, "init.lua"))
-		rec := &recordingRunner{err: errors.New("boom")}
-		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
-		if err := runSync(s); err == nil {
-			t.Error("runSync() = nil, want error when copy fails")
-		}
-	})
+			rec := &recordingRunner{err: tt.runErr}
+			s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
+			err := runSync(s)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("runSync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			want := make([]string, len(tt.wantSources))
+			for i, src := range tt.wantSources {
+				want[i] = filepath.Join(root, src)
+			}
+			sort.Strings(want)
+			got := rec.sources()
+			if len(got) != len(want) {
+				t.Fatalf("copied %v, want %v", got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("copied[%d] = %q, want %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
 }
 
 func TestWatchLoop(t *testing.T) {

--- a/scripts/nvim-sync/cmd/nvim-sync/main_test.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"nvim-sync/internal/syncer"
+)
+
+// recordingRunner captures docker invocations so tests stay off real Docker.
+type recordingRunner struct {
+	mu    sync.Mutex
+	calls [][]string
+	err   error
+}
+
+func (r *recordingRunner) run(name string, args ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string{name}, args...))
+	return r.err
+}
+
+func (r *recordingRunner) sources() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var srcs []string
+	for _, c := range r.calls {
+		// docker cp <src> <dest>
+		srcs = append(srcs, c[2])
+	}
+	sort.Strings(srcs)
+	return srcs
+}
+
+func TestGetenv(t *testing.T) {
+	t.Run("returns default when unset", func(t *testing.T) {
+		t.Setenv("NVIM_SYNC_TEST_KEY", "")
+		if got := getenv("NVIM_SYNC_TEST_KEY", "fallback"); got != "fallback" {
+			t.Errorf("getenv = %q, want %q", got, "fallback")
+		}
+	})
+	t.Run("returns value when set", func(t *testing.T) {
+		t.Setenv("NVIM_SYNC_TEST_KEY", "explicit")
+		if got := getenv("NVIM_SYNC_TEST_KEY", "fallback"); got != "explicit" {
+			t.Errorf("getenv = %q, want %q", got, "explicit")
+		}
+	})
+}
+
+func TestUsage(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	usage(&buf)
+	out := buf.String()
+	for _, want := range []string{"Usage: nvim-sync", "watch", "sync", "NVIM_SYNC_CONTAINER"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("usage output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestDefaultRunner(t *testing.T) {
+	t.Parallel()
+	if err := defaultRunner("true"); err != nil {
+		t.Errorf("defaultRunner(true) = %v, want nil", err)
+	}
+	if err := defaultRunner("false"); err == nil {
+		t.Error("defaultRunner(false) = nil, want error")
+	}
+	if err := defaultRunner("nvim-sync-no-such-binary"); err == nil {
+		t.Error("defaultRunner(missing) = nil, want error")
+	}
+}
+
+func TestNewSyncer(t *testing.T) {
+	t.Run("env overrides resolve to absolute src", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("NVIM_SYNC_SRC", dir)
+		t.Setenv("NVIM_SYNC_CONTAINER", "custom-box")
+		t.Setenv("NVIM_SYNC_DEST", "/custom/dest")
+
+		s, err := newSyncer()
+		if err != nil {
+			t.Fatalf("newSyncer() error = %v", err)
+		}
+		if s.Container != "custom-box" {
+			t.Errorf("Container = %q, want %q", s.Container, "custom-box")
+		}
+		if s.DestRoot != "/custom/dest" {
+			t.Errorf("DestRoot = %q, want %q", s.DestRoot, "/custom/dest")
+		}
+		if !filepath.IsAbs(s.SrcRoot) {
+			t.Errorf("SrcRoot = %q, want absolute", s.SrcRoot)
+		}
+		if s.Run == nil {
+			t.Error("Run is nil, want defaultRunner")
+		}
+	})
+
+	t.Run("defaults apply when env unset", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("NVIM_SYNC_SRC", dir)
+		t.Setenv("NVIM_SYNC_CONTAINER", "")
+		t.Setenv("NVIM_SYNC_DEST", "")
+
+		s, err := newSyncer()
+		if err != nil {
+			t.Fatalf("newSyncer() error = %v", err)
+		}
+		if s.Container != defaultContainer {
+			t.Errorf("Container = %q, want %q", s.Container, defaultContainer)
+		}
+		if s.DestRoot != defaultDest {
+			t.Errorf("DestRoot = %q, want %q", s.DestRoot, defaultDest)
+		}
+	})
+
+	t.Run("non-directory src is rejected", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("NVIM_SYNC_SRC", file)
+
+		if _, err := newSyncer(); err == nil {
+			t.Error("newSyncer() = nil error, want error for non-directory src")
+		}
+	})
+
+	t.Run("missing src is rejected", func(t *testing.T) {
+		t.Setenv("NVIM_SYNC_SRC", filepath.Join(t.TempDir(), "does-not-exist"))
+		if _, err := newSyncer(); err == nil {
+			t.Error("newSyncer() = nil error, want error for missing src")
+		}
+	})
+}
+
+func TestSyncBatch(t *testing.T) {
+	t.Parallel()
+	t.Run("copies every file on success", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingRunner{}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: "/src", DestRoot: "/dest", Run: rec.run}
+		syncBatch(s, []string{"/src/a.lua", "/src/b.lua"})
+		if got := len(rec.calls); got != 2 {
+			t.Fatalf("calls = %d, want 2", got)
+		}
+	})
+
+	t.Run("continues past a failing copy", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingRunner{err: errors.New("boom")}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: "/src", DestRoot: "/dest", Run: rec.run}
+		// Should not panic and should attempt both files despite errors.
+		syncBatch(s, []string{"/src/a.lua", "/src/b.lua"})
+		if got := len(rec.calls); got != 2 {
+			t.Fatalf("calls = %d, want 2 (must continue past failures)", got)
+		}
+	})
+}
+
+func TestRunSync(t *testing.T) {
+	t.Parallel()
+	t.Run("copies only lua files recursively", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		mustWrite(t, filepath.Join(root, "init.lua"))
+		mustWrite(t, filepath.Join(root, "notes.txt"))
+		mustWrite(t, filepath.Join(root, "lua", "ai_bridge.lua"))
+
+		rec := &recordingRunner{}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
+		if err := runSync(s); err != nil {
+			t.Fatalf("runSync() error = %v", err)
+		}
+		want := []string{filepath.Join(root, "init.lua"), filepath.Join(root, "lua", "ai_bridge.lua")}
+		sort.Strings(want)
+		got := rec.sources()
+		if len(got) != len(want) {
+			t.Fatalf("copied %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("copied[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("propagates copy failure", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		mustWrite(t, filepath.Join(root, "init.lua"))
+		rec := &recordingRunner{err: errors.New("boom")}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
+		if err := runSync(s); err == nil {
+			t.Error("runSync() = nil, want error when copy fails")
+		}
+	})
+}
+
+func TestWatchLoop(t *testing.T) {
+	t.Parallel()
+	t.Run("returns nil when context is cancelled", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		rec := &recordingRunner{}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- watchLoop(ctx, s) }()
+
+		// Give the watcher a moment to start, then cancel.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("watchLoop() = %v, want nil", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("watchLoop did not return after cancel")
+		}
+	})
+
+	t.Run("syncs a file written while watching", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		rec := &recordingRunner{}
+		s := &syncer.Syncer{Container: "nvim-dev", SrcRoot: root, DestRoot: "/dest", Run: rec.run}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- watchLoop(ctx, s) }()
+
+		time.Sleep(50 * time.Millisecond)
+		mustWrite(t, filepath.Join(root, "init.lua"))
+
+		// Wait for the debounced batch to be copied.
+		deadline := time.After(3 * time.Second)
+		for len(rec.sources()) == 0 {
+			select {
+			case <-deadline:
+				t.Fatal("file write was not synced")
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+		cancel()
+		<-done
+	})
+
+	t.Run("errors when src root is missing", func(t *testing.T) {
+		t.Parallel()
+		s := &syncer.Syncer{SrcRoot: filepath.Join(t.TempDir(), "missing")}
+		if err := watchLoop(context.Background(), s); err == nil {
+			t.Error("watchLoop() = nil, want error for missing src root")
+		}
+	})
+}
+
+func TestRun(t *testing.T) {
+	t.Run("no args prints usage and errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := run(nil, &buf); !errors.Is(err, errUsage) {
+			t.Errorf("run(nil) error = %v, want errUsage", err)
+		}
+		if !strings.Contains(buf.String(), "Usage") {
+			t.Error("run(nil) did not print usage")
+		}
+	})
+
+	t.Run("unknown command prints usage and errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := run([]string{"bogus"}, &buf); !errors.Is(err, errUsage) {
+			t.Errorf("run(bogus) error = %v, want errUsage", err)
+		}
+		if !strings.Contains(buf.String(), "Usage") {
+			t.Error("run(bogus) did not print usage")
+		}
+	})
+
+	t.Run("sync over empty dir succeeds without docker", func(t *testing.T) {
+		t.Setenv("NVIM_SYNC_SRC", t.TempDir())
+		var buf bytes.Buffer
+		// Empty dir => no .lua files => runSync makes no docker calls.
+		if err := run([]string{"sync"}, &buf); err != nil {
+			t.Errorf("run(sync) error = %v, want nil", err)
+		}
+	})
+
+	t.Run("sync with invalid src errors", func(t *testing.T) {
+		t.Setenv("NVIM_SYNC_SRC", filepath.Join(t.TempDir(), "missing"))
+		var buf bytes.Buffer
+		if err := run([]string{"sync"}, &buf); err == nil {
+			t.Error("run(sync) = nil, want error for invalid src")
+		}
+	})
+}
+
+// mustWrite creates an empty file, making parent dirs as needed.
+func mustWrite(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/nvim-sync/go.mod
+++ b/scripts/nvim-sync/go.mod
@@ -1,0 +1,7 @@
+module nvim-sync
+
+go 1.26
+
+require github.com/fsnotify/fsnotify v1.10.1
+
+require golang.org/x/sys v0.13.0 // indirect

--- a/scripts/nvim-sync/go.sum
+++ b/scripts/nvim-sync/go.sum
@@ -1,0 +1,4 @@
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/scripts/nvim-sync/internal/syncer/syncer.go
+++ b/scripts/nvim-sync/internal/syncer/syncer.go
@@ -1,0 +1,54 @@
+// Package syncer copies changed Neovim config files from the host into a
+// running nvim container via `docker cp`, preserving each file's path relative
+// to the configured source root.
+package syncer
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Runner executes an external command. It is injected so tests can stub out
+// `docker` without depending on a real Docker daemon.
+type Runner func(name string, args ...string) error
+
+// Syncer copies files into a target container.
+type Syncer struct {
+	// Container is the target container name (e.g. "nvim-dev").
+	Container string
+	// SrcRoot is the host directory whose tree is mirrored into the container.
+	SrcRoot string
+	// DestRoot is the directory inside the container that mirrors SrcRoot.
+	DestRoot string
+	// Run executes commands (defaults to a real exec runner in main).
+	Run Runner
+}
+
+// Dest returns the container-side `docker cp` destination for a changed file,
+// e.g. "nvim-dev:/root/.config/nvim/lua/ai_bridge.lua". The returned bool is
+// false if changed lies outside SrcRoot.
+func (s *Syncer) Dest(changed string) (string, bool) {
+	rel, relErr := filepath.Rel(s.SrcRoot, changed)
+	if relErr != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return fmt.Sprintf("%s:%s", s.Container, path.Join(s.DestRoot, rel)), true
+}
+
+// Copy copies a single changed file into the container with `docker cp`.
+func (s *Syncer) Copy(changed string) error {
+	dest, ok := s.Dest(changed)
+	if !ok {
+		return fmt.Errorf("file %q is outside src root %q", changed, s.SrcRoot)
+	}
+	if runErr := s.Run("docker", "cp", changed, dest); runErr != nil {
+		return fmt.Errorf("docker cp %s -> %s: %w", changed, dest, runErr)
+	}
+	return nil
+}

--- a/scripts/nvim-sync/internal/syncer/syncer_test.go
+++ b/scripts/nvim-sync/internal/syncer/syncer_test.go
@@ -1,0 +1,143 @@
+package syncer
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// recordingRunner captures invocations for verification.
+type recordingRunner struct {
+	mu    sync.Mutex
+	calls [][]string
+	err   error
+}
+
+func (r *recordingRunner) run(name string, args ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	return r.err
+}
+
+func TestDest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		srcRoot  string
+		destRoot string
+		changed  string
+		wantDest string
+		wantOK   bool
+	}{
+		{
+			name:     "top-level file",
+			srcRoot:  "/repo/nvim/config",
+			destRoot: "/root/.config/nvim",
+			changed:  "/repo/nvim/config/init.lua",
+			wantDest: "nvim-dev:/root/.config/nvim/init.lua",
+			wantOK:   true,
+		},
+		{
+			name:     "nested file",
+			srcRoot:  "/repo/nvim/config",
+			destRoot: "/root/.config/nvim",
+			changed:  "/repo/nvim/config/lua/ai_bridge.lua",
+			wantDest: "nvim-dev:/root/.config/nvim/lua/ai_bridge.lua",
+			wantOK:   true,
+		},
+		{
+			name:     "deeply nested file",
+			srcRoot:  "/repo/nvim/config",
+			destRoot: "/root/.config/nvim",
+			changed:  "/repo/nvim/config/lua/lsp/init.lua",
+			wantDest: "nvim-dev:/root/.config/nvim/lua/lsp/init.lua",
+			wantOK:   true,
+		},
+		{
+			name:     "outside src root",
+			srcRoot:  "/repo/nvim/config",
+			destRoot: "/root/.config/nvim",
+			changed:  "/repo/other/file.lua",
+			wantDest: "",
+			wantOK:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Syncer{Container: "nvim-dev", SrcRoot: tt.srcRoot, DestRoot: tt.destRoot}
+			got, ok := s.Dest(tt.changed)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.wantDest {
+				t.Errorf("dest = %q, want %q", got, tt.wantDest)
+			}
+		})
+	}
+}
+
+func TestCopy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		changed  string
+		runErr   error
+		wantArgs []string
+		wantErr  bool
+	}{
+		{
+			name:     "success runs docker cp",
+			changed:  "/repo/nvim/config/lua/ai_bridge.lua",
+			wantArgs: []string{"docker", "cp", "/repo/nvim/config/lua/ai_bridge.lua", "nvim-dev:/root/.config/nvim/lua/ai_bridge.lua"},
+		},
+		{
+			name:     "runner error propagates",
+			changed:  "/repo/nvim/config/init.lua",
+			runErr:   errors.New("boom"),
+			wantArgs: []string{"docker", "cp", "/repo/nvim/config/init.lua", "nvim-dev:/root/.config/nvim/init.lua"},
+			wantErr:  true,
+		},
+		{
+			name:    "outside src root is rejected without running",
+			changed: "/elsewhere/x.lua",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingRunner{err: tt.runErr}
+			s := &Syncer{
+				Container: "nvim-dev",
+				SrcRoot:   "/repo/nvim/config",
+				DestRoot:  "/root/.config/nvim",
+				Run:       rec.run,
+			}
+			copyErr := s.Copy(tt.changed)
+			if (copyErr != nil) != tt.wantErr {
+				t.Fatalf("Copy error = %v, wantErr %v", copyErr, tt.wantErr)
+			}
+			if tt.wantArgs == nil {
+				if len(rec.calls) != 0 {
+					t.Errorf("expected no docker invocation, got %v", rec.calls)
+				}
+				return
+			}
+			if len(rec.calls) != 1 {
+				t.Fatalf("expected 1 invocation, got %d: %v", len(rec.calls), rec.calls)
+			}
+			got := rec.calls[0]
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("args = %v, want %v", got, tt.wantArgs)
+			}
+			for i := range tt.wantArgs {
+				if got[i] != tt.wantArgs[i] {
+					t.Errorf("arg %d = %q, want %q", i, got[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}

--- a/scripts/nvim-sync/internal/watcher/watcher.go
+++ b/scripts/nvim-sync/internal/watcher/watcher.go
@@ -1,0 +1,152 @@
+// Package watcher recursively watches a Neovim config tree and emits debounced
+// batches of changed Lua file paths.
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher recursively watches root for Lua file changes.
+type Watcher struct {
+	root     string
+	debounce time.Duration
+}
+
+// New creates a Watcher for root with the given debounce window.
+func New(root string, debounce time.Duration) *Watcher {
+	return &Watcher{root: root, debounce: debounce}
+}
+
+// isLuaFile reports whether name is a Lua source file.
+func isLuaFile(name string) bool {
+	return filepath.Ext(name) == ".lua"
+}
+
+// batch coalesces changed paths into a unique, sorted set so a burst of saves
+// collapses into a single sync.
+type batch struct {
+	mu    sync.Mutex
+	items map[string]struct{}
+}
+
+func newBatch() *batch {
+	return &batch{items: make(map[string]struct{})}
+}
+
+func (b *batch) add(p string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.items[p] = struct{}{}
+}
+
+// drain returns the accumulated paths sorted and clears the set.
+func (b *batch) drain() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(b.items))
+	for p := range b.items {
+		out = append(out, p)
+	}
+	b.items = make(map[string]struct{})
+	sort.Strings(out)
+	return out
+}
+
+// addRecursive registers root and every subdirectory with fsw.
+func addRecursive(fsw *fsnotify.Watcher, root string) error {
+	return filepath.WalkDir(root, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if addErr := fsw.Add(p); addErr != nil {
+				return fmt.Errorf("watch %s: %w", p, addErr)
+			}
+		}
+		return nil
+	})
+}
+
+// Watch recursively watches the tree and sends debounced batches of changed Lua
+// file paths until ctx is cancelled. The channel is closed on cancellation.
+func (w *Watcher) Watch(ctx context.Context) (<-chan []string, error) {
+	fsw, newErr := fsnotify.NewWatcher()
+	if newErr != nil {
+		return nil, fmt.Errorf("create watcher: %w", newErr)
+	}
+	if addErr := addRecursive(fsw, w.root); addErr != nil {
+		_ = fsw.Close()
+		return nil, addErr
+	}
+
+	out := make(chan []string)
+	b := newBatch()
+	go func() {
+		defer close(out)
+		defer func() { _ = fsw.Close() }()
+
+		timer := time.NewTimer(w.debounce)
+		if !timer.Stop() {
+			<-timer.C
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-fsw.Events:
+				if !ok {
+					return
+				}
+				w.handleEvent(fsw, event, b, timer)
+			case <-timer.C:
+				if changed := b.drain(); len(changed) > 0 {
+					select {
+					case out <- changed:
+					case <-ctx.Done():
+						return
+					}
+				}
+			case fsErr, ok := <-fsw.Errors:
+				if !ok {
+					return
+				}
+				slog.Warn("watch error", "error", fsErr)
+			}
+		}
+	}()
+	return out, nil
+}
+
+// handleEvent records relevant changes and (re)arms the debounce timer.
+func (w *Watcher) handleEvent(fsw *fsnotify.Watcher, event fsnotify.Event, b *batch, timer *time.Timer) {
+	if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) {
+		return
+	}
+	// Watch directories created after startup so their files are not missed.
+	if event.Has(fsnotify.Create) {
+		if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
+			if addErr := addRecursive(fsw, event.Name); addErr != nil {
+				slog.Warn("watch new dir failed", "dir", event.Name, "error", addErr)
+			}
+			return
+		}
+	}
+	if !isLuaFile(event.Name) {
+		return
+	}
+	b.add(event.Name)
+	timer.Reset(w.debounce)
+}

--- a/scripts/nvim-sync/internal/watcher/watcher_test.go
+++ b/scripts/nvim-sync/internal/watcher/watcher_test.go
@@ -1,0 +1,128 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestIsLuaFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "lua file", path: "/x/init.lua", want: true},
+		{name: "nested lua", path: "/x/lua/lsp/init.lua", want: true},
+		{name: "non-lua", path: "/x/notes.txt", want: false},
+		{name: "no extension", path: "/x/Makefile", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isLuaFile(tt.path); got != tt.want {
+				t.Errorf("isLuaFile(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchDrain(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		adds []string
+		want []string
+	}{
+		{name: "empty", adds: nil, want: nil},
+		{name: "single", adds: []string{"/a.lua"}, want: []string{"/a.lua"}},
+		{
+			name: "dedup and sort",
+			adds: []string{"/b.lua", "/a.lua", "/b.lua", "/a.lua"},
+			want: []string{"/a.lua", "/b.lua"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBatch()
+			for _, p := range tt.adds {
+				b.add(p)
+			}
+			got := b.drain()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("drain() = %v, want %v", got, tt.want)
+			}
+			// A second drain after the first must be empty.
+			if again := b.drain(); again != nil {
+				t.Errorf("second drain() = %v, want nil", again)
+			}
+		})
+	}
+}
+
+func TestWatchEmitsChangedLuaFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if mkErr := os.MkdirAll(filepath.Join(root, "lua"), 0o755); mkErr != nil {
+		t.Fatalf("setup: %v", mkErr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := New(root, 50*time.Millisecond)
+	ch, watchErr := w.Watch(ctx)
+	if watchErr != nil {
+		t.Fatalf("Watch: %v", watchErr)
+	}
+
+	target := filepath.Join(root, "lua", "ai_bridge.lua")
+	if writeErr := os.WriteFile(target, []byte("-- x"), 0o644); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+
+	select {
+	case batch := <-ch:
+		found := false
+		for _, p := range batch {
+			if p == target {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("batch %v does not contain %q", batch, target)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for change batch")
+	}
+}
+
+func TestWatchIgnoresNonLua(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := New(root, 50*time.Millisecond)
+	ch, watchErr := w.Watch(ctx)
+	if watchErr != nil {
+		t.Fatalf("Watch: %v", watchErr)
+	}
+
+	if writeErr := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("x"), 0o644); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+
+	select {
+	case batch := <-ch:
+		t.Errorf("unexpected batch for non-lua file: %v", batch)
+	case <-time.After(300 * time.Millisecond):
+		// expected: no emission
+	}
+}

--- a/scripts/nvim-sync/internal/watcher/watcher_test.go
+++ b/scripts/nvim-sync/internal/watcher/watcher_test.go
@@ -1,7 +1,6 @@
 package watcher
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -65,64 +64,62 @@ func TestBatchDrain(t *testing.T) {
 	}
 }
 
-func TestWatchEmitsChangedLuaFiles(t *testing.T) {
+func TestWatch(t *testing.T) {
 	t.Parallel()
-	root := t.TempDir()
-	if mkErr := os.MkdirAll(filepath.Join(root, "lua"), 0o755); mkErr != nil {
-		t.Fatalf("setup: %v", mkErr)
+	tests := []struct {
+		name     string
+		rel      string // file written under root after the watcher starts
+		wantEmit bool
+	}{
+		{name: "emits changed lua file", rel: filepath.Join("lua", "ai_bridge.lua"), wantEmit: true},
+		{name: "ignores non-lua file", rel: "notes.txt", wantEmit: false},
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	w := New(root, 50*time.Millisecond)
-	ch, watchErr := w.Watch(ctx)
-	if watchErr != nil {
-		t.Fatalf("Watch: %v", watchErr)
-	}
-
-	target := filepath.Join(root, "lua", "ai_bridge.lua")
-	if writeErr := os.WriteFile(target, []byte("-- x"), 0o644); writeErr != nil {
-		t.Fatalf("write: %v", writeErr)
-	}
-
-	select {
-	case batch := <-ch:
-		found := false
-		for _, p := range batch {
-			if p == target {
-				found = true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			target := filepath.Join(root, tt.rel)
+			// Parent dirs must exist before Watch starts so they are registered.
+			if mkErr := os.MkdirAll(filepath.Dir(target), 0o755); mkErr != nil {
+				t.Fatalf("setup: %v", mkErr)
 			}
-		}
-		if !found {
-			t.Errorf("batch %v does not contain %q", batch, target)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for change batch")
-	}
-}
 
-func TestWatchIgnoresNonLua(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
+			ctx := t.Context()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			w := New(root, 50*time.Millisecond)
+			ch, watchErr := w.Watch(ctx)
+			if watchErr != nil {
+				t.Fatalf("Watch: %v", watchErr)
+			}
 
-	w := New(root, 50*time.Millisecond)
-	ch, watchErr := w.Watch(ctx)
-	if watchErr != nil {
-		t.Fatalf("Watch: %v", watchErr)
-	}
+			if writeErr := os.WriteFile(target, []byte("-- x"), 0o644); writeErr != nil {
+				t.Fatalf("write: %v", writeErr)
+			}
 
-	if writeErr := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("x"), 0o644); writeErr != nil {
-		t.Fatalf("write: %v", writeErr)
-	}
+			if tt.wantEmit {
+				select {
+				case batch := <-ch:
+					found := false
+					for _, p := range batch {
+						if p == target {
+							found = true
+						}
+					}
+					if !found {
+						t.Errorf("batch %v does not contain %q", batch, target)
+					}
+				case <-time.After(3 * time.Second):
+					t.Fatal("timed out waiting for change batch")
+				}
+				return
+			}
 
-	select {
-	case batch := <-ch:
-		t.Errorf("unexpected batch for non-lua file: %v", batch)
-	case <-time.After(300 * time.Millisecond):
-		// expected: no emission
+			select {
+			case batch := <-ch:
+				t.Errorf("unexpected batch for non-lua file: %v", batch)
+			case <-time.After(300 * time.Millisecond):
+				// expected: no emission
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #457

## 何を

`scripts/nvim-sync/` に net-new ツールを追加。ホスト側の `nvim/config/` を監視し、変更された Lua ファイルを稼働中の `nvim-dev` コンテナへ `docker cp` で自動転送する。

構成（ai-bridge に倣い Go + 外部依存は `fsnotify` のみ）:

- `cmd/nvim-sync/main.go` — サブコマンド `watch`（常駐監視）/ `sync`（全ファイル初期同期）、env からの設定解決、`docker cp` 実行ランナー。
- `internal/watcher/` — fsnotify 再帰監視 + デバウンス束ね。`*.lua` の create/write を検知し、連続保存を 1 バッチに集約。
- `internal/syncer/` — `Runner` 注入で `docker cp` を実行。変更ファイルのソースルート相対パスを保ちコピー先を組み立てる（例: `nvim/config/lua/ai_bridge.lua` → `nvim-dev:/root/.config/nvim/lua/ai_bridge.lua`）。
- `go.mod` / `go.sum` / `Makefile` / `README.md` / `.gitignore`。

env: `NVIM_SYNC_CONTAINER`（既定 `nvim-dev`）/ `NVIM_SYNC_SRC`（既定 `nvim/config`）/ `NVIM_SYNC_DEST`（既定 `/root/.config/nvim`）。

最小スコープ（issue 記載どおり）: `watch` + `sync` + 構造化ログまで。`:source` 自動再読込・`--json`・polling フォールバックは後続。

## なぜ

nvim 設定はイメージビルド時に `COPY` で焼き込まれ bind mount されていないため、1 行直すたびにイメージリビルドか手作業の `docker cp`（ai-bridge README に暫定対応として明記）が必要だった。`nvim-sync` はこの手作業を編集ループから消し、設定イテレーションを速くする。ツールは `scripts/nvim-sync/` に閉じ、ai-bridge には一切手を入れない。

## 検証

- `goimports -d .`（差分なし）/ `go build ./...` / `go vet ./...` → パス。
- `golangci-lint run ./...` → **0 issues**。
- `go test ./...` → パス（相対パス算出・コピー先パス組み立て・デバウンス束ね・isLuaFile をテーブル駆動で検証。`docker` 実行は `syncer.Runner` 注入でスタブ化し実 Docker 非依存。watcher は temp dir 上の実 fsnotify で create→batch を確認。table-driven + `t.Parallel()`・`t.TempDir()`）。
- README: `prettier --check` / `markdownlint-cli2` → パス。

## CI カバレッジの留意点（issue (e) 由来）

既存 Go CI（`.github/workflows/lint_ai_bridge.yml` / `test_ai_bridge.yml`）は `paths: scripts/ai-bridge/**` 限定のため、**本モジュールは現状 CI 対象外**。CI へ載せるには両ワークフローの path 一般化、または本モジュール用の同等ワークフロー追加が必要（本 issue のスコープ外。README にも明記）。

## 留意点

- `docker cp` の配置先親ディレクトリはコンテナ側に既存である前提（Dockerfile の `COPY` 先と一致）。深い新規ディレクトリ作成は最小構成の範囲外。
- コンテナ未起動・`docker` 不在時は `docker cp` のエラーを warn ログに出力して継続する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BctLw3niPaHj9uyzsPNAvF)_