### PR TITLE
chore: scripts のハーネス強化に golangci-lint 設定を追加

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+# golangci-lint 設定（v2 フォーマット）
+#
+# scripts/ 配下の Go モジュール（nvim-sync / ai-bridge）共通の設定。
+# golangci-lint は実行ディレクトリから上位を探索するため、リポジトリ直下に
+# 1ファイル置くことで両モジュール・CI・Stop フック（lint-changed.sh）すべてが参照する。
+#
+# 目的: AI 駆動開発のハーネス強化。バグ検出系リンターで「動くが壊れている」コードを
+# 早期に止め、AGENTS.md の規約を機械的に担保する。
+version: "2"
+
+linters:
+  # 標準セット（errcheck / govet / ineffassign / staticcheck / unused）を維持して追加有効化する。
+  default: standard
+  enable:
+    # --- バグ検出（correctness） ---
+    - errorlint # %w ラップ / errors.Is/As の誤用検出
+    - nilerr # err != nil チェック後に nil を返すバグ
+    - nilnil # nil, nil の同時返却
+    - bodyclose # レスポンスボディ閉じ忘れ
+    - contextcheck # context の伝播漏れ
+    - makezero # make + append の初期長バグ
+    - wastedassign # 使われない代入
+    # --- 規約・品質（maintainability） ---
+    - gocritic # 高シグナルな診断群
+    - revive # golint 後継
+    - unconvert # 不要な型変換
+    - unparam # 使われない関数引数
+    - misspell # スペルミス
+    # --- テスト品質（AGENTS.md 規約に直結） ---
+    - tparallel # t.Parallel() の誤用検出
+    - thelper # ヘルパーでの t.Helper() 呼び出し漏れ
+
+  settings:
+    govet:
+      enable:
+        - shadow # err などのシャドーイング検出（規約「err を使い回さない」を部分的に担保）
+    errcheck:
+      check-type-assertions: true # 型アサーションのエラー無視を検出
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+
+  exclusions:
+    rules:
+      # テストコードでは可読性を優先し、一部リンターを緩和する。
+      # revive: ドレインループ（for range ch {}）など、テスト特有の慣用句を許容する。
+      - path: _test.go
+        linters:
+          - errcheck
+          - unparam
+          - revive
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/docs/plan/2026-06-29_golangci-lint-harness-scripts.md
+++ b/docs/plan/2026-06-29_golangci-lint-harness-scripts.md
@@ -1,0 +1,59 @@
+# Plan: scripts/ 配下の golangci-lint ハーネス強化
+
+AI駆動開発における「ハーネス（検証ループ）」の質を高めるため、Go コードが集中する `scripts/`（`nvim-sync` / `ai-bridge` の2モジュール）に明示的な golangci-lint 設定を導入し、バグ検出と規約の機械的担保を内側ループ（Stop フック）と CI の双方で効かせる。
+
+## Background
+
+- 現状、両モジュールの golangci-lint は **設定ファイルなし＝GitHub Action のデフォルト**でしか回っておらず、AIへのフィードバックが弱い。
+- `lint-changed.sh` Stop フックは変更ディレクトリに対し `golangci-lint run` を実行するため、設定を強化すると AI の内側ループの解像度がそのまま上がる。
+- `scripts/ai-bridge/AGENTS.md` は既に規約（table-driven test + `t.Parallel()`、`err` の使い回し禁止、不要な export 回避）を定めており、いくつかは特定リンターに対応づけられる。
+- 参考: OpenAI「Harness Engineering」、Anthropic「Steering Claude Code」。
+
+## Current structure
+
+- 2モジュールとも **Go 1.26**、それぞれ `go.mod` を持つ別モジュール。
+  - `scripts/nvim-sync`（~1,032 LOC, pkg: main/syncer/watcher）
+  - `scripts/ai-bridge`（~1,990 LOC, pkg: main/daemon/doctor/launchd/launcher/testutil/watcher）
+- `.golangci.{yml,yaml,toml}` はリポジトリ内に存在しなかった。
+- CI（`.github/workflows/lint_{nvim_sync,ai_bridge}.yml`）は `golangci/golangci-lint-action@v9.2.0`（= golangci-lint v2 系）を `working-directory` 指定で実行。→ 設定は v2 フォーマット必須。
+
+## 採用方針
+
+- リンター範囲: バグ検出 + 規約 + 品質（推奨ティア）。
+- 既存違反: 同じ変更で全部修正（CIを最初から緑に）。
+- 設定配置: リポジトリ直下に `.golangci.yml` を1つ。golangci-lint は実行ディレクトリから上位を探索するため、両モジュール・CI・Stop フックすべてがこの1ファイルを参照する（DRY）。
+
+## 変更内容
+
+### 1. `.golangci.yml`（リポジトリ直下・新規, v2 フォーマット）
+
+標準セット（errcheck / govet / ineffassign / staticcheck / unused）を維持して追加有効化:
+
+- バグ検出: `errorlint` `nilerr` `nilnil` `bodyclose` `contextcheck` `makezero` `wastedassign`
+- 規約・品質: `gocritic` `revive` `unconvert` `unparam` `misspell`
+- テスト品質: `tparallel` `thelper`
+- settings: `govet` の `shadow`（`err` の使い回しを部分的に担保）、`errcheck.check-type-assertions`、`gocritic` tags（diagnostic/performance/style）
+- exclusions: `_test.go` では `errcheck` / `unparam` / `revive` を緩和（ドレインループ等の慣用句を許容）
+- formatters: `gofmt` + `goimports`
+
+> 見送り: `gosec`（docker/tmux を exec するため G204 多発）と `paralleltest`（`t.Setenv` 例外と衝突）はノイズが大きいため今回は対象外。`err` の同一スコープ再代入禁止は対応リンターが無いため規約として残す。
+
+### 2. 既存違反の修正
+
+- `thelper`: ヘルパークロージャに `t.Helper()` を追加（nvim-sync 2, ai-bridge 4）。
+- `revive package-comments`: 6パッケージにパッケージコメントを追加（launchd/launcher/testutil/main/daemon/watcher）。
+
+### 3. CI
+
+CI は `working-directory` をモジュール配下に指定しているが、golangci-lint が上位のルート設定（`../../.golangci.yml`）を探索・適用することをサブディレクトリ実行で確認済みのため、ワークフローの変更は不要。
+
+## 検証結果
+
+| モジュール | golangci-lint | go vet | go test   |
+| ---------- | ------------- | ------ | --------- |
+| nvim-sync  | 0 issues      | ✅     | ✅ 全パス |
+| ai-bridge  | 0 issues      | ✅     | ✅ 全パス |
+
+## 備考
+
+golangci-lint はデフォルトで `max-same-issues=3` のため、初回実行では同種違反が3件しか表示されず見落としやすい。全件確認は `--max-same-issues=0 --max-issues-per-linter=0` を付ける。

--- a/scripts/ai-bridge/cmd/ai-bridge/main.go
+++ b/scripts/ai-bridge/cmd/ai-bridge/main.go
@@ -1,3 +1,4 @@
+// Command ai-bridge bridges AI agent requests to local terminal launches.
 package main
 
 import (

--- a/scripts/ai-bridge/internal/daemon/daemon.go
+++ b/scripts/ai-bridge/internal/daemon/daemon.go
@@ -1,3 +1,4 @@
+// Package daemon runs the ai-bridge background loop that watches for and handles requests.
 package daemon
 
 import (

--- a/scripts/ai-bridge/internal/daemon/daemon_test.go
+++ b/scripts/ai-bridge/internal/daemon/daemon_test.go
@@ -314,6 +314,7 @@ func TestRun(t *testing.T) {
 		{
 			name: "MkdirAll error returns error immediately",
 			setupBridgeDir: func(t *testing.T) string {
+				t.Helper()
 				blocker := filepath.Join(t.TempDir(), "blocker")
 				if writeErr := os.WriteFile(blocker, []byte("x"), 0o644); writeErr != nil {
 					t.Fatal(writeErr)

--- a/scripts/ai-bridge/internal/launchd/plist.go
+++ b/scripts/ai-bridge/internal/launchd/plist.go
@@ -1,3 +1,4 @@
+// Package launchd generates and installs the launchd plist that runs ai-bridge.
 package launchd
 
 import (

--- a/scripts/ai-bridge/internal/launchd/plist_test.go
+++ b/scripts/ai-bridge/internal/launchd/plist_test.go
@@ -96,12 +96,12 @@ func TestInstallTo(t *testing.T) {
 		{
 			name:        "success: writes plist and calls unload then load",
 			binaryPath:  "/path/to/ai-bridge",
-			setupDstDir: func(t *testing.T) string { return t.TempDir() },
+			setupDstDir: func(t *testing.T) string { t.Helper(); return t.TempDir() },
 		},
 		{
 			name:        "launchctl load error is returned",
 			binaryPath:  "/path/to/ai-bridge",
-			setupDstDir: func(t *testing.T) string { return t.TempDir() },
+			setupDstDir: func(t *testing.T) string { t.Helper(); return t.TempDir() },
 			ctlErrOnN:   2,
 			wantErr:     true,
 			wantErrMsg:  "launchctl load",
@@ -109,6 +109,7 @@ func TestInstallTo(t *testing.T) {
 		{
 			name: "MkdirAll error when dstDir is under a file",
 			setupDstDir: func(t *testing.T) string {
+				t.Helper()
 				blocker := filepath.Join(t.TempDir(), "blocker")
 				if writeErr := os.WriteFile(blocker, []byte("x"), 0o644); writeErr != nil {
 					t.Fatal(writeErr)
@@ -120,6 +121,7 @@ func TestInstallTo(t *testing.T) {
 		{
 			name: "WriteFile error on read-only directory",
 			setupDstDir: func(t *testing.T) string {
+				t.Helper()
 				dir := filepath.Join(t.TempDir(), "readonly")
 				if mkdirErr := os.MkdirAll(dir, 0o755); mkdirErr != nil {
 					t.Fatal(mkdirErr)

--- a/scripts/ai-bridge/internal/launcher/launcher.go
+++ b/scripts/ai-bridge/internal/launcher/launcher.go
@@ -1,3 +1,4 @@
+// Package launcher opens a new terminal tab and runs a script in it.
 package launcher
 
 import (

--- a/scripts/ai-bridge/internal/testutil/exec_stub.go
+++ b/scripts/ai-bridge/internal/testutil/exec_stub.go
@@ -1,3 +1,4 @@
+// Package testutil provides shared helpers for ai-bridge tests.
 package testutil
 
 import "sync"

--- a/scripts/ai-bridge/internal/watcher/watcher.go
+++ b/scripts/ai-bridge/internal/watcher/watcher.go
@@ -1,3 +1,4 @@
+// Package watcher watches the bridge directory for incoming request files.
 package watcher
 
 import (

--- a/scripts/nvim-sync/cmd/nvim-sync/main_test.go
+++ b/scripts/nvim-sync/cmd/nvim-sync/main_test.go
@@ -335,12 +335,12 @@ func TestRun(t *testing.T) {
 			name: "sync over empty dir succeeds without docker",
 			args: []string{"sync"},
 			// Empty dir => no .lua files => runSync makes no docker calls.
-			src: func(t *testing.T) string { return t.TempDir() },
+			src: func(t *testing.T) string { t.Helper(); return t.TempDir() },
 		},
 		{
 			name:    "sync with invalid src errors",
 			args:    []string{"sync"},
-			src:     func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") },
+			src:     func(t *testing.T) string { t.Helper(); return filepath.Join(t.TempDir(), "missing") },
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
## 実装経緯の説明

AI駆動開発では「ハーネス（検証ループ）」の質が成果を左右する。Go コードが集中する `scripts/`（`nvim-sync` / `ai-bridge` の2モジュール）は、これまで golangci-lint を **設定ファイルなし＝GitHub Action のデフォルト**でしか回しておらず、AIへのフィードバックが弱かった。

ここに明示的な `.golangci.yml` を導入し、バグ検出と AGENTS.md の規約担保を、`lint-changed.sh` Stop フックと CI の双方で効かせることで、AIが自分の出力を高い解像度で検証できる状態にする。

参考: [OpenAI「Harness Engineering」](https://openai.com/ja-JP/index/harness-engineering/) / [Anthropic「Steering Claude Code」](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more)

## 補足

### 主な変更内容

- `.golangci.yml` をリポジトリ直下に新規追加（v2 フォーマット）。標準セットを維持しつつ追加有効化:
  - バグ検出: `errorlint` `nilerr` `nilnil` `bodyclose` `contextcheck` `makezero` `wastedassign`
  - 規約・品質: `gocritic` `revive` `unconvert` `unparam` `misspell`
  - テスト品質: `tparallel` `thelper`
  - settings: `govet` の `shadow`、`errcheck.check-type-assertions`
  - `_test.go` では `errcheck`/`unparam`/`revive` を緩和、formatters に `gofmt`/`goimports` 登録
- 上記有効化で出た既存違反を全修正: ヘルパークロージャへの `t.Helper()` 追加（計6箇所）、6パッケージへのパッケージコメント追加。
- 実装方針と検証結果を `docs/plan/2026-06-29_golangci-lint-harness-scripts.md` に記録。

### 技術的な詳細

- 設定はリポジトリ直下に1ファイルのみ。golangci-lint は実行ディレクトリから上位を探索するため、両モジュール・CI（`working-directory` 指定）・Stop フックすべてがこの設定を参照する（DRY）。`scripts/ai-bridge` から実行すると `../../.golangci.yml` が解決されることを確認済みのため、**CI ワークフローの変更は不要**。
- `gosec`（docker/tmux を exec するため G204 多発）と `paralleltest`（`t.Setenv` 例外と衝突）はノイズが大きいため今回は見送り。`err` の同一スコープ再代入禁止は対応リンターが無いため規約として残す。

### 確認事項

- nvim-sync / ai-bridge とも `golangci-lint run` 0 issues、`go vet ./...`・`go test ./...` 全パス（当セッションで検証済み）。
- CI の `Lint nvim-sync` / `Lint ai-bridge` / 各 test ワークフローが緑になること。
- 今後リンターを追加する際、`max-same-issues` のデフォルト(3)で初回は同種違反が一部しか出ない点に注意（全件確認は `--max-same-issues=0 --max-issues-per-linter=0`）。