### PR TITLE
chore: prettier hook の対象に .mjs を追加

### DIFF
--- a/ai-agents/settings/claude/hooks/prettier.sh
+++ b/ai-agents/settings/claude/hooks/prettier.sh
@@ -9,7 +9,7 @@ print(data.get('tool_input', {}).get('file_path', ''))
 ")
 
 case "$FILE_PATH" in
-*.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
+*.html | *.css | *.js | *.mjs | *.ts | *.json | *.yaml | *.yml)
 	if ! prettier --write "$FILE_PATH" 2>&1; then
 		echo "[prettier] fail: $FILE_PATH" >&2
 		exit 1

--- a/ai-agents/settings/copilot/hooks/prettier.sh
+++ b/ai-agents/settings/copilot/hooks/prettier.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FILE_PATH=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/get_file_path.py")
 
 case "$FILE_PATH" in
-*.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
+*.html | *.css | *.js | *.mjs | *.ts | *.json | *.yaml | *.yml)
 	if ! prettier --write "$FILE_PATH" 2>&1; then
 		echo "[prettier] fail: $FILE_PATH" >&2
 		exit 1

--- a/ai-agents/settings/cursor/hooks/prettier.sh
+++ b/ai-agents/settings/cursor/hooks/prettier.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FILE_PATH=$(printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/get_file_path.py")
 
 case "$FILE_PATH" in
-*.html | *.css | *.js | *.ts | *.json | *.yaml | *.yml)
+*.html | *.css | *.js | *.mjs | *.ts | *.json | *.yaml | *.yml)
 	if ! prettier --write "$FILE_PATH" 2>&1; then
 		echo "[prettier] fail: $FILE_PATH" >&2
 		exit 1


### PR DESCRIPTION
## 実装経緯の説明

prettier hook (`ai-agents/settings/*/hooks/prettier.sh`) は編集されたファイルの拡張子を `case` 文で判定して prettier をかけているが、`.mjs` (ES module 形式の JS) が対象外でフォーマットが走っていなかった。`.js` と同様に `.mjs` も整形対象に含める。claude / cursor / copilot の 3 エージェント分すべてに同じ修正を適用した。

## 補足

### 主な変更内容

- `prettier.sh` の case パターンに `*.mjs` を追加
  - `ai-agents/settings/claude/hooks/prettier.sh`
  - `ai-agents/settings/cursor/hooks/prettier.sh`
  - `ai-agents/settings/copilot/hooks/prettier.sh`

### 技術的な詳細

- prettier は標準で `.mjs` をパース可能なため、追加の設定や parser 指定は不要
- 他の hook (goimports=`.go` / shfmt=`.sh` / stylua=`.lua` / tombi=`.toml` / markdown-format=`.md`) は `.js` 系拡張子を扱わないため変更不要

### 確認事項

- `.mjs` ファイルを編集した際に prettier が自動実行され整形されること
- 既存の対象拡張子 (`.js` / `.ts` / `.json` 等) の挙動が変わっていないこと

> shellcheck / shfmt クリーン、実在の `.mjs` ファイルで整形動作を確認済み。
