### PR TITLE
feat(ai-bridge): リクエスト履歴の永続化と history/replay サブコマンドを追加（新アーキ版）

### DIFF
--- a/scripts/ai-bridge/README.md
+++ b/scripts/ai-bridge/README.md
@@ -72,6 +72,21 @@ docker cp nvim/config/lua/ai_bridge.lua nvim-dev:/root/.config/nvim/lua/ai_bridg
 4. プロンプトを確認・編集する
 5. `<CR>`（Enter）で送信 → ホスト側のターミナルタブでAI CLIが起動する
 
+### 履歴と再送（history / replay）
+
+デーモンは正常に受理したリクエスト（プロンプト・cwd・タイムスタンプ）を `~/.ai-bridge/history.jsonl` に追記する。Neovim を開かずホスト側だけで過去のプロンプトを確認・再送できる。
+
+```bash
+# 直近の履歴を一覧（既定 20 件、-n で件数指定）
+./scripts/ai-bridge/ai-bridge history
+./scripts/ai-bridge/ai-bridge history -n 5
+
+# 直前のプロンプトを再送（request.json を書き出し、稼働中のデーモンが起動する）
+./scripts/ai-bridge/ai-bridge replay --last
+```
+
+`replay` は稼働中のデーモンが既存の watcher → launcher 経路で consume するため、デーモンが起動している必要がある。プロンプト全文が平文で `history.jsonl` に残る点に注意する（`~/.ai-bridge/` 配下に閉じる）。
+
 ### フローティングウィンドウのキーマップ
 
 | キー    | 動作                                               |

--- a/scripts/ai-bridge/cmd/ai-bridge/main.go
+++ b/scripts/ai-bridge/cmd/ai-bridge/main.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"ai-bridge/internal/domain"
 	"ai-bridge/internal/infra/config"
@@ -44,6 +46,10 @@ func main() {
 		err = runInstallLaunchd(cfg)
 	case "doctor":
 		runDoctor(cfg)
+	case "history":
+		err = runHistory(cfg)
+	case "replay":
+		err = runReplay(cfg)
 	default:
 		usage()
 		os.Exit(1)
@@ -61,6 +67,8 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  daemon            Start the ai-bridge daemon")
 	fmt.Fprintln(os.Stderr, "  install-launchd   Install and load the launchd agent")
 	fmt.Fprintln(os.Stderr, "  doctor            Diagnose the ai-bridge environment")
+	fmt.Fprintln(os.Stderr, "  history [-n N]    List recent requests (default 20)")
+	fmt.Fprintln(os.Stderr, "  replay [--last]   Re-send the most recent request")
 }
 
 func runDaemon(cfg *domain.Config) error {
@@ -70,7 +78,7 @@ func runDaemon(cfg *domain.Config) error {
 	}
 
 	dir := fsrepo.Dir{}
-	process := usecase.NewProcessRequest(fsrepo.RequestRepository{}, dir, fsrepo.ScriptStore{}, l, cfg.CLI)
+	process := usecase.NewProcessRequest(fsrepo.RequestRepository{}, dir, fsrepo.ScriptStore{}, l, fsrepo.HistoryRepository{}, cfg.BridgeDir, cfg.CLI)
 	daemon := usecase.NewRunDaemon(dir, watcher.New(cfg.BridgeDir), process, cfg)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
@@ -89,4 +97,31 @@ func runDoctor(cfg *domain.Config) {
 
 func runInstallLaunchd(cfg *domain.Config) error {
 	return usecase.NewInstallAgent(system.Executable{}, launchd.Installer{}, cfg).Run()
+}
+
+func runHistory(cfg *domain.Config) error {
+	fs := flag.NewFlagSet("history", flag.ContinueOnError)
+	n := fs.Int("n", 20, "number of recent entries to show")
+	if parseErr := fs.Parse(os.Args[2:]); parseErr != nil {
+		return parseErr
+	}
+
+	records, runErr := usecase.NewListHistory(fsrepo.HistoryRepository{}, cfg.BridgeDir).Run()
+	if runErr != nil {
+		return runErr
+	}
+	fmt.Print(domain.FormatHistory(records, *n))
+	return nil
+}
+
+func runReplay(cfg *domain.Config) error {
+	fs := flag.NewFlagSet("replay", flag.ContinueOnError)
+	// --last is accepted for explicitness; the most recent request is replayed.
+	_ = fs.Bool("last", false, "replay the most recent request")
+	if parseErr := fs.Parse(os.Args[2:]); parseErr != nil {
+		return parseErr
+	}
+
+	now := func() int64 { return time.Now().Unix() }
+	return usecase.NewReplayRequest(fsrepo.HistoryRepository{}, fsrepo.RequestWriter{}, cfg.BridgeDir, now).Run()
 }

--- a/scripts/ai-bridge/internal/domain/history.go
+++ b/scripts/ai-bridge/internal/domain/history.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FormatHistory renders records (already newest-first) as a human-readable,
+// indexed list. limit > 0 caps the number of rows shown; limit <= 0 shows all.
+// An empty result yields a single "(no history)" line.
+func FormatHistory(records []*Request, limit int) string {
+	if limit > 0 && limit < len(records) {
+		records = records[:limit]
+	}
+	if len(records) == 0 {
+		return "(no history)\n"
+	}
+	var b strings.Builder
+	for i, r := range records {
+		ts := time.Unix(r.Timestamp, 0).Format("2006-01-02 15:04:05")
+		fmt.Fprintf(&b, "%3d  %s  %s\n     %s\n", i, ts, r.CWD, firstLine(r.Prompt))
+	}
+	return b.String()
+}
+
+// firstLine returns the first line of s, truncated to keep list rows compact.
+func firstLine(s string) string {
+	const maxLen = 100
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = s[:idx]
+	}
+	if len(s) > maxLen {
+		return s[:maxLen] + "…"
+	}
+	return s
+}

--- a/scripts/ai-bridge/internal/domain/history_test.go
+++ b/scripts/ai-bridge/internal/domain/history_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatHistory(t *testing.T) {
+	t.Parallel()
+	records := []*Request{
+		{Prompt: "newest", CWD: "/c", Timestamp: 1700000000},
+		{Prompt: "middle\nsecond line", CWD: "/b", Timestamp: 1700000001},
+		{Prompt: strings.Repeat("x", 150), CWD: "/a", Timestamp: 1700000002},
+	}
+
+	tests := []struct {
+		name        string
+		records     []*Request
+		limit       int
+		wantRows    int      // number of "index" rows (records shown)
+		wantContain []string // substrings expected in output
+	}{
+		{
+			name:        "empty yields placeholder",
+			records:     nil,
+			limit:       20,
+			wantRows:    0,
+			wantContain: []string{"(no history)"},
+		},
+		{
+			name:        "limit caps rows",
+			records:     records,
+			limit:       2,
+			wantRows:    2,
+			wantContain: []string{"newest", "/c"},
+		},
+		{
+			name:        "non-positive limit shows all",
+			records:     records,
+			limit:       0,
+			wantRows:    3,
+			wantContain: []string{"newest", "middle", "/a"},
+		},
+		{
+			name:        "multiline prompt shows only first line",
+			records:     records[1:2],
+			limit:       20,
+			wantRows:    1,
+			wantContain: []string{"middle"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatHistory(tt.records, tt.limit)
+			if tt.wantRows == 0 {
+				if !strings.Contains(got, "(no history)") {
+					t.Errorf("empty output = %q, want placeholder", got)
+				}
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("output %q does not contain %q", got, want)
+				}
+			}
+			if strings.Contains(got, "second line") {
+				t.Errorf("output leaked second line of multiline prompt: %q", got)
+			}
+		})
+	}
+}

--- a/scripts/ai-bridge/internal/infra/fsrepo/fsrepo.go
+++ b/scripts/ai-bridge/internal/infra/fsrepo/fsrepo.go
@@ -3,11 +3,19 @@
 package fsrepo
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"ai-bridge/internal/domain"
+)
+
+// Canonical file names inside the bridge directory.
+const (
+	requestFileName = "request.json"
+	historyFileName = "history.jsonl"
 )
 
 // RequestRepository reads and removes request files. It implements the
@@ -39,6 +47,112 @@ func (RequestRepository) Load(path string) (*domain.Request, error) {
 // Remove deletes the consumed request file, ignoring errors.
 func (RequestRepository) Remove(path string) {
 	_ = os.Remove(path)
+}
+
+// toDTO projects a validated request onto its on-disk JSON shape.
+func toDTO(req *domain.Request) requestDTO {
+	return requestDTO{Prompt: req.Prompt, CWD: req.CWD, Timestamp: req.Timestamp}
+}
+
+// RequestWriter writes request.json atomically. It implements the
+// usecase.RequestWriter port.
+type RequestWriter struct{}
+
+// Save marshals req and writes it to <bridgeDir>/request.json via a temp file in
+// the same directory followed by a rename, so the daemon never observes a
+// partially written request.
+func (RequestWriter) Save(bridgeDir string, req *domain.Request) (retErr error) {
+	data, marshalErr := json.Marshal(toDTO(req))
+	if marshalErr != nil {
+		return fmt.Errorf("marshal request: %w", marshalErr)
+	}
+
+	tmp, createErr := os.CreateTemp(bridgeDir, ".request-*.tmp")
+	if createErr != nil {
+		return fmt.Errorf("create temp request: %w", createErr)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, writeErr := tmp.Write(data); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp request: %w", writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp request: %w", closeErr)
+	}
+	if renameErr := os.Rename(tmpName, filepath.Join(bridgeDir, requestFileName)); renameErr != nil {
+		return fmt.Errorf("rename temp request: %w", renameErr)
+	}
+	return nil
+}
+
+// HistoryRepository persists requests to an append-only JSONL file. It
+// implements the usecase.HistoryRepository port.
+type HistoryRepository struct{}
+
+// Append writes req as one JSON line to <bridgeDir>/history.jsonl, creating the
+// file if needed. A single O_APPEND write keeps concurrent lines from interleaving.
+func (HistoryRepository) Append(bridgeDir string, req *domain.Request) error {
+	f, openErr := os.OpenFile(filepath.Join(bridgeDir, historyFileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if openErr != nil {
+		return fmt.Errorf("open history: %w", openErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, marshalErr := json.Marshal(toDTO(req))
+	if marshalErr != nil {
+		return fmt.Errorf("marshal record: %w", marshalErr)
+	}
+	if _, writeErr := f.Write(append(data, '\n')); writeErr != nil {
+		return fmt.Errorf("write history: %w", writeErr)
+	}
+	return nil
+}
+
+// Load reads all history entries newest-first. A missing file yields an empty
+// slice and no error. Blank and corrupt (unparseable or invalid) lines are
+// skipped so one bad row cannot block the whole history.
+func (HistoryRepository) Load(bridgeDir string) ([]*domain.Request, error) {
+	f, openErr := os.Open(filepath.Join(bridgeDir, historyFileName))
+	if openErr != nil {
+		if os.IsNotExist(openErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open history: %w", openErr)
+	}
+	defer func() { _ = f.Close() }()
+
+	var records []*domain.Request
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var dto requestDTO
+		if unmarshalErr := json.Unmarshal(line, &dto); unmarshalErr != nil {
+			continue // skip corrupt line
+		}
+		req, newErr := domain.NewRequest(dto.Prompt, dto.CWD, dto.Timestamp)
+		if newErr != nil {
+			continue // skip invalid line
+		}
+		records = append(records, req)
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, fmt.Errorf("read history: %w", scanErr)
+	}
+
+	for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
+		records[i], records[j] = records[j], records[i]
+	}
+	return records, nil
 }
 
 // ScriptStore writes self-deleting launch scripts to temporary files. It

--- a/scripts/ai-bridge/internal/infra/fsrepo/fsrepo_test.go
+++ b/scripts/ai-bridge/internal/infra/fsrepo/fsrepo_test.go
@@ -1,6 +1,7 @@
 package fsrepo
 
 import (
+	"ai-bridge/internal/domain"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,6 +132,102 @@ func TestScriptStoreSave(t *testing.T) {
 				t.Error("script should be executable")
 			}
 		})
+	}
+}
+
+func TestHistoryRepositoryAppendAndLoad(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	records := []*domain.Request{
+		{Prompt: "first", CWD: "/a", Timestamp: 1},
+		{Prompt: "second", CWD: "/b", Timestamp: 2},
+		{Prompt: "third", CWD: "/c", Timestamp: 3},
+	}
+	for _, rec := range records {
+		if appendErr := (HistoryRepository{}).Append(dir, rec); appendErr != nil {
+			t.Fatalf("Append(%q): %v", rec.Prompt, appendErr)
+		}
+	}
+
+	got, loadErr := HistoryRepository{}.Load(dir)
+	if loadErr != nil {
+		t.Fatalf("Load: %v", loadErr)
+	}
+	if len(got) != len(records) {
+		t.Fatalf("got %d records, want %d", len(got), len(records))
+	}
+	if got[0].Prompt != "third" || got[2].Prompt != "first" {
+		t.Errorf("not newest-first: %q ... %q", got[0].Prompt, got[2].Prompt)
+	}
+}
+
+func TestHistoryRepositoryLoad(t *testing.T) {
+	t.Parallel()
+	valid := `{"prompt":"ok","cwd":"/x","timestamp":1}`
+	tests := []struct {
+		name    string
+		content string
+		write   bool
+		wantLen int
+	}{
+		{name: "missing file yields empty", write: false, wantLen: 0},
+		{name: "empty file yields empty", write: true, content: "", wantLen: 0},
+		{name: "blank lines skipped", write: true, content: "\n\n", wantLen: 0},
+		{
+			name:    "corrupt and invalid lines skipped",
+			write:   true,
+			content: valid + "\nnot json\n" + `{"cwd":"/y","timestamp":2}` + "\n" + `{"prompt":"ok2","cwd":"/z","timestamp":3}` + "\n",
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if tt.write {
+				if writeErr := os.WriteFile(filepath.Join(dir, historyFileName), []byte(tt.content), 0o600); writeErr != nil {
+					t.Fatalf("setup: %v", writeErr)
+				}
+			}
+			got, loadErr := HistoryRepository{}.Load(dir)
+			if loadErr != nil {
+				t.Fatalf("Load: %v", loadErr)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("got %d records, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestRequestWriterSave(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	req := &domain.Request{Prompt: "replay me", CWD: "/work", Timestamp: 42}
+
+	if saveErr := (RequestWriter{}).Save(dir, req); saveErr != nil {
+		t.Fatalf("Save: %v", saveErr)
+	}
+
+	// request.json is readable back through the request repository round-trip.
+	got, loadErr := RequestRepository{}.Load(filepath.Join(dir, requestFileName))
+	if loadErr != nil {
+		t.Fatalf("Load back: %v", loadErr)
+	}
+	if got.Prompt != req.Prompt || got.CWD != req.CWD || got.Timestamp != req.Timestamp {
+		t.Errorf("round-trip = %+v, want %+v", got, req)
+	}
+
+	// No temp residue is left behind.
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".request-") {
+			t.Errorf("temp residue left: %s", e.Name())
+		}
 	}
 }
 

--- a/scripts/ai-bridge/internal/usecase/list_history.go
+++ b/scripts/ai-bridge/internal/usecase/list_history.go
@@ -1,0 +1,22 @@
+package usecase
+
+import (
+	"ai-bridge/internal/domain"
+	"ai-bridge/internal/usecase/port"
+)
+
+// ListHistory reads the persisted request history newest-first for display.
+type ListHistory struct {
+	history   port.HistoryRepository
+	bridgeDir string
+}
+
+// NewListHistory wires the dependencies of the history-listing use case.
+func NewListHistory(history port.HistoryRepository, bridgeDir string) *ListHistory {
+	return &ListHistory{history: history, bridgeDir: bridgeDir}
+}
+
+// Run returns the history entries, newest first.
+func (uc *ListHistory) Run() ([]*domain.Request, error) {
+	return uc.history.Load(uc.bridgeDir)
+}

--- a/scripts/ai-bridge/internal/usecase/list_history_test.go
+++ b/scripts/ai-bridge/internal/usecase/list_history_test.go
@@ -1,0 +1,59 @@
+package usecase_test
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"ai-bridge/internal/domain"
+	"ai-bridge/internal/usecase"
+	"ai-bridge/internal/usecase/port/mock"
+)
+
+func TestListHistoryRun(t *testing.T) {
+	t.Parallel()
+	records := []*domain.Request{
+		{Prompt: "second", CWD: "/b", Timestamp: 2},
+		{Prompt: "first", CWD: "/a", Timestamp: 1},
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(history *mock.MockHistoryRepository)
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "passes through loaded records",
+			setup: func(history *mock.MockHistoryRepository) {
+				history.EXPECT().Load("/bridge").Return(records, nil)
+			},
+			wantLen: 2,
+		},
+		{
+			name: "load error is propagated",
+			setup: func(history *mock.MockHistoryRepository) {
+				history.EXPECT().Load("/bridge").Return(nil, errors.New("read failed"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			history := mock.NewMockHistoryRepository(ctrl)
+			tt.setup(history)
+
+			got, runErr := usecase.NewListHistory(history, "/bridge").Run()
+			if gotErr := runErr != nil; gotErr != tt.wantErr {
+				t.Fatalf("Run() error = %v, wantErr %v", runErr, tt.wantErr)
+			}
+			if !tt.wantErr && len(got) != tt.wantLen {
+				t.Errorf("got %d records, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}

--- a/scripts/ai-bridge/internal/usecase/port/mock/mock_port.go
+++ b/scripts/ai-bridge/internal/usecase/port/mock/mock_port.go
@@ -68,6 +68,97 @@ func (mr *MockRequestRepositoryMockRecorder) Remove(path any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockRequestRepository)(nil).Remove), path)
 }
 
+// MockRequestWriter is a mock of RequestWriter interface.
+type MockRequestWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockRequestWriterMockRecorder
+	isgomock struct{}
+}
+
+// MockRequestWriterMockRecorder is the mock recorder for MockRequestWriter.
+type MockRequestWriterMockRecorder struct {
+	mock *MockRequestWriter
+}
+
+// NewMockRequestWriter creates a new mock instance.
+func NewMockRequestWriter(ctrl *gomock.Controller) *MockRequestWriter {
+	mock := &MockRequestWriter{ctrl: ctrl}
+	mock.recorder = &MockRequestWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRequestWriter) EXPECT() *MockRequestWriterMockRecorder {
+	return m.recorder
+}
+
+// Save mocks base method.
+func (m *MockRequestWriter) Save(bridgeDir string, req *domain.Request) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Save", bridgeDir, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Save indicates an expected call of Save.
+func (mr *MockRequestWriterMockRecorder) Save(bridgeDir, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockRequestWriter)(nil).Save), bridgeDir, req)
+}
+
+// MockHistoryRepository is a mock of HistoryRepository interface.
+type MockHistoryRepository struct {
+	ctrl     *gomock.Controller
+	recorder *MockHistoryRepositoryMockRecorder
+	isgomock struct{}
+}
+
+// MockHistoryRepositoryMockRecorder is the mock recorder for MockHistoryRepository.
+type MockHistoryRepositoryMockRecorder struct {
+	mock *MockHistoryRepository
+}
+
+// NewMockHistoryRepository creates a new mock instance.
+func NewMockHistoryRepository(ctrl *gomock.Controller) *MockHistoryRepository {
+	mock := &MockHistoryRepository{ctrl: ctrl}
+	mock.recorder = &MockHistoryRepositoryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockHistoryRepository) EXPECT() *MockHistoryRepositoryMockRecorder {
+	return m.recorder
+}
+
+// Append mocks base method.
+func (m *MockHistoryRepository) Append(bridgeDir string, req *domain.Request) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Append", bridgeDir, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Append indicates an expected call of Append.
+func (mr *MockHistoryRepositoryMockRecorder) Append(bridgeDir, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockHistoryRepository)(nil).Append), bridgeDir, req)
+}
+
+// Load mocks base method.
+func (m *MockHistoryRepository) Load(bridgeDir string) ([]*domain.Request, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Load", bridgeDir)
+	ret0, _ := ret[0].([]*domain.Request)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Load indicates an expected call of Load.
+func (mr *MockHistoryRepositoryMockRecorder) Load(bridgeDir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockHistoryRepository)(nil).Load), bridgeDir)
+}
+
 // MockScriptStore is a mock of ScriptStore interface.
 type MockScriptStore struct {
 	ctrl     *gomock.Controller

--- a/scripts/ai-bridge/internal/usecase/port/port.go
+++ b/scripts/ai-bridge/internal/usecase/port/port.go
@@ -25,6 +25,21 @@ type RequestRepository interface {
 	Remove(path string)
 }
 
+// RequestWriter writes a request back into the bridge directory so the running
+// daemon consumes it through its existing watcher/launcher path (used by replay).
+type RequestWriter interface {
+	// Save atomically writes req as request.json inside bridgeDir.
+	Save(bridgeDir string, req *domain.Request) error
+}
+
+// HistoryRepository persists and reads the append-only request history.
+type HistoryRepository interface {
+	// Append records req as a new entry in the history under bridgeDir.
+	Append(bridgeDir string, req *domain.Request) error
+	// Load reads all history entries under bridgeDir, newest first.
+	Load(bridgeDir string) ([]*domain.Request, error)
+}
+
 // ScriptStore persists a generated launch script to a runnable location.
 type ScriptStore interface {
 	// Save creates the script file, then calls build with the final path to

--- a/scripts/ai-bridge/internal/usecase/process_request.go
+++ b/scripts/ai-bridge/internal/usecase/process_request.go
@@ -14,16 +14,18 @@ import (
 // ProcessRequest handles a single consumed request file end to end: load and
 // validate it, generate a launch script, and launch it in a terminal.
 type ProcessRequest struct {
-	requests port.RequestRepository
-	dirs     port.DirVerifier
-	scripts  port.ScriptStore
-	launcher port.Launcher
-	cli      string
+	requests  port.RequestRepository
+	dirs      port.DirVerifier
+	scripts   port.ScriptStore
+	launcher  port.Launcher
+	history   port.HistoryRepository
+	bridgeDir string
+	cli       string
 }
 
 // NewProcessRequest wires the dependencies of the request-processing use case.
-func NewProcessRequest(requests port.RequestRepository, dirs port.DirVerifier, scripts port.ScriptStore, launcher port.Launcher, cli string) *ProcessRequest {
-	return &ProcessRequest{requests: requests, dirs: dirs, scripts: scripts, launcher: launcher, cli: cli}
+func NewProcessRequest(requests port.RequestRepository, dirs port.DirVerifier, scripts port.ScriptStore, launcher port.Launcher, history port.HistoryRepository, bridgeDir, cli string) *ProcessRequest {
+	return &ProcessRequest{requests: requests, dirs: dirs, scripts: scripts, launcher: launcher, history: history, bridgeDir: bridgeDir, cli: cli}
 }
 
 // Handle processes the request at consumedPath. The consumed file is always
@@ -33,6 +35,12 @@ func (uc *ProcessRequest) Handle(consumedPath string) error {
 	uc.requests.Remove(consumedPath)
 	if loadErr != nil {
 		return fmt.Errorf("invalid request: %w", loadErr)
+	}
+
+	// Persist the request before launching. History is a secondary concern, so a
+	// failure here must not block the launch: log and continue.
+	if appendErr := uc.history.Append(uc.bridgeDir, req); appendErr != nil {
+		slog.Warn("history append failed", "error", appendErr)
 	}
 
 	if !uc.dirs.IsDir(req.CWD) {

--- a/scripts/ai-bridge/internal/usecase/process_request_test.go
+++ b/scripts/ai-bridge/internal/usecase/process_request_test.go
@@ -19,15 +19,16 @@ func TestProcessRequestHandle(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		setup   func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher)
+		setup   func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository)
 		wantErr bool
 	}{
 		{
-			name: "valid request builds script and launches",
-			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher) {
+			name: "valid request appends history, builds script and launches",
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository) {
 				t.Helper()
 				reqs.EXPECT().Load(consumed).Return(validReq, nil)
 				reqs.EXPECT().Remove(consumed)
+				history.EXPECT().Append("/bridge", validReq).Return(nil)
 				dirs.EXPECT().IsDir("/work").Return(true)
 				scripts.EXPECT().Save(gomock.Any()).DoAndReturn(func(build func(string) string) (string, error) {
 					content := build("/tmp/ai-bridge-x.sh")
@@ -40,8 +41,20 @@ func TestProcessRequestHandle(t *testing.T) {
 			},
 		},
 		{
+			name: "history append failure does not block launch",
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository) {
+				t.Helper()
+				reqs.EXPECT().Load(consumed).Return(validReq, nil)
+				reqs.EXPECT().Remove(consumed)
+				history.EXPECT().Append("/bridge", validReq).Return(errors.New("disk full"))
+				dirs.EXPECT().IsDir("/work").Return(true)
+				scripts.EXPECT().Save(gomock.Any()).Return("/tmp/s.sh", nil)
+				launcher.EXPECT().Launch("/work", "/tmp/s.sh").Return(nil)
+			},
+		},
+		{
 			name: "load error removes file and returns error",
-			setup: func(t *testing.T, reqs *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher, _ *mock.MockHistoryRepository) {
 				t.Helper()
 				reqs.EXPECT().Load(consumed).Return(nil, errors.New("bad json"))
 				reqs.EXPECT().Remove(consumed)
@@ -50,20 +63,22 @@ func TestProcessRequestHandle(t *testing.T) {
 		},
 		{
 			name: "invalid cwd returns error before script generation",
-			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher, history *mock.MockHistoryRepository) {
 				t.Helper()
 				reqs.EXPECT().Load(consumed).Return(validReq, nil)
 				reqs.EXPECT().Remove(consumed)
+				history.EXPECT().Append("/bridge", validReq).Return(nil)
 				dirs.EXPECT().IsDir("/work").Return(false)
 			},
 			wantErr: true,
 		},
 		{
 			name: "save error returns error before launch",
-			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, _ *mock.MockLauncher, history *mock.MockHistoryRepository) {
 				t.Helper()
 				reqs.EXPECT().Load(consumed).Return(validReq, nil)
 				reqs.EXPECT().Remove(consumed)
+				history.EXPECT().Append("/bridge", validReq).Return(nil)
 				dirs.EXPECT().IsDir("/work").Return(true)
 				scripts.EXPECT().Save(gomock.Any()).Return("", errors.New("disk full"))
 			},
@@ -71,10 +86,11 @@ func TestProcessRequestHandle(t *testing.T) {
 		},
 		{
 			name: "launch error removes script and returns error",
-			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher) {
+			setup: func(t *testing.T, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository) {
 				t.Helper()
 				reqs.EXPECT().Load(consumed).Return(validReq, nil)
 				reqs.EXPECT().Remove(consumed)
+				history.EXPECT().Append("/bridge", validReq).Return(nil)
 				dirs.EXPECT().IsDir("/work").Return(true)
 				scripts.EXPECT().Save(gomock.Any()).Return("/tmp/s.sh", nil)
 				launcher.EXPECT().Launch("/work", "/tmp/s.sh").Return(errors.New("no terminal"))
@@ -92,9 +108,10 @@ func TestProcessRequestHandle(t *testing.T) {
 			dirs := mock.NewMockDirVerifier(ctrl)
 			scripts := mock.NewMockScriptStore(ctrl)
 			launcher := mock.NewMockLauncher(ctrl)
-			tt.setup(t, reqs, dirs, scripts, launcher)
+			history := mock.NewMockHistoryRepository(ctrl)
+			tt.setup(t, reqs, dirs, scripts, launcher, history)
 
-			uc := usecase.NewProcessRequest(reqs, dirs, scripts, launcher, "claude")
+			uc := usecase.NewProcessRequest(reqs, dirs, scripts, launcher, history, "/bridge", "claude")
 			err := uc.Handle(consumed)
 
 			if gotErr := err != nil; gotErr != tt.wantErr {

--- a/scripts/ai-bridge/internal/usecase/replay_request.go
+++ b/scripts/ai-bridge/internal/usecase/replay_request.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"fmt"
+
+	"ai-bridge/internal/domain"
+	"ai-bridge/internal/usecase/port"
+)
+
+// ReplayRequest re-injects the most recent history entry as a new request so the
+// running daemon picks it up through its existing watcher/launcher path.
+type ReplayRequest struct {
+	history   port.HistoryRepository
+	writer    port.RequestWriter
+	bridgeDir string
+	now       func() int64
+}
+
+// NewReplayRequest wires the dependencies of the replay use case. now supplies
+// the replay timestamp (injected for deterministic tests).
+func NewReplayRequest(history port.HistoryRepository, writer port.RequestWriter, bridgeDir string, now func() int64) *ReplayRequest {
+	return &ReplayRequest{history: history, writer: writer, bridgeDir: bridgeDir, now: now}
+}
+
+// Run loads the history, selects the most recent entry, stamps it with the
+// replay time and writes it back as request.json. It errors when there is
+// nothing to replay.
+func (uc *ReplayRequest) Run() error {
+	records, loadErr := uc.history.Load(uc.bridgeDir)
+	if loadErr != nil {
+		return fmt.Errorf("load history: %w", loadErr)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("no history to replay")
+	}
+
+	latest := records[0]
+	replayed, newErr := domain.NewRequest(latest.Prompt, latest.CWD, uc.now())
+	if newErr != nil {
+		return fmt.Errorf("build replay request: %w", newErr)
+	}
+	if saveErr := uc.writer.Save(uc.bridgeDir, replayed); saveErr != nil {
+		return fmt.Errorf("write request: %w", saveErr)
+	}
+	return nil
+}

--- a/scripts/ai-bridge/internal/usecase/replay_request_test.go
+++ b/scripts/ai-bridge/internal/usecase/replay_request_test.go
@@ -1,0 +1,75 @@
+package usecase_test
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"ai-bridge/internal/domain"
+	"ai-bridge/internal/usecase"
+	"ai-bridge/internal/usecase/port/mock"
+)
+
+func TestReplayRequestRun(t *testing.T) {
+	t.Parallel()
+	const replayTime int64 = 999
+	// History is newest-first; the most recent entry is replayed with a fresh timestamp.
+	loaded := []*domain.Request{
+		{Prompt: "latest", CWD: "/work", Timestamp: 5},
+		{Prompt: "older", CWD: "/old", Timestamp: 1},
+	}
+	wantSaved := &domain.Request{Prompt: "latest", CWD: "/work", Timestamp: replayTime}
+
+	tests := []struct {
+		name    string
+		setup   func(history *mock.MockHistoryRepository, writer *mock.MockRequestWriter)
+		wantErr bool
+	}{
+		{
+			name: "replays newest entry with refreshed timestamp",
+			setup: func(history *mock.MockHistoryRepository, writer *mock.MockRequestWriter) {
+				history.EXPECT().Load("/bridge").Return(loaded, nil)
+				writer.EXPECT().Save("/bridge", wantSaved).Return(nil)
+			},
+		},
+		{
+			name: "empty history returns error and never writes",
+			setup: func(history *mock.MockHistoryRepository, _ *mock.MockRequestWriter) {
+				history.EXPECT().Load("/bridge").Return(nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "load error is propagated",
+			setup: func(history *mock.MockHistoryRepository, _ *mock.MockRequestWriter) {
+				history.EXPECT().Load("/bridge").Return(nil, errors.New("read failed"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "write error is propagated",
+			setup: func(history *mock.MockHistoryRepository, writer *mock.MockRequestWriter) {
+				history.EXPECT().Load("/bridge").Return(loaded, nil)
+				writer.EXPECT().Save("/bridge", wantSaved).Return(errors.New("disk full"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			history := mock.NewMockHistoryRepository(ctrl)
+			writer := mock.NewMockRequestWriter(ctrl)
+			tt.setup(history, writer)
+
+			now := func() int64 { return replayTime }
+			runErr := usecase.NewReplayRequest(history, writer, "/bridge", now).Run()
+			if gotErr := runErr != nil; gotErr != tt.wantErr {
+				t.Fatalf("Run() error = %v, wantErr %v", runErr, tt.wantErr)
+			}
+		})
+	}
+}

--- a/scripts/ai-bridge/internal/usecase/run_daemon_test.go
+++ b/scripts/ai-bridge/internal/usecase/run_daemon_test.go
@@ -19,19 +19,19 @@ func TestRunDaemonRun(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		setup   func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher)
+		setup   func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository)
 		wantErr bool
 	}{
 		{
 			name: "ensure error returns immediately",
-			setup: func(ensurer *mock.MockBridgeDirEnsurer, _ *mock.MockWatcher, _ *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(ensurer *mock.MockBridgeDirEnsurer, _ *mock.MockWatcher, _ *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher, _ *mock.MockHistoryRepository) {
 				ensurer.EXPECT().Ensure("/bridge").Return(errors.New("permission denied"))
 			},
 			wantErr: true,
 		},
 		{
 			name: "watch error returns error",
-			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, _ *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, _ *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher, _ *mock.MockHistoryRepository) {
 				ensurer.EXPECT().Ensure("/bridge").Return(nil)
 				watcher.EXPECT().Watch(gomock.Any()).Return(nil, errors.New("fsnotify failed"))
 			},
@@ -39,7 +39,7 @@ func TestRunDaemonRun(t *testing.T) {
 		},
 		{
 			name: "consumed request is dispatched then channel closes",
-			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher) {
+			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, dirs *mock.MockDirVerifier, scripts *mock.MockScriptStore, launcher *mock.MockLauncher, history *mock.MockHistoryRepository) {
 				ensurer.EXPECT().Ensure("/bridge").Return(nil)
 				ch := make(chan string, 1)
 				ch <- "/bridge/request.json.consumed"
@@ -48,6 +48,7 @@ func TestRunDaemonRun(t *testing.T) {
 				watcher.EXPECT().Watch(gomock.Any()).Return(recv, nil)
 				reqs.EXPECT().Load("/bridge/request.json.consumed").Return(validReq, nil)
 				reqs.EXPECT().Remove("/bridge/request.json.consumed")
+				history.EXPECT().Append("/bridge", validReq).Return(nil)
 				dirs.EXPECT().IsDir("/work").Return(true)
 				scripts.EXPECT().Save(gomock.Any()).Return("/tmp/s.sh", nil)
 				launcher.EXPECT().Launch("/work", "/tmp/s.sh").Return(nil)
@@ -55,7 +56,7 @@ func TestRunDaemonRun(t *testing.T) {
 		},
 		{
 			name: "failing request is logged but loop continues to close",
-			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher) {
+			setup: func(ensurer *mock.MockBridgeDirEnsurer, watcher *mock.MockWatcher, reqs *mock.MockRequestRepository, _ *mock.MockDirVerifier, _ *mock.MockScriptStore, _ *mock.MockLauncher, _ *mock.MockHistoryRepository) {
 				ensurer.EXPECT().Ensure("/bridge").Return(nil)
 				ch := make(chan string, 1)
 				ch <- "/bridge/request.json.consumed"
@@ -78,9 +79,10 @@ func TestRunDaemonRun(t *testing.T) {
 			dirs := mock.NewMockDirVerifier(ctrl)
 			scripts := mock.NewMockScriptStore(ctrl)
 			launcher := mock.NewMockLauncher(ctrl)
-			tt.setup(ensurer, watcher, reqs, dirs, scripts, launcher)
+			history := mock.NewMockHistoryRepository(ctrl)
+			tt.setup(ensurer, watcher, reqs, dirs, scripts, launcher, history)
 
-			process := usecase.NewProcessRequest(reqs, dirs, scripts, launcher, cfg.CLI)
+			process := usecase.NewProcessRequest(reqs, dirs, scripts, launcher, history, cfg.BridgeDir, cfg.CLI)
 			uc := usecase.NewRunDaemon(ensurer, watcher, process, cfg)
 			err := uc.Run(context.Background())
 


### PR DESCRIPTION
Closes #456

## 何を

ai-bridge にリクエスト履歴の永続化と再送を追加し、過去のプロンプトを Neovim を経由せずホスト側から確認・再投入できるようにする。

ai-bridge は DDD/クリーンアーキへリファクタ済みのため、旧アーキ向けだった #460 はクローズし、本PRで現行アーキ（`domain` / `usecase`(+`port`) / `infra/*`）向けに作り直した。

### レイヤ別の変更

- **domain** `internal/domain/history.go`: `FormatHistory`（一覧整形。`FormatChecks` と同様の純粋関数）。
- **port** `internal/usecase/port/port.go`: `HistoryRepository`（Append/Load）と `RequestWriter`（Save）を追加。`make generate` でモック再生成。
- **usecase**:
  - `process_request.go`: parse 成功後に `history.Append`（**append のみ**追加。失敗は warn ログのみで起動を妨げない。起動経路は不変）。
  - `list_history.go` / `replay_request.go`: 新規ユースケース。replay の timestamp は注入した `now` で更新（テスト決定性）。
- **infra** `internal/infra/fsrepo/fsrepo.go`: `HistoryRepository`（O_APPEND 追記・newest-first・空/壊れた行スキップ・欠損ファイルは空）と `RequestWriter`（temp+rename で `request.json` を原子的に書き出し）。既存の非公開 `requestDTO` を再利用。
- **cmd** `cmd/ai-bridge/main.go`: `history`（`-n N`、既定 20）/ `replay`（`--last`）サブコマンドと `usage()`。
- **README**: 履歴と再送の使い方・プライバシー注記。

最小スコープ（issue 記載どおり）: ① daemon 側 `Append` ② `history` 一覧 ③ `replay --last`。`--index N`・件数ローテーション・prompt 全文表示は後続。

## なぜ

現状の ai-bridge は送ったプロンプトを consume 後に破棄しており、再送も監査もできない。履歴を残し `replay` で既存経路へ再投入することで、Neovim/Docker の往復を 1 コマンドに短縮し記録欠落を解消する。

## 設計上のポイント

- 再送は **request.json を書き出すだけ**。稼働中デーモンが既存の watcher → launcher 経路でそのまま consume するため、再送ロジックを二重実装しない。
- `RequestWriter.Save` は temp+rename で原子的に書き出し、daemon が部分書き込みを観測しない。
- `HistoryRepository.Append` は単一 `O_APPEND` 書き込みで行の混在を防止。

## 検証

- `make generate` でモック再生成済み。
- `goimports -w .` / `go build ./...` / `go vet ./...` → パス。
- `golangci-lint run ./...` → **0 issues**。
- `go test ./...` → パス（Append↔Load ラウンドトリップ・newest-first・空/欠損/壊れた行スキップ、`RequestWriter.Save` の round-trip と temp 残骸なし、`FormatHistory`、各ユースケースをモックで検証。table-driven + `t.Parallel()` / `t.TempDir()`）。
- README: `prettier --check` / `markdownlint-cli2` → パス。

## プライバシー留意

プロンプト全文が平文で `~/.ai-bridge/history.jsonl` に残る点を README に明記。件数上限ローテーションは後続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)