### PR TITLE
chore: リポジトリ固有の Claude 制御層を整理・強化

### DIFF
--- a/.claude/hooks/guard-version-pins.sh
+++ b/.claude/hooks/guard-version-pins.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# PreToolUse(Edit|Write|MultiEdit) guard.
+# ピン留めされたツールバージョンの手動編集をブロックする。
+# 更新は update-go-tools.sh / bump-tool-versions.yml 経由で行う想定。
+set -eu
+
+INPUT=$(cat)
+
+HOOK_INPUT="$INPUT" python3 <<'PY'
+import os, json, re
+
+try:
+    data = json.loads(os.environ.get("HOOK_INPUT", "") or "{}")
+except json.JSONDecodeError:
+    raise SystemExit(0)
+
+ti = data.get("tool_input", {}) or {}
+file_path = (ti.get("file_path") or "").replace("\\", "/")
+if not file_path:
+    raise SystemExit(0)
+
+DOCKERFILE_SUFFIX = "environment/docker/nvim.dockerfile"
+PIN_MANIFESTS = (
+    "environment/tools/go/go-tools.txt",
+    "environment/tools/node/package.json",
+)
+
+ARG_PIN = re.compile(r"^\s*ARG\s+[A-Z0-9_]+(?:VERSION|TOOLCHAIN)\s*=", re.MULTILINE)
+
+
+def edited_text(ti):
+    parts = []
+    for key in ("old_string", "new_string", "content"):
+        val = ti.get(key)
+        if isinstance(val, str):
+            parts.append(val)
+    for edit in ti.get("edits", []) or []:
+        for key in ("old_string", "new_string"):
+            val = edit.get(key)
+            if isinstance(val, str):
+                parts.append(val)
+    return "\n".join(parts)
+
+
+blocked = ""
+if file_path.endswith(DOCKERFILE_SUFFIX):
+    if ARG_PIN.search(edited_text(ti)):
+        blocked = "nvim.dockerfile の ARG ピン留めバージョン行"
+elif any(file_path.endswith(m) for m in PIN_MANIFESTS):
+    blocked = "%s（ツールバージョンのピン留めマニフェスト）" % os.path.basename(file_path)
+
+if blocked:
+    import sys
+
+    sys.stderr.write(
+        "[guard-version-pins] ブロック: %s を手動編集しようとしています。\n"
+        "ピン留めされたツールバージョンは手動で変更しないでください。更新は次のいずれか経由で行ってください:\n"
+        "  - environment/tools/go/update-go-tools.sh （Go ツール）\n"
+        "  - .github/workflows/bump-tool-versions.yml （Node/Go/Neovim/Rust/npm の週次自動更新）\n"
+        % blocked
+    )
+    raise SystemExit(2)
+
+raise SystemExit(0)
+PY

--- a/.claude/rules/agent-authoring.md
+++ b/.claude/rules/agent-authoring.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "ai-agents/agents/**"
+---
+
+# Subagent authoring rules
+
+- Required frontmatter: `name`, `description`, `tools`. The `description` MUST state the agent's phase/role
+  and the trigger condition ("Use this when…", "Use after…") so the orchestrator routes to it correctly.
+- Optional frontmatter as needed: `model`, `permissionMode` (e.g. `plan`), `memory` (e.g. `project`),
+  `maxTurns`, `color`. Keep `tools` minimal — grant only what the role needs (read-only reviewers: `Read, Grep, Glob`).
+- Body opens with "You are …" defining the role, then the procedure. Keep it focused; move long reference
+  material out of the prompt.
+- These are the reusable definitions deployed to Claude/Cursor via `make agents-copy`. Mirror the two-phase
+  Scanner→Critic / Scout→Diver split already established here when adding pipeline agents.

--- a/.claude/rules/dockerfile-versions.md
+++ b/.claude/rules/dockerfile-versions.md
@@ -7,5 +7,5 @@ paths:
 # Dockerfile / toolchain version rules
 
 - Keep `ARG` lines in `environment/docker/nvim.dockerfile` unindented and single-line; CI automation (`bump-tool-versions.yml`) edits them by pattern.
-- Do NOT manually bump pinned tool versions. Update via the version-bump workflows or `environment/tools/go/update-go-tools.sh`.
+- Do NOT manually bump pinned tool versions. Update via the version-bump workflows or `environment/tools/go/update-go-tools.sh`. This is enforced deterministically by the `guard-version-pins.sh` PreToolUse hook (`.claude/settings.json`), which blocks edits to `ARG *_VERSION=`/`*_TOOLCHAIN=` lines and to the pin manifests `environment/tools/go/go-tools.txt` and `environment/tools/node/package.json`.
 - Rebuild the image after changing tool versions or `environment/tools/node/package.json`.

--- a/.claude/rules/go-ai-bridge.md
+++ b/.claude/rules/go-ai-bridge.md
@@ -5,6 +5,9 @@ paths:
 
 # ai-bridge (Go) rules
 
-- Detailed conventions live in `scripts/ai-bridge/AGENTS.md` (table-driven tests, unique error-variable names, package scope). Follow them.
+Detailed conventions (table-driven tests, unique error-variable names, package scope, DDD layering,
+mock generation) load automatically from `scripts/ai-bridge/CLAUDE.md` → `@AGENTS.md` when you touch
+these files. Claude-specific workflow additions:
+
 - Bug fixes are test-first: add a failing test that reproduces the issue before changing code.
 - Verify with `make ai-bridge-test`, `go vet ./...`, and `golangci-lint run`; format with `goimports`.

--- a/.claude/rules/plan-docs.md
+++ b/.claude/rules/plan-docs.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "docs/plan/**"
+---
+
+# Plan document rules
+
+- Filename: `YYYY-MM-DD_slug.md` (date the plan is written, kebab-case slug).
+- Title line: `# Plan: <短いタイトル>`.
+- Use this section skeleton (omit sections only when truly N/A):
+  `## Background` → `## Current structure` → `## Design policy` → `## Implementation steps`
+  → `## File changes` → `## Risks and mitigations` → `## Validation` → `## Open questions`.
+- `## Background` states the problem/need and intended outcome; `## File changes` names concrete paths.
+- Plans are design records, not running logs. Keep them scannable; long rationale goes in prose, not nested lists.

--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "**/*.tf"
+---
+
+# Terraform rules
+
+- Format with `terraform fmt`; lint with `tflint`.
+- Definition jump/completion is provided by `terraform-ls`.
+- The AWS ruleset (`tflint-ruleset-aws`) is NOT bundled in this repo. Install it per Terraform project via
+  a project-local `.tflint.hcl` + `tflint --init`, not globally here.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-version-pins.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/deploy-ai-config/SKILL.md
+++ b/.claude/skills/deploy-ai-config/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: deploy-ai-config
+description: ai-agents/ と dotfiles/ の編集内容を各 AI CLI（~/.claude, ~/.cursor, ~/.codex, ~/.copilot）と ~/.config へ反映するデプロイ手順。「設定を反映」「デプロイ」「~/.claude に配って」「スキル/エージェント/設定を更新したから配布」等を求められたときに使用する。
+metadata:
+  version: 1
+---
+
+# Deploy AI config
+
+このリポジトリ（my-pde）が AI CLI 設定とドットファイルの source of truth。`ai-agents/` や `dotfiles/`
+を編集したら、このスキルで配布物を各ツールへ反映する。全 make ターゲットはリポジトリルートから実行する
+（ルート Makefile が `ai-agents/Makefile` へ委譲している）。
+
+## 何をどのターゲットで配るか
+
+| 編集した場所                                         | 反映ターゲット                                         | 配布先                                       |
+| ---------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `ai-agents/agents.xml`                               | `make claude-link`（Cursor/Codex/Copilot は `*-link`） | `~/.claude/CLAUDE.md`（symlink）             |
+| `ai-agents/skills/**`                                | `make skills-copy`                                     | 各 CLI の `skills/`（全 CLI 一括）           |
+| `ai-agents/agents/**`                                | `make agents-copy`                                     | 各 CLI の `agents/`（Claude/Cursor/Copilot） |
+| `ai-agents/settings/**`（hooks/rules/settings.json） | `make settings-copy`                                   | 各 CLI のルート（Claude/Cursor/Copilot）     |
+| `dotfiles/wezterm/**`                                | `make dotfiles-link`                                   | `~/.config/wezterm`（symlink）               |
+
+`*-copy` は実体コピー（編集ごとに再実行が必要）。`*-link` / `dotfiles-link` は symlink（一度貼れば追従）。
+
+## 手順
+
+1. `git status` で何を編集したかを確認し、上表から必要なターゲットだけ選ぶ。
+2. ドライランで配布先を確認: `make -n skills-copy` 等（特に初回や配布先を確認したいとき）。
+3. 実行: 該当ターゲットを `make <target>` で実行。複数同時なら `make skills-copy agents-copy settings-copy`。
+4. Claude 設定（hooks/rules/settings.json）を変えた場合は、反映を効かせるため Claude Code セッションの
+   再読み込みが必要（`/memory` でルール、`/hooks` 相当でフック状態を確認）。
+
+## 検証
+
+- `*-copy` 後: 配布先（例 `ls ~/.claude/skills`, `ls ~/.claude/hooks`）に最新が入ったか確認。
+- `*-link` 後: `ls -l ~/.claude/CLAUDE.md` / `ls -l ~/.config/wezterm` が本リポジトリを指す symlink か確認。
+- hooks を変えたら、対象ファイルを 1 つ編集して PostToolUse フォーマッタ／Stop linter が想定通り動くか確認。
+
+## 注意
+
+- このリポジトリ直下の `.claude/`（rules・settings.json・guard hook）は **このリポジトリ専用** で、
+  デプロイ対象ではない。配布されるのは `ai-agents/` と `dotfiles/` 配下のみ。
+- バージョンピン（`environment/**`）はこのスキルの対象外。`guard-version-pins.sh` で保護されている。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Neovim runs inside a Docker container; AI agent configs and dotfiles live on the
 - `make skills-copy` — copy skills to all CLIs.
 - `make agents-copy` — copy agent definitions to Claude/Cursor.
 - `make settings-copy` — copy settings and hooks to Claude/Cursor.
+- Claude Code: the `deploy-ai-config` skill wraps this flow (which target for which edit, plus verification).
 
 ### Dotfiles
 
@@ -50,16 +51,15 @@ Neovim runs inside a Docker container; AI agent configs and dotfiles live on the
 ## Coding Style
 
 - Per-language lint/format conventions load on demand from path-scoped rules in `.claude/rules/` (and personal rules in `~/.claude/rules/`) when you touch matching files.
-- Dockerfile/toolchain version constraints live in `.claude/rules/dockerfile-versions.md`; tool versions are pinned and updated via workflows or scripts, not manual edits.
-- For sub-directory conventions, see each directory's `AGENTS.md`.
+- Dockerfile/toolchain version constraints live in `.claude/rules/dockerfile-versions.md`; tool versions are pinned and updated via workflows or scripts, not manual edits. For Claude this is enforced by the `guard-version-pins.sh` PreToolUse hook.
+- For sub-directory conventions, see each directory's `AGENTS.md`. (`scripts/ai-bridge/` also has a `CLAUDE.md` importing its `AGENTS.md` so the Go conventions auto-load for Claude.)
 
 ## Testing & Linting
 
-- Per-language lint/format commands load on demand as path-scoped rules (`.claude/rules/`, `~/.claude/rules/`): Go, Lua, Markdown, TOML, JSON/YAML, Shell.
-- Not covered by rules: Dockerfile (`hadolint environment/docker/nvim.dockerfile`), Terraform (`tflint`, `terraform fmt`).
+- Per-language lint/format commands load on demand as path-scoped rules (`.claude/rules/`, `~/.claude/rules/`): Go, Lua, Markdown, TOML, JSON/YAML, Shell, Terraform.
+- Not covered by rules: Dockerfile lint (`hadolint environment/docker/nvim.dockerfile`).
 - AI Bridge has Go unit tests: `make ai-bridge-test`.
 - No repository-level test suite beyond per-directory checks.
-- Terraform definition jump/completion is provided by `terraform-ls`. `tflint`'s AWS ruleset (`tflint-ruleset-aws`) is not bundled here; install it per Terraform project via `.tflint.hcl` + `tflint --init`.
 
 ## Commit & PR Guidelines
 

--- a/docs/plan/2026-07-01_repo-claude-steering-refinement.md
+++ b/docs/plan/2026-07-01_repo-claude-steering-refinement.md
@@ -1,0 +1,86 @@
+# Plan: my-pde リポジトリ固有の Claude 制御層の効率化
+
+## Background
+
+このリポジトリで Claude を動かすときの効率を上げたい。狙いは **このリポジトリ専用の制御層**
+（リポジトリ直下の `AGENTS.md` と `.claude/`）であり、他リポジトリへ配布する再利用層
+（`ai-agents/` → `~/.claude` へデプロイ）ではない。Anthropic のブログ
+[Steering Claude Code](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more)
+の指針（CLAUDE.md は薄く / 手続きは skill / 決定的強制は hook / path-scoped rule で文脈限定）に照らして、
+溜まった残骸を掃除し、指針に沿った穴を埋める。
+
+## Current structure
+
+- **再利用層（対象外）**: `ai-agents/` → `~/.claude/settings.json` 等へデプロイ。clean な allow/deny、
+  PostToolUse フォーマッタ、Stop linter、グローバル rule、サブエージェント、スキル。
+- **このリポジトリ層（対象）**:
+  - `AGENTS.md`（`.claude/CLAUDE.md` は `@AGENTS.md` の 1 行参照＝単一ソース、73 行）
+  - `.claude/rules/`（path-scoped rule、tracked）
+  - `.claude/settings.local.json`（個人用 allowlist、untracked、デバッグ残骸・重複・古いパスが堆積）
+  - `.claude/skills/skill-creator/`（untracked のはぐれコピー）
+
+ブログの指針に照らすと本リポジトリは既に良い形（CLAUDE.md が薄い / rule が path-scoped / 手続きは skill /
+隔離は subagent / 決定的処理は hook）。よって再設計は不要で、掃除＋的を絞った穴埋めが本題。
+
+## Design policy
+
+- 既存の良い構造は壊さない。クロスツール共有ソース（`AGENTS.md`）と Claude 専用制御（`.claude/`）の
+  役割分担を保つ。
+- ブログのアンチパターン「never do X をプロンプトで書く」→ 決定的な PreToolUse hook へ。
+- 未 rule 化の頻出領域は path-scoped rule で穴埋め（普段はトークンゼロ、触れた時だけロード）。
+- 冗長・重複・古い設定は削り、context と permission の無駄を減らす。
+
+## Implementation steps
+
+1. **クリーンアップ**: `.claude/settings.local.json` からデバッグ残骸・古いパス（`my_dotfiles_nvim`）・
+   グローバル allowlist と重複するエントリを削除（60+ → 25）。はぐれ `.claude/skills/skill-creator/` を削除。
+2. **決定的フック**: `.claude/hooks/guard-version-pins.sh` を新設し、`.claude/settings.json`（tracked、
+   PreToolUse のみ、グローバルとマージ）で登録。Dockerfile の `ARG *_VERSION=`/`*_TOOLCHAIN=` 行、および
+   ピンマニフェスト `environment/tools/go/go-tools.txt`・`environment/tools/node/package.json` の手動編集を
+   exit 2 でブロックし、更新経路（`update-go-tools.sh` / `bump-tool-versions.yml`）を案内する。
+3. **未カバー rule 追加**: `plan-docs.md`（`docs/plan/**`）、`agent-authoring.md`（`ai-agents/agents/**`）、
+   `terraform.md`（`**/*.tf`）を既存ファイルから規約抽出して新設。
+4. **デプロイのスキル化**: `.claude/skills/deploy-ai-config/SKILL.md` を新設し、`make claude-link` /
+   `skills-copy` / `agents-copy` / `settings-copy` / `dotfiles-link` の「どの編集にどのターゲットか」＋検証を手続き化。
+5. **ai-bridge 詳細規約の確実ロード**: Claude Code は `AGENTS.md` を自動ロードしない（読むのは `CLAUDE.md`
+   のみ）。`scripts/ai-bridge/CLAUDE.md`（中身は `@AGENTS.md`）を新設し、配下に触れると nested CLAUDE.md 経由で
+   詳細規約が決定的にロードされるようにする。`AGENTS.md` はクロスツール共有ソースのまま維持。
+   `.claude/rules/go-ai-bridge.md` はポインタを外し Claude 固有の追記だけにスリム化。
+
+## File changes
+
+| 種別 | パス                                       | 内容                                                                  |
+| ---- | ------------------------------------------ | --------------------------------------------------------------------- |
+| 変更 | `.claude/settings.local.json`              | 残骸/重複/古いパス削除（untracked、コミット対象外）                   |
+| 削除 | `.claude/skills/skill-creator/`            | はぐれコピー除去                                                      |
+| 変更 | `AGENTS.md`                                | Coding/Testing 節をポインタ化、hook/skill/nested CLAUDE.md を相互参照 |
+| 新規 | `.claude/settings.json`                    | PreToolUse hook 登録（tracked、追加マージ）                           |
+| 新規 | `.claude/hooks/guard-version-pins.sh`      | 版数ピン編集ブロック hook                                             |
+| 変更 | `.claude/rules/dockerfile-versions.md`     | hook 強制の旨を相互参照                                               |
+| 新規 | `.claude/rules/plan-docs.md`               | `docs/plan/**` 規約                                                   |
+| 新規 | `.claude/rules/agent-authoring.md`         | `ai-agents/agents/**` 規約                                            |
+| 新規 | `.claude/rules/terraform.md`               | `**/*.tf` 規約                                                        |
+| 新規 | `.claude/skills/deploy-ai-config/SKILL.md` | デプロイ手続きスキル                                                  |
+| 新規 | `scripts/ai-bridge/CLAUDE.md`              | `@AGENTS.md` import（詳細規約を決定的ロード）                         |
+| 変更 | `.claude/rules/go-ai-bridge.md`            | ポインタ削除し Claude 固有の追記だけにスリム化                        |
+
+## Risks and mitigations
+
+- **guard hook の過剰ブロック**: バージョン行に触れない Dockerfile 編集や `update-go-tools.sh`・
+  `pyproject.toml` 等は通す設計。7 ケースの手動テストで確認済み。
+- **重複 permission 削除でプロンプト増**: グローバル `~/.claude/settings.json` がデプロイ済みの前提。
+  重複分はグローバルが引き続き許可するため増えない。
+- **nested CLAUDE.md の初回 import 承認ダイアログ**: ルートの `@AGENTS.md` import と同じ挙動、想定内。
+
+## Validation
+
+- guard hook: 7 シナリオ（ARG 版数変更 / 非版数編集 / go-tools.txt / 無関係ファイル / update-go-tools.sh /
+  MultiEdit / package.json）で期待 exit を確認。`shellcheck`・`shfmt` クリーン。
+- `.claude/settings.json` / `.claude/settings.local.json` を `jq` で JSON 検証。
+- 追加 md をリポジトリルートから `markdownlint-cli2` でチェック（0 エラー）。
+- `make -n skills-copy` / `make -n claude-link` でデプロイターゲットのドライラン確認。
+- `deploy-ai-config` がスキル一覧に登録されることを確認。
+
+## Open questions
+
+- なし（プラン承認済み・実装済み。本ドキュメントは設計記録）。

--- a/scripts/ai-bridge/CLAUDE.md
+++ b/scripts/ai-bridge/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## 実装経緯の説明

このリポジトリ（my-pde）で Claude を動かす際の効率を上げるため、**リポジトリ専用の制御層**（`AGENTS.md` と `.claude/`）を Anthropic のブログ [Steering Claude Code](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more) の指針に沿って整理・強化した。他リポジトリへ配布する再利用層（`ai-agents/` → `~/.claude`）は対象外。

ブログに照らすと本リポジトリは既に良い形（CLAUDE.md が薄い / rule が path-scoped / 手続きは skill / 隔離は subagent / 決定的処理は hook）だったため、再設計ではなく **掃除＋的を絞った穴埋め** に絞った。

## 補足

### 主な変更内容

- **クリーンアップ**: `.claude/settings.local.json`（untracked・コミット対象外）のデバッグ残骸・古いパス（`my_dotfiles_nvim`）・グローバル allowlist と重複するエントリを削減（60+ → 25）。はぐれ `.claude/skills/skill-creator/` を削除。
- **決定的フック**（ブログ「never do X → hook」）: `.claude/hooks/guard-version-pins.sh` を新設し `.claude/settings.json`（PreToolUse のみ・グローバルとマージ）で登録。Dockerfile の `ARG *_VERSION=`/`*_TOOLCHAIN=` 行、およびピンマニフェスト `go-tools.txt`・`node/package.json` の手動編集を exit 2 でブロックし、更新経路を案内。
- **未カバー rule 追加**: `plan-docs.md`（`docs/plan/**`）/ `agent-authoring.md`（`ai-agents/agents/**`）/ `terraform.md`（`**/*.tf`）を path-scoped で新設。
- **デプロイのスキル化**: `deploy-ai-config` スキルで `make claude-link`/`skills-copy`/`agents-copy`/`settings-copy`/`dotfiles-link` の手順と検証を集約。
- **ai-bridge 詳細規約の確実ロード**: Claude Code は `AGENTS.md` を自動ロードしない（読むのは `CLAUDE.md` のみ）ため、`scripts/ai-bridge/CLAUDE.md`（`@AGENTS.md`）を新設して nested CLAUDE.md 経由で決定的にロード。`go-ai-bridge.md` はポインタを外しスリム化。
- 本 PR のプラン記録を `docs/plan/2026-07-01_repo-claude-steering-refinement.md` に追加。

### 技術的な詳細

- `.claude/settings.json` は PreToolUse のみを持ち、グローバル `~/.claude/settings.json`（PostToolUse/Stop hook）とマージされる追加定義。
- guard hook は `tool_input` を解析し、版数行に触れない Dockerfile 編集や `update-go-tools.sh`・`pyproject.toml` 等は通す（過剰ブロック回避）。

### 確認事項

- [ ] `guard-version-pins.sh` の動作（7 ケースでテスト済み。ARG 版数変更/非版数編集/go-tools.txt/無関係/update-go-tools.sh/MultiEdit/package.json）
- [ ] `.claude/settings.json` の PreToolUse がグローバル設定と競合せずマージされること
- [ ] 新規 path-scoped rule が対象ファイルに触れた時だけロードされること
- [ ] `deploy-ai-config` スキルがスキル一覧に出ること