### PR TITLE
feat(nvim): treesitter foldexpr で構造的なコードフォールドを有効化する

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -28,6 +28,7 @@ vim.opt.conceallevel = 0 -- Show double quotations in json file and so on.
 vim.g.mapleader = " " -- Set a space key to a leader.
 vim.opt.mouse = "" -- Don't use a mouse.
 vim.opt.signcolumn = "yes" -- Always show signcolumn to prevent rattling.
+vim.opt.foldlevelstart = 99 -- Open files fully expanded; folds (treesitter foldexpr) are closed manually when needed.
 vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
 
 -- ----------------------------------------

--- a/nvim/config/lua/nvim_treesitter.lua
+++ b/nvim/config/lua/nvim_treesitter.lua
@@ -17,9 +17,9 @@ vim.api.nvim_create_autocmd("FileType", {
 	callback = function()
 		-- highlight
 		vim.treesitter.start()
-		-- folds
-		-- vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
-		-- vim.wo.foldmethod = "expr"
+		-- folds（treesitter の構文木ベースで関数/ブロック単位に折りたたむ）
+		vim.wo.foldmethod = "expr"
+		vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
 		-- indent
 		-- vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
 	end,


### PR DESCRIPTION
Closes #462

## 何を

- `nvim/config/lua/nvim_treesitter.lua` の FileType autocmd でコメントアウトされていたフォールド設定を有効化:
  - `vim.wo.foldmethod = "expr"`
  - `vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"`
- `nvim/config/init.lua` に `vim.opt.foldlevelstart = 99` を追加。

## なぜ

これまでフォールドが未設定（`foldmethod=manual`）で、関数/構造体/ブロック単位で畳んで俯瞰する基本機能が使えていなかった。既に parser を install 済みの go/python/markdown/terraform/hcl に対し、コア標準の `vim.treesitter.foldexpr()` を使って構文木ベースで折りたためるようにする。新規プラグイン・新規キーマップは不要（開閉は `za`/`zo`/`zc`/`zR`/`zM` のコア標準）。`foldlevelstart=99` によりファイルを開いた直後は全展開のままにして「勝手に畳まれる」体験を避ける。

## 検証

- 変更は既存の parser 起動対象 filetype に限定され、ウィンドウローカルオプションのみを設定するため他挙動に影響しない。
- ローカル環境に `stylua` が無いため stylua 実行は未。既存インデント（タブ）とスタイルに合わせて記述済み。CI の `lint_stylua` で確認される。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_