### PR TITLE
feat(nvim): TextYankPost でヤンク範囲をハイライトする

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -65,6 +65,23 @@ elseif vim.fn.has("clipboard") == 1 then
 end
 
 -- ----------------------------------------
+-- Highlight yanked text (ヤンク範囲を一瞬フラッシュして視覚フィードバックする)
+-- ----------------------------------------
+local hl_yank_group = vim.api.nvim_create_augroup("highlight_yank", { clear = true })
+vim.api.nvim_create_autocmd("TextYankPost", {
+	group = hl_yank_group,
+	callback = function()
+		-- 0.12 では vim.hl.on_yank が現行 API。将来 (0.13+) は hl_op へ移行し
+		-- on_yank が deprecated 化するため、存在すれば hl_op を優先する。
+		if vim.hl and vim.hl.hl_op then
+			vim.hl.hl_op({ higroup = "IncSearch", timeout = 200 })
+		else
+			vim.hl.on_yank({ higroup = "IncSearch", timeout = 200 })
+		end
+	end,
+})
+
+-- ----------------------------------------
 -- Remember a history of undo/redo.
 -- ----------------------------------------
 if vim.fn.has("persistent_undo") == 1 then


### PR DESCRIPTION
Closes #475

## 何を

`nvim/config/init.lua` のクリップボード設定ブロック直後に、ヤンク範囲をハイライトする `TextYankPost` autocmd を追加する。

```lua
local hl_yank_group = vim.api.nvim_create_augroup("highlight_yank", { clear = true })
vim.api.nvim_create_autocmd("TextYankPost", {
	group = hl_yank_group,
	callback = function()
		if vim.hl and vim.hl.hl_op then
			vim.hl.hl_op({ higroup = "IncSearch", timeout = 200 })
		else
			vim.hl.on_yank({ higroup = "IncSearch", timeout = 200 })
		end
	end,
})
```

## なぜ

`mouse=""`（マウス無効）でキーボード操作前提の本設定では、ヤンク時にどの範囲がコピーされたかを視覚的に確認できる意味が大きい。コア標準の `vim.hl.on_yank()` のみで実現でき新規プラグインは不要。0.13+ で `hl_op` へ移行し `on_yank` が deprecated 化するため、存在すれば `hl_op` を優先するフォールバック形にして 0.12 でも nightly でも警告なく動く。既存の OSC52 コピー autocmd とは別グループ・別責務で共存する。

## 検証

- 新規 autocmd 1 個の追加のみで、既存の OSC52 グループ（`clear=true` は新設グループにのみ効く）や既存キーマップに影響しない。
- ローカルに `stylua` が無いため未実行。既存スタイル（タブインデント）に合わせて記述。CI の `lint_stylua` で確認される。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_