### PR TITLE
feat(nvim): treesitter ハイライト対象に lua/yaml/json/bash/dockerfile/gitcommit を追加する

### DIFF
--- a/nvim/config/lua/nvim_treesitter.lua
+++ b/nvim/config/lua/nvim_treesitter.lua
@@ -10,10 +10,38 @@ ts.setup({
 -- nvim-treesitter 新 main では `incremental_selection` モジュールが廃止されているため、
 -- ここでプラグイン側のキー (gnn / grn / grm / grc 等) を再現する設定は入れない。
 
-ts.install({ "go", "python", "markdown", "markdown_inline", "terraform", "hcl" })
+ts.install({
+	"go",
+	"python",
+	"markdown",
+	"markdown_inline",
+	"terraform",
+	"hcl",
+	"lua",
+	"yaml",
+	"json",
+	"bash",
+	"dockerfile",
+	"gitcommit",
+})
 
 vim.api.nvim_create_autocmd("FileType", {
-	pattern = { "go", "python", "markdown", "markdown_inline", "terraform", "hcl" },
+	-- 注意: bash スクリプトの filetype は "sh"。parser 名 "bash" とは異なるため
+	-- pattern には filetype 名の "sh" を書く (コアが sh->bash のマッピングを持つ)。
+	pattern = {
+		"go",
+		"python",
+		"markdown",
+		"markdown_inline",
+		"terraform",
+		"hcl",
+		"lua",
+		"yaml",
+		"json",
+		"sh",
+		"dockerfile",
+		"gitcommit",
+	},
 	callback = function()
 		-- highlight
 		vim.treesitter.start()


### PR DESCRIPTION
Closes #476

## 何を

`nvim/config/lua/nvim_treesitter.lua` の 2 箇所に対象 filetype を追記:

- `ts.install({...})` に `lua` / `yaml` / `json` / `bash` / `dockerfile` / `gitcommit` を追加。
- FileType autocmd の `pattern` に `lua` / `yaml` / `json` / `sh` / `dockerfile` / `gitcommit` を追加。

## なぜ

これまで treesitter ハイライトは go/python/markdown/terraform/hcl の 6 系統に限定されていたが、このリポジトリが最も頻繁に編集するのは Lua 設定・CI の YAML・JSON・シェル・Dockerfile であり、それらが構文木ベースのハイライトを得られていなかった。「コアが提供する機能を素直に使う」方針に沿って対象 filetype を広げるだけの変更で、新規プラグイン・新規キーマップは不要。

## 留意点

- **filetype と parser 名の食い違い**: bash スクリプトの filetype は `sh`（parser 名は `bash`）。`FileType` autocmd の `pattern` は filetype 名で書く必要があるため `sh` を指定し、install リストには parser 名 `bash` を書いている。コメントでも明記した。
- `yaml`/`json`/`bash`/`dockerfile`/`gitcommit` はコア同梱でないため install が必須、`lua` は同梱だが明示リストに入れて見通しを良くする（害はない）。

## 検証

- ハイライト対象 filetype を増やすのみで既存挙動に影響しない。
- ローカルに `stylua` が無いため未実行。既存スタイル（タブインデント）に合わせて記述。CI の `lint_stylua` で確認される。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_