### PR TITLE
feat(nvim): 手動フォーマット &lt;space&gt;f を conform 経由に統一する

### DIFF
--- a/nvim/config/lua/conform_nvim.lua
+++ b/nvim/config/lua/conform_nvim.lua
@@ -17,3 +17,9 @@ require("conform").setup({
 		yaml = { "prettierd", "prettier", stop_after_first = true },
 	},
 })
+
+-- 手動フォーマット。保存時 (format_on_save) と同じ conform のチェーンを通す。
+-- conform にフォーマッタが無い filetype では lsp_format = "fallback" で LSP 整形に委譲する。
+vim.keymap.set({ "n", "v" }, "<space>f", function()
+	require("conform").format({ async = true, lsp_format = "fallback" })
+end, { desc = "Format buffer or range (conform)" })

--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -88,9 +88,9 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		vim.keymap.set("n", "<space>wl", function()
 			print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
 		end, opts)
-		vim.keymap.set("n", "<space>f", function()
-			vim.lsp.buf.format({ async = true })
-		end, opts)
+		-- 手動フォーマット (<space>f) は conform 側 (conform_nvim.lua) に一本化した。
+		-- 保存時 (format_on_save) と同じチェーンを通し、conform 未定義の filetype は
+		-- lsp_format = "fallback" で LSP 整形へ委譲する。
 
 		-- Code lens を全 LSP で常時有効化する。
 		-- vim.lsp.codelens.enable は内部で BufEnter/InsertLeave 等の refresh まで面倒を見るので、


### PR DESCRIPTION
Closes #466

## 何を

- `nvim/config/lua/conform_nvim.lua` に手動フォーマットのキーマップを追加:
  ```lua
  vim.keymap.set({ "n", "v" }, "<space>f", function()
  	require("conform").format({ async = true, lsp_format = "fallback" })
  end, { desc = "Format buffer or range (conform)" })
  ```
- `nvim/config/lua/lsp/init.lua` の `LspAttach` 内にあった `<space>f` → `vim.lsp.buf.format` 直叩きのキーマップを削除。

## なぜ

保存時（`format_on_save`）は conform のチェーン（goimports / ruff 3 段 / prettier など）が走る一方、手動フォーマットの `<space>f` は `vim.lsp.buf.format` を直叩きしており、Go の import 整理や Python の `ruff_organize_imports`、prettier 設定の反映などが手動時に効かず、保存時と結果が食い違っていた。conform 公式 recipe に従い手動フォーマットを `require("conform").format` に割り当て、`lsp_format = "fallback"` で conform 未定義 filetype は従来どおり LSP 整形に委譲することで、既存挙動を失わずに保存時と手動時を一本化する。

## Issue との差分（キー名）

Issue 本文は対象キーを `f` と記載しているが、実コードの手動フォーマットキーは `<space>f`（`lsp/init.lua` の `LspAttach` 内）。実コードに合わせて `<space>f` を対象とし、ビジュアル選択時の範囲フォーマットに対応するため normal/visual 両モードにバインドした。

## 検証

- `<space>f` は変更せず経路のみ差し替え。conform は `event = { "BufRead", "BufNewFile" }` で遅延ロード済みのため `require("conform")` は解決される。
- ローカルに `stylua` が無いため未実行。既存スタイルに合わせて記述。CI の `lint_stylua` で確認される。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_