### PR TITLE
feat(nvim): lazydev.nvim + lua_ls を導入し Lua 設定編集に LSP を効かせる

### DIFF
--- a/nvim/config/lua/blink_cmp.lua
+++ b/nvim/config/lua/blink_cmp.lua
@@ -34,7 +34,15 @@ require("blink.cmp").setup({
 	-- Default list of enabled providers defined so that you can extend it
 	-- elsewhere in your config, without redefining it, due to `opts_extend`
 	sources = {
-		default = { "lsp", "path", "snippets", "buffer" },
+		default = { "lazydev", "lsp", "path", "snippets", "buffer" },
+		providers = {
+			-- Neovim 設定 (Lua) 編集時に vim API 等を上位に出すため lazydev を高スコアで足す。
+			lazydev = {
+				name = "LazyDev",
+				module = "lazydev.integrations.blink",
+				score_offset = 100,
+			},
+		},
 	},
 
 	-- (Default) Rust fuzzy matcher for typo resistance and significantly better performance

--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -65,6 +65,9 @@ vim.lsp.enable("yamlls")
 vim.lsp.enable("tombi")
 -- vim.lsp.enable("lemminx")
 
+-- Lua (Neovim 設定自身の編集用。型/補完/診断は lazydev.nvim が lua_ls に供給する)
+vim.lsp.enable("lua_ls")
+
 -- Global mappings.
 -- See `:help vim.diagnostic.*` for documentation on any of the below functions
 vim.keymap.set("n", "<space>e", vim.diagnostic.open_float)

--- a/nvim/config/lua/plugins.lua
+++ b/nvim/config/lua/plugins.lua
@@ -51,6 +51,16 @@ return {
 		"neovim/nvim-lspconfig",
 		lazy = false,
 	},
+	{ -- Neovim 設定 (Lua) 編集用に lua_ls を構成する
+		"folke/lazydev.nvim",
+		ft = "lua",
+		opts = {
+			library = {
+				-- vim.uv.* を使うとき luv の型を読み込む (lazy_nvim.lua で vim.uv を使用済み)
+				{ path = "${3rd}/luv/library", words = { "vim%.uv" } },
+			},
+		},
+	},
 	{ -- Formatt runner
 		"stevearc/conform.nvim",
 		lazy = true,


### PR DESCRIPTION
Closes #470

## 何を

`nvim/config` 配下の Lua 編集に補完・型・診断（`lua_ls`）を効かせる。3 ファイルに最小追記:

1. `nvim/config/lua/plugins.lua` — `folke/lazydev.nvim` を `ft = "lua"` で遅延ロード追加。`vim.uv` 用に luv の型ライブラリを供給。
2. `nvim/config/lua/lsp/init.lua` — 既存の `vim.lsp.enable(...)` 群に `vim.lsp.enable("lua_ls")` を追加。
3. `nvim/config/lua/blink_cmp.lua` — `sources.default` 先頭に `lazydev` を追加し、`providers.lazydev`（`module = "lazydev.integrations.blink"`, `score_offset = 100`）を定義。

## なぜ

設定は `nvim/config/` 配下が丸ごと Lua なのに、唯一 `lua_ls` が未設定で、Lua だけ `vim.api.*` / `vim.opt.*` の補完・ホバー・定義ジャンプ・診断が効いていなかった（stylua による整形のみ）。lazydev.nvim は「Neovim 設定そのものを編集するとき」に特化して `lua_ls` を構成し、`require` を見て必要なときだけ型ライブラリを動的ロードする軽量な後継（neodev は非推奨）。既に採用済みの blink.cmp 用ソースも公式提供されるため既存補完に溶け込む。

## リスク / 留意点

- `lua_ls` 本体は PATH 必須（Go/Python 等の既存サーバと同じ前提）。未インストールでも他言語・既存挙動には影響しない。
- lazydev は `ft = "lua"` 遅延ロードのため Lua 以外の編集にオーバーヘッドなし。`providers.lazydev` は Lua 以外の filetype では候補を返さないので補完順にも影響しない。

## 検証

- ローカルに `stylua` が無いため未実行。既存スタイル（タブインデント）に合わせて記述。CI の `lint_stylua` で確認される。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_