### PR TITLE
feat(claude-hook): 破壊的 Bash コマンドを PreToolUse でブロックするガードを追加する

### DIFF
--- a/ai-agents/settings/claude/hooks/guard-dangerous-bash.sh
+++ b/ai-agents/settings/claude/hooks/guard-dangerous-bash.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# PreToolUse(Bash) guard: 取り返しのつかない破壊的コマンドを実行前にブロックする。
+# exit 2 + stderr で Claude はツール呼び出しを中断し、理由をモデルに返す。
+# 悪意ある回避の完全防御ではなく「うっかり事故の防止」を目的とした多層防御の 1 枚。
+set -u
+
+INPUT=$(cat)
+
+CMD=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print('')
+    sys.exit(0)
+print(data.get('tool_input', {}).get('command', ''))
+")
+
+[ -n "$CMD" ] || exit 0
+
+block() {
+	echo "[guard-dangerous-bash] blocked: $1" >&2
+	echo "危険な操作を検出したためブロックしました。意図的な場合はユーザーに確認するか、手動で実行してください。" >&2
+	exit 2
+}
+
+# 改行を空白へ、連続空白を 1 つに正規化してからパターン照合する。
+norm=$(printf '%s' "$CMD" | tr '\n' ' ' | tr -s ' ')
+
+case "$norm" in
+*"rm -rf /"* | *"rm -rf ~"*)
+	block "rm -rf on a dangerous path"
+	;;
+*"git reset --hard"*)
+	block "git reset --hard (discards uncommitted work)"
+	;;
+*"git clean -"*d*f* | *"git clean -"*f*d*)
+	block "git clean -fd (deletes untracked files)"
+	;;
+*"git push"*"--force"* | *"git push"*" -f"*)
+	block "git push --force"
+	;;
+*"--no-verify"*)
+	block "--no-verify (bypasses pre-commit/secret guards)"
+	;;
+*"git checkout ."* | *"git restore ."*)
+	block "mass discard of working-tree changes"
+	;;
+*":(){ :|:& };:"*)
+	block "fork bomb"
+	;;
+esac
+
+exit 0

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -59,6 +59,17 @@
     "SKILL_OBSERVE_HOME": "~/workspace/my-pde"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/guard-dangerous-bash.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",


### PR DESCRIPTION
Closes #474

## 何を

Claude の `Bash` ツール呼び出しに対する PreToolUse ガードフックを追加する。

- **フック本体**: `ai-agents/settings/claude/hooks/guard-dangerous-bash.sh` — stdin の JSON から `tool_input.command` を取り出し、正規化して破壊的パターンに照合。ヒットで `exit 2` + stderr により Claude がツール呼び出しを中断し理由を受け取る。
- **配線**: `ai-agents/settings/claude/settings.json` の `hooks.PreToolUse` に `matcher: "Bash"` で追加。

ブロック対象（初版・保守的セット）: `rm -rf /` / `rm -rf ~`、`git reset --hard`、`git clean -fd`、`git push --force` / `-f`、`--no-verify`、`git checkout .` / `git restore .`、fork bomb。

## なぜ

既存の破壊防御は `permissions.deny` の粗いプレフィックス glob（`rm -rf *` 等）のみで、`git reset --hard` / `push --force` / `git clean -fdx` / `--no-verify` 等の「一度実行したら戻せない」操作を全くカバーしていない。フックの `exit 2` は `--dangerously-skip-permissions` 下でも効くため、`routine-*` / スケジュールエージェントの自律実行の安全弁として適切。`credential-leak-prevention`（コミット時のシークレット防止）とは層が異なり、`--no-verify` 迂回を止める点でむしろ相互強化。

## 配布・スコープ

- `copy-entries.sh` の `settings` モードは `find "$src" -type f` で総当りコピーするため、新規 hook と settings.json は `make settings-copy` で自動配布される（**Makefile 変更不要**）。
- 本フックは **claude スコープに限定**。既存の Stop 系フック（`lint-changed` / `notify-macos`）も claude のみで、cursor/copilot はブロックの contract が異なる（cursor: `beforeShellExecution`、copilot: `hooks.json`）。まず claude で導入し、横展開は別 issue とする（Issue 本文 (d) の方針どおり）。

## 検証（ローカル実行済み）

- `jq -e . settings.json` → JSON パース OK
- `shfmt -d guard-dangerous-bash.sh` → 差分なし
- `shellcheck guard-dangerous-bash.sh` → 警告なし
- 機能テスト: `git reset --hard` / `rm -rf /tmp/foo` / `git push --force` / `--no-verify` / `git clean -fd` は exit 2 でブロック、`git status` / `ls` / `echo` / 空コマンドは exit 0 で通過を確認。

## 留意点

- 単純な文字列照合のため `eval` / 変数展開 / base64 経由等は抜けられる（うっかり事故防止が主目的の多層防御の 1 枚）。
- `rm -rf /...`（絶対パス）と `--no-verify` は保守的に全ブロック。運用で過剰と判明した場合はパターンを緩める余地あり。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_