### PR TITLE
feat(scripts): scripts 配下の Go モジュールを CI 同等でローカル検証する go-verify を追加する

### DIFF
--- a/scripts/go-verify/README.md
+++ b/scripts/go-verify/README.md
@@ -1,0 +1,51 @@
+# go-verify
+
+`scripts/` 配下の Go モジュールを自動探索し、各モジュールに対して CI と同一手順の検証を
+ローカルで一括実行する shift-left な品質ゲート。`fail` があれば非ゼロ終了する。
+
+## 何を検証するか
+
+`go.mod` を持つディレクトリごとに、CI と同じ順・同じ設定で次を実行する。
+
+1. **goimports** — `goimports -l .` の出力（整形差分のあるファイル一覧）が空でなければ fail。
+2. **golangci-lint** — `golangci-lint run ./...`（リポジトリ root の `.golangci.yml` を使用）。
+3. **go test** — `go test ./... -count=1`。
+
+## 使い方
+
+```sh
+# scripts/ 配下の全 Go モジュールを全チェック
+go run ./cmd/go-verify -root ..
+
+# lint だけ / test だけに絞る
+go run ./cmd/go-verify -root .. -only lint
+go run ./cmd/go-verify -root .. -only test
+
+# パスに "ai-bridge" を含むモジュールだけ
+go run ./cmd/go-verify -root .. -mod ai-bridge
+```
+
+### フラグ
+
+| フラグ  | 既定 | 説明                                                                    |
+| ------- | ---- | ----------------------------------------------------------------------- |
+| `-root` | `.`  | Go モジュールを探索するルートディレクトリ                               |
+| `-only` | 空   | 実行するチェックを絞る（`lint` = goimports+golangci、`test` = go test） |
+| `-mod`  | 空   | パスに指定文字列を含むモジュールだけを対象にする                        |
+
+## 終了コード
+
+- `0` — 全チェック pass
+- `1` — いずれかのチェックが fail
+- `2` — 使用方法・探索エラー（不正な `-only` 値、モジュールが見つからない等）
+
+## 設計
+
+- 外部依存ゼロ（標準ライブラリのみ）。
+- 外部コマンド実行は `runner.Runner` 関数として注入でき、探索・チェック順・集約・終了コードを
+  実 `go` / `golangci-lint` やネットワークに依存せず table-driven テストで検証している。
+- `vendor` / `testdata` / ドットディレクトリは探索から除外する。
+
+## 前提ツール
+
+ホストの PATH に `goimports` / `golangci-lint` / `go` が必要（未導入のチェックは fail として表示される）。

--- a/scripts/go-verify/cmd/go-verify/main.go
+++ b/scripts/go-verify/cmd/go-verify/main.go
@@ -1,0 +1,88 @@
+// Command go-verify discovers the Go modules under a root directory and runs the
+// same checks as CI (goimports diff gate, golangci-lint, go test) against each,
+// printing an aggregated pass/fail summary and exiting non-zero on any failure.
+//
+// It is a shift-left quality gate: run it before pushing to catch formatting,
+// lint and test failures locally instead of waiting for CI.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go-verify/internal/runner"
+)
+
+func main() {
+	root := flag.String("root", ".", "root directory to search for Go modules")
+	only := flag.String("only", "", "run only a subset of checks: lint|test (default: all)")
+	mod := flag.String("mod", "", "only verify modules whose path contains this substring")
+	flag.Parse()
+
+	os.Exit(execute(*root, *only, *mod, os.Stdout))
+}
+
+// execute runs the verification and writes a summary to out, returning the
+// process exit code (0 = all passed, 1 = a check failed, 2 = usage/setup error).
+func execute(root, only, mod string, out io.Writer) int {
+	names, selErr := runner.SelectChecks(only)
+	if selErr != nil {
+		_, _ = fmt.Fprintln(out, "go-verify:", selErr)
+		return 2
+	}
+
+	var filter []string
+	if mod != "" {
+		filter = []string{mod}
+	}
+
+	checks, verifyErr := runner.VerifyAll(root, defaultRunner, names, filter)
+	if verifyErr != nil {
+		_, _ = fmt.Fprintln(out, "go-verify:", verifyErr)
+		return 2
+	}
+	if len(checks) == 0 {
+		_, _ = fmt.Fprintln(out, "go-verify: no Go modules found under", root)
+		return 2
+	}
+
+	writeSummary(out, checks)
+	if runner.AnyFailed(checks) {
+		return 1
+	}
+	return 0
+}
+
+// writeSummary prints a human-readable module × check pass/fail report.
+func writeSummary(out io.Writer, checks []runner.Check) {
+	for _, c := range checks {
+		status := "PASS"
+		if !c.OK {
+			status = "FAIL"
+		}
+		_, _ = fmt.Fprintf(out, "%s  %-14s %s\n", status, c.Name, c.Mod)
+		if !c.OK && c.Output != "" {
+			_, _ = fmt.Fprintln(out, indent(c.Output))
+		}
+	}
+}
+
+// indent prefixes every line of s with two spaces for nested output.
+func indent(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = "  " + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// defaultRunner executes a command in dir and returns its combined output.
+func defaultRunner(dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}

--- a/scripts/go-verify/go.mod
+++ b/scripts/go-verify/go.mod
@@ -1,0 +1,3 @@
+module go-verify
+
+go 1.26

--- a/scripts/go-verify/internal/runner/runner.go
+++ b/scripts/go-verify/internal/runner/runner.go
@@ -1,0 +1,186 @@
+// Package runner discovers Go modules under a root directory and runs the same
+// checks as CI (goimports diff gate, golangci-lint, go test) against each one.
+//
+// It is deliberately dependency-free: external commands are executed through an
+// injectable Runner so the discovery, check ordering, and result aggregation can
+// be unit-tested without a real toolchain or network access.
+package runner
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Runner executes a command in dir and returns its combined output.
+type Runner func(dir, name string, args ...string) ([]byte, error)
+
+// Check is the result of a single check run against one module.
+type Check struct {
+	// Mod is the module directory (relative to the search root when possible).
+	Mod string
+	// Name is the check identifier: "goimports", "golangci-lint" or "go test".
+	Name string
+	// OK reports whether the check passed.
+	OK bool
+	// Output holds diff/log detail, populated on failure.
+	Output string
+}
+
+// checkOrder lists the checks in the order CI runs them.
+var checkOrder = []string{"goimports", "golangci-lint", "go test"}
+
+// SelectChecks maps an -only value ("", "lint", "test") to the check names to
+// run. An empty value runs every check. An unknown value returns an error.
+func SelectChecks(only string) ([]string, error) {
+	switch only {
+	case "":
+		return append([]string(nil), checkOrder...), nil
+	case "lint":
+		return []string{"goimports", "golangci-lint"}, nil
+	case "test":
+		return []string{"go test"}, nil
+	default:
+		return nil, fmt.Errorf("unknown -only value %q (want lint|test or empty)", only)
+	}
+}
+
+// Discover returns the directories under root that contain a go.mod file,
+// sorted for stable output. vendor, testdata and dot-directories are skipped.
+func Discover(root string) ([]string, error) {
+	var mods []string
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != root && skipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "go.mod" {
+			mods = append(mods, filepath.Dir(path))
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Strings(mods)
+	return mods, nil
+}
+
+// skipDir reports whether a directory should be pruned from the walk.
+func skipDir(name string) bool {
+	return name == "vendor" || name == "testdata" || strings.HasPrefix(name, ".")
+}
+
+// Verify runs the named checks against a single module directory and returns one
+// Check per name, preserving the given order.
+func Verify(mod string, run Runner, names []string) []Check {
+	checks := make([]Check, 0, len(names))
+	for _, name := range names {
+		checks = append(checks, runCheck(name, mod, run))
+	}
+	return checks
+}
+
+// VerifyAll discovers modules under root, filters them by modFilter (a path
+// substring; empty matches all), runs the given checks against each, and
+// returns the aggregated results. Mod labels are made relative to root.
+func VerifyAll(root string, run Runner, names, modFilter []string) ([]Check, error) {
+	mods, discErr := Discover(root)
+	if discErr != nil {
+		return nil, discErr
+	}
+	var checks []Check
+	for _, mod := range mods {
+		if !matchesFilter(mod, modFilter) {
+			continue
+		}
+		label := relLabel(root, mod)
+		for _, c := range Verify(mod, run, names) {
+			c.Mod = label
+			checks = append(checks, c)
+		}
+	}
+	return checks, nil
+}
+
+// AnyFailed reports whether at least one check failed.
+func AnyFailed(checks []Check) bool {
+	for _, c := range checks {
+		if !c.OK {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesFilter reports whether mod contains every requested substring. An empty
+// filter list matches everything.
+func matchesFilter(mod string, filter []string) bool {
+	for _, f := range filter {
+		if f != "" && !strings.Contains(mod, f) {
+			return false
+		}
+	}
+	return true
+}
+
+// relLabel returns mod relative to root, falling back to mod on failure.
+func relLabel(root, mod string) string {
+	rel, relErr := filepath.Rel(root, mod)
+	if relErr != nil {
+		return mod
+	}
+	if rel == "." {
+		return filepath.Base(mod)
+	}
+	return rel
+}
+
+// runCheck runs a single named check in moddir via the injected runner.
+func runCheck(name, moddir string, run Runner) Check {
+	switch name {
+	case "goimports":
+		// goimports -l lists files whose formatting differs; any output is a fail.
+		out, importsErr := run(moddir, "goimports", "-l", ".")
+		listed := strings.TrimSpace(string(out))
+		return result(name, importsErr == nil && listed == "", listed, importsErr)
+	case "golangci-lint":
+		out, lintErr := run(moddir, "golangci-lint", "run", "./...")
+		return result(name, lintErr == nil, strings.TrimSpace(string(out)), lintErr)
+	case "go test":
+		out, testErr := run(moddir, "go", "test", "./...", "-count=1")
+		return result(name, testErr == nil, strings.TrimSpace(string(out)), testErr)
+	default:
+		return Check{Name: name, OK: false, Output: "unknown check"}
+	}
+}
+
+// result builds a Check, leaving Output empty on success and populating it with
+// the failure detail otherwise.
+func result(name string, ok bool, output string, cmdErr error) Check {
+	if ok {
+		return Check{Name: name, OK: true}
+	}
+	return Check{Name: name, OK: false, Output: detail(output, cmdErr)}
+}
+
+// detail combines command output with the exec error for a failure message.
+func detail(output string, cmdErr error) string {
+	switch {
+	case output != "" && cmdErr != nil:
+		return output + "\n" + cmdErr.Error()
+	case output != "":
+		return output
+	case cmdErr != nil:
+		return cmdErr.Error()
+	default:
+		return ""
+	}
+}

--- a/scripts/go-verify/internal/runner/runner_test.go
+++ b/scripts/go-verify/internal/runner/runner_test.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSelectChecks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		only    string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty runs all", only: "", want: []string{"goimports", "golangci-lint", "go test"}},
+		{name: "lint subset", only: "lint", want: []string{"goimports", "golangci-lint"}},
+		{name: "test subset", only: "test", want: []string{"go test"}},
+		{name: "unknown errors", only: "bogus", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := SelectChecks(tt.only)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("SelectChecks(%q) err = %v, wantErr %v", tt.only, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("SelectChecks(%q) = %v, want %v", tt.only, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Layout: two modules (a, b/c) plus decoys that must be skipped.
+	writeModules(t, root, []string{
+		"a",
+		filepath.Join("b", "c"),
+		filepath.Join("vendor", "d"),   // pruned: vendor
+		filepath.Join("testdata", "e"), // pruned: testdata
+		filepath.Join(".hidden", "f"),  // pruned: dot-dir
+	})
+
+	got, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "a"),
+		filepath.Join(root, "b", "c"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discover = %v, want %v", got, want)
+	}
+}
+
+func TestRunCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		check      string
+		out        []byte
+		runErr     error
+		wantOK     bool
+		wantOutput string
+	}{
+		{name: "goimports clean", check: "goimports", out: []byte(""), wantOK: true},
+		{name: "goimports diff", check: "goimports", out: []byte("main.go\n"), wantOK: false, wantOutput: "main.go"},
+		{name: "golangci pass", check: "golangci-lint", out: []byte(""), wantOK: true},
+		{name: "golangci fail", check: "golangci-lint", out: []byte("issue"), runErr: errors.New("exit 1"), wantOK: false, wantOutput: "issue\nexit 1"},
+		{name: "go test pass", check: "go test", out: []byte("ok"), wantOK: true},
+		{name: "go test fail", check: "go test", out: []byte("FAIL"), runErr: errors.New("exit 1"), wantOK: false, wantOutput: "FAIL\nexit 1"},
+		{name: "unknown check", check: "bogus", wantOK: false, wantOutput: "unknown check"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			run := func(_, _ string, _ ...string) ([]byte, error) {
+				return tt.out, tt.runErr
+			}
+			got := runCheck(tt.check, "/mod", run)
+			if got.OK != tt.wantOK {
+				t.Fatalf("runCheck(%q) OK = %v, want %v", tt.check, got.OK, tt.wantOK)
+			}
+			if got.Output != tt.wantOutput {
+				t.Fatalf("runCheck(%q) Output = %q, want %q", tt.check, got.Output, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestVerifyAll(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeModules(t, root, []string{"a", "b"})
+
+	// Stub runner: goimports clean everywhere; golangci-lint fails only in "a".
+	run := func(dir, name string, _ ...string) ([]byte, error) {
+		if name == "golangci-lint" && filepath.Base(dir) == "a" {
+			return []byte("bad"), errors.New("exit 1")
+		}
+		return []byte(""), nil
+	}
+
+	checks, err := VerifyAll(root, run, []string{"goimports", "golangci-lint"}, nil)
+	if err != nil {
+		t.Fatalf("VerifyAll: %v", err)
+	}
+	if len(checks) != 4 {
+		t.Fatalf("VerifyAll returned %d checks, want 4", len(checks))
+	}
+	if !AnyFailed(checks) {
+		t.Fatal("AnyFailed = false, want true (golangci-lint fails in module a)")
+	}
+	// Confirm exactly the golangci-lint check in module "a" failed.
+	for _, c := range checks {
+		wantFail := c.Mod == "a" && c.Name == "golangci-lint"
+		if c.OK == wantFail {
+			t.Fatalf("check %s/%s OK = %v, want %v", c.Mod, c.Name, c.OK, !wantFail)
+		}
+	}
+}
+
+func TestVerifyAllModFilter(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeModules(t, root, []string{"a", "b"})
+
+	run := func(_, _ string, _ ...string) ([]byte, error) { return []byte(""), nil }
+
+	checks, err := VerifyAll(root, run, []string{"goimports"}, []string{"b"})
+	if err != nil {
+		t.Fatalf("VerifyAll: %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("VerifyAll with filter returned %d checks, want 1", len(checks))
+	}
+	if checks[0].Mod != "b" {
+		t.Fatalf("filtered check Mod = %q, want %q", checks[0].Mod, "b")
+	}
+}
+
+// writeModules creates a go.mod under each relative path below root.
+func writeModules(t *testing.T, root string, rels []string) {
+	t.Helper()
+	for _, rel := range rels {
+		dir := filepath.Join(root, rel)
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			t.Fatalf("MkdirAll %s: %v", dir, mkErr)
+		}
+		mod := filepath.Join(dir, "go.mod")
+		if writeErr := os.WriteFile(mod, []byte("module x\n\ngo 1.26\n"), 0o644); writeErr != nil {
+			t.Fatalf("WriteFile %s: %v", mod, writeErr)
+		}
+	}
+}


### PR DESCRIPTION
Closes #465

## 何を

`scripts/go-verify/`（net-new / 外部依存ゼロ）を追加する。`go.mod` を自動探索し、各モジュールに CI と同順・同設定の検証を実行して集約し、`fail` があれば非ゼロ終了する shift-left な品質ゲート。

```
scripts/go-verify/
  cmd/go-verify/main.go              # フラグ解析 → 検証 → 集約サマリ → exit code
  internal/runner/runner.go          # モジュール探索 + チェック実行（Runner 注入）
  internal/runner/runner_test.go     # table-driven テスト
  go.mod                             # 依存なし（標準ライブラリのみ）
  README.md
```

## 検証内容（CI パリティ）

1. `goimports -l .`（整形差分のあるファイルが列挙されたら fail）
2. `golangci-lint run ./...`（リポジトリ root の `.golangci.yml` を使用）
3. `go test ./... -count=1`

## なぜ

`scripts/` は ai-bridge / nvim-sync の 2 Go モジュールに増え、CI 側はモジュールごとに lint/test ワークフローを複製している一方、ローカルには横断的な検証手段が無く「PR を出して CI が落ちて初めて気づく」往復が常態化していた。`go-verify` は push 前に 1 コマンドで CI 同等の結果を得られ、`go.mod` 自動探索により新モジュール追加に設定ゼロで追従する。

## 設計・テスト容易性

- 外部コマンド実行は `runner.Runner` 関数として注入でき、探索・チェック順・集約・終了コードを実 `go` / `golangci-lint` やネットワークに依存せず table-driven + `t.Parallel()` で検証（`scripts/ai-bridge/AGENTS.md` 規約に準拠：`err` 使い回し禁止、未公開関数は lowercase、テスト FS は `t.TempDir()`）。
- `vendor` / `testdata` / ドットディレクトリは探索から除外。
- フラグ: `-root`（探索ルート）/ `-only lint|test` / `-mod <substr>`。終了コード 0=全 pass / 1=fail / 2=使用方法・探索エラー。

## 検証（ローカル実行済み）

- `go build ./...` / `go vet ./...` / `go test ./... -count=1` → いずれも成功。
- `goimports -l .` → 差分なし。
- `golangci-lint run ./...`（go1.26 でビルドした golangci-lint 2.5.0、root `.golangci.yml`）→ `0 issues`。
- e2e: 自モジュールに対して実行し `PASS goimports / golangci-lint / go test`（exit 0）、不正な `-only` で exit 2 を確認。

## スコープ / 留意点（Issue (e) に対応）

- 本モジュールは既存の path スコープ CI（`scripts/ai-bridge/**` 限定等）に乗らない。CI ワークフロー（`.github/workflows/`）の追加・一般化は本 PR のスコープ外（別 issue）。
- ai-bridge / nvim-sync には一切手を入れていない。`scripts/go-verify/` に閉じている。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_