### PR TITLE
feat(scripts): AI CLI 設定のデプロイ差分を read-only 検出する config-diff を追加する

### DIFF
--- a/scripts/config-diff/README.md
+++ b/scripts/config-diff/README.md
@@ -1,0 +1,60 @@
+# config-diff
+
+リポジトリの `ai-agents/` 内「設定ソース」と、デプロイ先（`~/.claude` / `~/.cursor` /
+`~/.codex` / `~/.copilot`）の実体を **read-only** で比較し、`ok` / `drift`（内容が食い違う）/
+`missing`（未デプロイ）を集約表示する差分ツール。**一切コピーしない。** `drift` / `missing` が
+あれば非ゼロ終了する。
+
+`ai-agents/scripts/copy-entries.sh` と同じ `<mode> <src> <dest>` 契約・同じ列挙規則を取るので、
+「copy が触る対象」と「diff が見る対象」が必ず揃う。
+
+## 使い方
+
+```sh
+config-diff <mode> <src> <dest>    # mode: skills | agents | settings
+```
+
+例（`ai-agents/Makefile` の `*_SRC` / `*_DEST` を流用する想定）:
+
+```sh
+config-diff settings ai-agents/settings/claude ~/.claude
+config-diff skills   ai-agents/skills          ~/.claude/skills
+config-diff agents   ai-agents/agents          ~/.claude/agents
+```
+
+## 列挙規則（copy-entries.sh と一致）
+
+| mode       | 列挙対象                       | label            | 比較単位             |
+| ---------- | ------------------------------ | ---------------- | -------------------- |
+| `skills`   | `src` 直下のディレクトリ       | basename         | ディレクトリ再帰比較 |
+| `agents`   | `src` 直下の `*.md` ファイル   | basename         | ファイル（sha256）   |
+| `settings` | `src` 配下の全ファイル（再帰） | `src` からの相対 | ファイル（sha256）   |
+
+## 判定
+
+- `missing` — dest に対応エントリが無い
+- `drift` — 存在するが内容が違う（`skills` はディレクトリ内の `drift:` / `missing:` / `extra:` を列挙）
+- `ok` — 一致
+
+`extra:`（dest 側のみに存在するファイル）は `skills` のディレクトリ比較でのみ検出する。`cp -R` は
+`rm -rf` 後に上書きするため、この余剰ファイルはデプロイ時に消える対象を表す。
+
+## 終了コード
+
+- `0` — 全エントリ ok
+- `1` — drift / missing が 1 つ以上
+- `2` — 使用方法・ソース不明・不正な mode 等
+
+## 比較の意味論
+
+- 内容比較は **sha256**（バイト一致）。ファイルモード（実行ビット、`cp -p` の time 保存）や
+  改行差は v1 では drift とみなさない（内容のみ）。
+- シンボリックリンク（`codex` の `AGENTS.md` は Makefile で `ln -sf`）は copy 対象外なので
+  check でも対象外。
+
+## 設計
+
+- 外部依存ゼロ（標準ライブラリのみ）。マッピングは持たず `(mode, src, dest)` を受けるだけで、
+  単一情報源は `ai-agents/Makefile` に保つ。
+- 列挙・分類・再帰比較・集約・終了コードを `t.TempDir()` に組み立てた src/dest で table-driven
+  テスト（実ホーム・ネットワーク非依存）。

--- a/scripts/config-diff/README.md
+++ b/scripts/config-diff/README.md
@@ -47,8 +47,9 @@ config-diff agents   ai-agents/agents          ~/.claude/agents
 
 ## 比較の意味論
 
-- 内容比較は **sha256**（バイト一致）。ファイルモード（実行ビット、`cp -p` の time 保存）や
-  改行差は v1 では drift とみなさない（内容のみ）。
+- 内容比較は **sha256**（バイト一致）。バイト列そのものを比較するため、改行コードの違い
+  （LF / CRLF）も drift になる。一方、sha256 に含まれないファイルモード（実行ビット）や
+  `cp -p` が保存する mtime は drift とみなさない。
 - シンボリックリンク（`codex` の `AGENTS.md` は Makefile で `ln -sf`）は copy 対象外なので
   check でも対象外。
 

--- a/scripts/config-diff/cmd/config-diff/main.go
+++ b/scripts/config-diff/cmd/config-diff/main.go
@@ -1,0 +1,61 @@
+// Command config-diff compares an AI CLI configuration source directory with its
+// deployed copy read-only, printing an ok/drift/missing summary and exiting
+// non-zero when anything has drifted or is not yet deployed.
+//
+// It takes the same arguments as ai-agents/scripts/copy-entries.sh:
+//
+//	config-diff <mode> <src> <dest>    # mode: skills | agents | settings
+//
+// so a Makefile can place a diff/check target next to each copy target using the
+// same *_SRC / *_DEST variables.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"config-diff/internal/diff"
+)
+
+func main() {
+	os.Exit(execute(os.Args[1:], os.Stdout))
+}
+
+// execute parses args, runs the comparison and writes a summary to out,
+// returning the process exit code (0 = all ok, 1 = drift/missing, 2 = usage/error).
+func execute(args []string, out io.Writer) int {
+	if len(args) != 3 {
+		_, _ = fmt.Fprintln(out, "Usage: config-diff <mode> <src> <dest>")
+		_, _ = fmt.Fprintln(out, "  mode: skills | agents | settings")
+		return 2
+	}
+	mode, src, dest := args[0], args[1], args[2]
+
+	entries, classifyErr := diff.Classify(mode, src, dest)
+	if classifyErr != nil {
+		_, _ = fmt.Fprintln(out, "config-diff:", classifyErr)
+		return 2
+	}
+
+	writeSummary(out, mode, dest, entries)
+	if diff.AnyDivergent(entries) {
+		return 1
+	}
+	return 0
+}
+
+// writeSummary prints one line per entry plus drift detail.
+func writeSummary(out io.Writer, mode, dest string, entries []diff.Entry) {
+	_, _ = fmt.Fprintf(out, "%s -> %s\n", mode, dest)
+	if len(entries) == 0 {
+		_, _ = fmt.Fprintln(out, "  (no entries)")
+		return
+	}
+	for _, e := range entries {
+		_, _ = fmt.Fprintf(out, "  %-8s %s\n", e.State, e.Label)
+		if e.State == diff.StateDrift && e.Note != "" {
+			_, _ = fmt.Fprintf(out, "           %s\n", e.Note)
+		}
+	}
+}

--- a/scripts/config-diff/go.mod
+++ b/scripts/config-diff/go.mod
@@ -1,0 +1,3 @@
+module config-diff
+
+go 1.26

--- a/scripts/config-diff/internal/diff/diff.go
+++ b/scripts/config-diff/internal/diff/diff.go
@@ -103,7 +103,8 @@ func enumerate(mode, src string) ([]item, error) {
 		return topLevel(src, func(d fs.DirEntry) bool { return d.IsDir() }, true)
 	case "agents":
 		return topLevel(src, func(d fs.DirEntry) bool {
-			return !d.IsDir() && strings.HasSuffix(d.Name(), ".md")
+			// find -type f matches regular files only, so symlinked *.md are skipped.
+			return d.Type().IsRegular() && strings.HasSuffix(d.Name(), ".md")
 		}, false)
 	case "settings":
 		return settingsFiles(src)
@@ -139,7 +140,9 @@ func settingsFiles(src string) ([]item, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		// Mirror copy-entries.sh `find -type f`: descend into directories but only
+		// enumerate regular files, skipping symlinks and other special entries.
+		if !d.Type().IsRegular() {
 			return nil
 		}
 		rel, relErr := filepath.Rel(src, path)
@@ -241,7 +244,8 @@ func relFiles(dir string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		// Regular files only, matching the copy enumeration; skip symlinks.
+		if !d.Type().IsRegular() {
 			return nil
 		}
 		rel, relErr := filepath.Rel(dir, path)

--- a/scripts/config-diff/internal/diff/diff.go
+++ b/scripts/config-diff/internal/diff/diff.go
@@ -1,0 +1,294 @@
+// Package diff compares the AI CLI configuration sources under ai-agents/ with
+// their deployed copies (~/.claude, ~/.cursor, ~/.codex, ~/.copilot) read-only,
+// classifying each entry as ok, drift or missing.
+//
+// It takes the same (mode, src, dest) contract as ai-agents/scripts/copy-entries.sh
+// and enumerates entries with the same rules, so "what copy touches" and "what
+// diff inspects" stay in lockstep. It never writes anything.
+package diff
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// State is the classification of a single entry.
+type State int
+
+const (
+	// StateOK means the source entry matches its deployed copy.
+	StateOK State = iota
+	// StateDrift means the deployed copy exists but its content differs.
+	StateDrift
+	// StateMissing means the entry has not been deployed yet.
+	StateMissing
+)
+
+// String returns the lowercase label used in the summary output.
+func (s State) String() string {
+	switch s {
+	case StateOK:
+		return "ok"
+	case StateDrift:
+		return "drift"
+	case StateMissing:
+		return "missing"
+	default:
+		return "unknown"
+	}
+}
+
+// Entry is the comparison result for one source entry.
+type Entry struct {
+	// Label is the entry name relative to src, matching copy-entries.sh.
+	Label string
+	// State is ok, drift or missing.
+	State State
+	// Note carries drift detail (per-file differences) when State is StateDrift.
+	Note string
+}
+
+// item is an enumerated source entry before classification.
+type item struct {
+	path  string // absolute or src-relative source path
+	label string // name under dest, per copy-entries.sh rules
+	isDir bool   // true for skills entries (directory trees)
+}
+
+// Classify enumerates the src entries for mode and compares each with dest,
+// returning results sorted by label. mode is skills, agents or settings.
+func Classify(mode, src, dest string) ([]Entry, error) {
+	if _, statErr := os.Stat(src); statErr != nil {
+		return nil, fmt.Errorf("source directory not found: %s", src)
+	}
+	items, enumErr := enumerate(mode, src)
+	if enumErr != nil {
+		return nil, enumErr
+	}
+	entries := make([]Entry, 0, len(items))
+	for _, it := range items {
+		entry, classErr := classify(it, dest)
+		if classErr != nil {
+			return nil, classErr
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Label < entries[j].Label })
+	return entries, nil
+}
+
+// AnyDivergent reports whether any entry is drift or missing.
+func AnyDivergent(entries []Entry) bool {
+	for _, e := range entries {
+		if e.State != StateOK {
+			return true
+		}
+	}
+	return false
+}
+
+// enumerate lists the source entries for mode, mirroring copy-entries.sh:
+//   - skills:   top-level directories (label = basename)
+//   - agents:   top-level *.md files (label = basename)
+//   - settings: every file, recursively (label = path relative to src)
+func enumerate(mode, src string) ([]item, error) {
+	switch mode {
+	case "skills":
+		return topLevel(src, func(d fs.DirEntry) bool { return d.IsDir() }, true)
+	case "agents":
+		return topLevel(src, func(d fs.DirEntry) bool {
+			return !d.IsDir() && strings.HasSuffix(d.Name(), ".md")
+		}, false)
+	case "settings":
+		return settingsFiles(src)
+	default:
+		return nil, fmt.Errorf("unknown mode: %s", mode)
+	}
+}
+
+// topLevel returns the direct children of src that satisfy keep, labelled by
+// basename. isDir records whether the entries are directory trees.
+func topLevel(src string, keep func(fs.DirEntry) bool, isDir bool) ([]item, error) {
+	dirEntries, readErr := os.ReadDir(src)
+	if readErr != nil {
+		return nil, readErr
+	}
+	var items []item
+	for _, d := range dirEntries {
+		if keep(d) {
+			items = append(items, item{
+				path:  filepath.Join(src, d.Name()),
+				label: d.Name(),
+				isDir: isDir,
+			})
+		}
+	}
+	return items, nil
+}
+
+// settingsFiles returns every file under src labelled by its path relative to src.
+func settingsFiles(src string) ([]item, error) {
+	var items []item
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		items = append(items, item{path: path, label: rel, isDir: false})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return items, nil
+}
+
+// classify compares one source item with dest/<label>.
+func classify(it item, dest string) (Entry, error) {
+	target := filepath.Join(dest, it.label)
+	if it.isDir {
+		return classifyDir(it, target)
+	}
+	return classifyFile(it, target)
+}
+
+// classifyFile compares a single source file with its deployed target.
+func classifyFile(it item, target string) (Entry, error) {
+	if !exists(target) {
+		return Entry{Label: it.label, State: StateMissing}, nil
+	}
+	same, cmpErr := sameFile(it.path, target)
+	if cmpErr != nil {
+		return Entry{}, cmpErr
+	}
+	if !same {
+		return Entry{Label: it.label, State: StateDrift, Note: "content differs"}, nil
+	}
+	return Entry{Label: it.label, State: StateOK}, nil
+}
+
+// classifyDir compares a source directory tree with its deployed target,
+// reporting per-file drift/missing/extra as the note.
+func classifyDir(it item, target string) (Entry, error) {
+	if !isDir(target) {
+		return Entry{Label: it.label, State: StateMissing}, nil
+	}
+	notes, cmpErr := compareDir(it.path, target)
+	if cmpErr != nil {
+		return Entry{}, cmpErr
+	}
+	if len(notes) > 0 {
+		return Entry{Label: it.label, State: StateDrift, Note: strings.Join(notes, ", ")}, nil
+	}
+	return Entry{Label: it.label, State: StateOK}, nil
+}
+
+// compareDir returns per-file differences between srcDir and destDir:
+//   - "missing: r" a file present in src but not in dest
+//   - "drift: r"   a file whose content differs
+//   - "extra: r"   a file present in dest but not in src (would be removed on copy)
+func compareDir(srcDir, destDir string) ([]string, error) {
+	srcFiles, srcErr := relFiles(srcDir)
+	if srcErr != nil {
+		return nil, srcErr
+	}
+	destFiles, destErr := relFiles(destDir)
+	if destErr != nil {
+		return nil, destErr
+	}
+	inSrc := make(map[string]bool, len(srcFiles))
+	var notes []string
+	for _, rel := range srcFiles {
+		inSrc[rel] = true
+		destPath := filepath.Join(destDir, rel)
+		if !exists(destPath) {
+			notes = append(notes, "missing: "+rel)
+			continue
+		}
+		same, cmpErr := sameFile(filepath.Join(srcDir, rel), destPath)
+		if cmpErr != nil {
+			return nil, cmpErr
+		}
+		if !same {
+			notes = append(notes, "drift: "+rel)
+		}
+	}
+	for _, rel := range destFiles {
+		if !inSrc[rel] {
+			notes = append(notes, "extra: "+rel)
+		}
+	}
+	sort.Strings(notes)
+	return notes, nil
+}
+
+// relFiles returns the sorted paths of every file under dir, relative to dir.
+func relFiles(dir string) ([]string, error) {
+	var files []string
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// exists reports whether path exists.
+func exists(path string) bool {
+	_, statErr := os.Stat(path)
+	return statErr == nil
+}
+
+// isDir reports whether path exists and is a directory.
+func isDir(path string) bool {
+	info, statErr := os.Stat(path)
+	return statErr == nil && info.IsDir()
+}
+
+// sameFile reports whether two files have identical content (sha256).
+func sameFile(a, b string) (bool, error) {
+	sumA, sumErrA := hashFile(a)
+	if sumErrA != nil {
+		return false, sumErrA
+	}
+	sumB, sumErrB := hashFile(b)
+	if sumErrB != nil {
+		return false, sumErrB
+	}
+	return bytes.Equal(sumA, sumB), nil
+}
+
+// hashFile returns the sha256 digest of the file at path.
+func hashFile(path string) ([]byte, error) {
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return nil, readErr
+	}
+	sum := sha256.Sum256(data)
+	return sum[:], nil
+}

--- a/scripts/config-diff/internal/diff/diff_test.go
+++ b/scripts/config-diff/internal/diff/diff_test.go
@@ -112,6 +112,28 @@ func TestClassifySkills(t *testing.T) {
 	}
 }
 
+func TestClassifySettingsSkipsSymlinks(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dest := t.TempDir()
+	// A regular file plus a symlink to it. copy-entries.sh `find -type f` never
+	// enumerates the symlink, so config-diff must not report it either.
+	writeFile(t, filepath.Join(src, "real.txt"), "content")
+	if err := os.Symlink(filepath.Join(src, "real.txt"), filepath.Join(src, "link.txt")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	entries, err := Classify("settings", src, dest)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	got := stateByLabel(entries)
+	want := map[string]State{"real.txt": StateMissing}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Classify settings = %v, want %v (symlink link.txt must be excluded)", got, want)
+	}
+}
+
 func TestClassifyUnknownMode(t *testing.T) {
 	t.Parallel()
 	src := t.TempDir()

--- a/scripts/config-diff/internal/diff/diff_test.go
+++ b/scripts/config-diff/internal/diff/diff_test.go
@@ -1,0 +1,181 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestStateString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		state State
+		want  string
+	}{
+		{name: "ok", state: StateOK, want: "ok"},
+		{name: "drift", state: StateDrift, want: "drift"},
+		{name: "missing", state: StateMissing, want: "missing"},
+		{name: "unknown", state: State(99), want: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.state.String(); got != tt.want {
+				t.Fatalf("State(%d).String() = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAgents(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dest := t.TempDir()
+	// Source has two .md agents and one non-md file that must be ignored.
+	writeFile(t, filepath.Join(src, "a.md"), "alpha")
+	writeFile(t, filepath.Join(src, "b.md"), "beta")
+	writeFile(t, filepath.Join(src, "ignore.txt"), "nope")
+	// dest: a.md matches, b.md missing.
+	writeFile(t, filepath.Join(dest, "a.md"), "alpha")
+
+	entries, err := Classify("agents", src, dest)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	got := stateByLabel(entries)
+	want := map[string]State{"a.md": StateOK, "b.md": StateMissing}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Classify agents = %v, want %v (ignore.txt must be excluded)", got, want)
+	}
+}
+
+func TestClassifySettings(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dest := t.TempDir()
+	// Recursive files; label is the path relative to src.
+	writeFile(t, filepath.Join(src, "settings.json"), "{}")
+	writeFile(t, filepath.Join(src, "hooks", "a.sh"), "echo a")
+	writeFile(t, filepath.Join(src, "hooks", "b.sh"), "echo b")
+	// dest: settings.json drifts, hooks/a.sh ok, hooks/b.sh missing.
+	writeFile(t, filepath.Join(dest, "settings.json"), "{changed}")
+	writeFile(t, filepath.Join(dest, "hooks", "a.sh"), "echo a")
+
+	entries, err := Classify("settings", src, dest)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	got := stateByLabel(entries)
+	want := map[string]State{
+		"settings.json":                StateDrift,
+		filepath.Join("hooks", "a.sh"): StateOK,
+		filepath.Join("hooks", "b.sh"): StateMissing,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Classify settings = %v, want %v", got, want)
+	}
+}
+
+func TestClassifySkills(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dest := t.TempDir()
+	// One skill dir that is ok, one that drifts (a file changed + an extra file
+	// in dest), one that is missing entirely.
+	writeFile(t, filepath.Join(src, "ok-skill", "SKILL.md"), "ok")
+	writeFile(t, filepath.Join(src, "drift-skill", "SKILL.md"), "v1")
+	writeFile(t, filepath.Join(src, "missing-skill", "SKILL.md"), "m")
+
+	writeFile(t, filepath.Join(dest, "ok-skill", "SKILL.md"), "ok")
+	writeFile(t, filepath.Join(dest, "drift-skill", "SKILL.md"), "v2")
+	writeFile(t, filepath.Join(dest, "drift-skill", "stale.txt"), "orphan")
+
+	entries, err := Classify("skills", src, dest)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	got := stateByLabel(entries)
+	want := map[string]State{
+		"ok-skill":      StateOK,
+		"drift-skill":   StateDrift,
+		"missing-skill": StateMissing,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Classify skills = %v, want %v", got, want)
+	}
+	// The drift note must call out both the changed file and the extra file.
+	note := noteByLabel(entries, "drift-skill")
+	if note != "drift: SKILL.md, extra: stale.txt" {
+		t.Fatalf("drift-skill note = %q, want %q", note, "drift: SKILL.md, extra: stale.txt")
+	}
+}
+
+func TestClassifyUnknownMode(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	if _, err := Classify("bogus", src, src); err == nil {
+		t.Fatal("Classify with unknown mode: want error, got nil")
+	}
+}
+
+func TestClassifyMissingSource(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := Classify("agents", missing, t.TempDir()); err == nil {
+		t.Fatal("Classify with missing source: want error, got nil")
+	}
+}
+
+func TestAnyDivergent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		entries []Entry
+		want    bool
+	}{
+		{name: "all ok", entries: []Entry{{State: StateOK}, {State: StateOK}}, want: false},
+		{name: "has drift", entries: []Entry{{State: StateOK}, {State: StateDrift}}, want: true},
+		{name: "has missing", entries: []Entry{{State: StateMissing}}, want: true},
+		{name: "empty", entries: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AnyDivergent(tt.entries); got != tt.want {
+				t.Fatalf("AnyDivergent = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// stateByLabel indexes entry states by label for order-independent comparison.
+func stateByLabel(entries []Entry) map[string]State {
+	m := make(map[string]State, len(entries))
+	for _, e := range entries {
+		m[e.Label] = e.State
+	}
+	return m
+}
+
+// noteByLabel returns the note for the entry with the given label.
+func noteByLabel(entries []Entry, label string) string {
+	for _, e := range entries {
+		if e.Label == label {
+			return e.Note
+		}
+	}
+	return ""
+}
+
+// writeFile writes content to path, creating parent directories.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), mkErr)
+	}
+	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("WriteFile %s: %v", path, writeErr)
+	}
+}


### PR DESCRIPTION
Closes #472

## 何を

`scripts/config-diff/`（net-new / 外部依存ゼロ）を追加する。`ai-agents/` の設定ソースとデプロイ先（`~/.claude` / `~/.cursor` / `~/.codex` / `~/.copilot`）の実体を **read-only** で比較し、`ok` / `drift` / `missing` を集約表示する。**一切コピーせず**、`drift` / `missing` があれば非ゼロ終了する。

```
scripts/config-diff/
  cmd/config-diff/main.go            # 引数解析 → 分類 → 集約出力 → exit code
  internal/diff/diff.go              # enumerate(mode) + classify（純粋・FS 読み取りのみ）
  internal/diff/diff_test.go         # table-driven テスト
  go.mod                             # 依存なし（標準ライブラリのみ）
  README.md
```

## なぜ

この PDE の AI CLI 設定デプロイは `copy-entries.sh` による push 一方向で、差分を見る手段が無く、ソースと実体が静かにドリフトする。`config-diff` はデプロイ前に drift を可視化し、`deploy-ai-config` skill や SessionStart hook の前段に置ける「足切り」を与える。

## 契約・列挙規則（copy-entries.sh と一致）

`config-diff <mode> <src> <dest>` を `copy-entries.sh` と同一シグネチャにし、列挙規則も一致させる：

| mode       | 列挙対象                     | label            | 比較単位             |
| ---------- | ---------------------------- | ---------------- | -------------------- |
| `skills`   | `src` 直下のディレクトリ     | basename         | ディレクトリ再帰比較 |
| `agents`   | `src` 直下の `*.md` ファイル | basename         | ファイル（sha256）   |
| `settings` | `src` 配下の全ファイル(再帰) | `src` からの相対 | ファイル（sha256）   |

これにより `ai-agents/Makefile` の既存 `*_SRC` / `*_DEST` 変数をそのまま流用でき、マッピングの単一情報源は Makefile のまま（ツール側にマッピングを持たない）。

## 判定・意味論

- `missing` — dest に対応エントリが無い / `drift` — 存在するが内容が違う / `ok` — 一致
- `skills` はディレクトリ内の `drift:` / `missing:` / `extra:` を列挙。`extra:`（dest のみに存在）は `cp -R`（`rm -rf` 後上書き）で消える対象を表すため skills でのみ検出。
- 内容比較は sha256（バイト一致）。ファイルモード・改行差は v1 では drift とみなさない（README に明記）。シンボリックリンクは copy 対象外なので check でも対象外。

## 検証（ローカル実行済み）

- `go build ./...` / `go vet ./...` / `go test ./... -count=1` → 成功。
- `goimports -l .` → 差分なし。`golangci-lint run ./...`（go1.26 ビルドの 2.5.0、root `.golangci.yml`）→ `0 issues`。`prettier --check README.md` → OK。
- e2e: 実 `ai-agents/settings/claude` に対し、dest 完全コピー→全 `ok`（exit 0）、`settings.json` 改変→`drift`（exit 1）、dest 未作成→全 `missing`（exit 1）、`skills` モードも同様を確認。

## スコープ / 留意点（Issue (e) に対応）

- 本モジュールは既存の path スコープ CI に乗らない。CI ワークフローの追加・一般化は本 PR のスコープ外（別 issue）。
- ツールは `scripts/config-diff/` に閉じ、`copy-entries.sh` / ai-bridge / nvim-sync には手を入れていない。Makefile の `*-check` ターゲット追加も後続に委ねた（列挙規則の一致はテストで固定済み）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGJvPWzgmesaZ5xEQhENxF)_