### PR TITLE
feat: mise 導入でツールバージョンを一元管理する (Phase 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The `--login` option is required to read the `.bash_profile` file.
 
 The Neovim dotfiles work in any environment. You can find [the dotfiles here](./nvim/config).
 
+### Host toolchain (mise)
+
+Host-side tool versions (Go, Node.js, linters) are pinned in `mise.toml` at the repo root and managed by [mise](https://mise.jdx.dev):
+
+```sh
+brew install mise
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+mise install    # run at the repo root
+```
+
 ## Features
 
 - **LSP / Linter / Formatter**: Go (gopls, golangci-lint), Python (pyright, ruff), JavaScript (eslint, prettier), Lua (stylua), Terraform (terraform-ls, tflint, terraform fmt), YAML, TOML, Markdown, etc.

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -123,3 +123,7 @@ export BLOG_IDEA_DRAFT_EXPORT_DIR="$HOME/workspace/hodalog-hugo/docs/idea"
 # codex
 eval "$(codex completion zsh)"
 
+####################
+# mise
+####################
+eval "$(mise activate zsh)"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,13 @@
+# mise.toml — single source of truth for tool versions (and tasks, later phases).
+# Setup: `brew install mise` and add `eval "$(mise activate zsh)"` to ~/.zshrc,
+# then run `mise install` at the repo root.
+
+[tools]
+go = "1.26.4"
+golangci-lint = "2.3.1"
+node = "24.18.0"
+shfmt = "3.13.1"
+shellcheck = "0.11.0"
+stylua = "2.5.2"
+hadolint = "2.14.0"
+"go:golang.org/x/tools/cmd/goimports" = "0.36.0"


### PR DESCRIPTION
## 実装経緯の説明

タスクランナー(Makefile 4枚)とバージョンピン(go.mod ×4、Dockerfile ARG、go-tools.txt、CI ハードコード)が分散しているため、mise に一元化する。本 PR はその Phase 0(mise 導入・挙動変更なし)。全体プランは 4 Phase 構成:

- **Phase 0(本 PR)**: mise 導入 + `mise.toml` に `[tools]` ピン
- Phase 1: Makefile 4枚を mise tasks に置換(config-diff / go-verify のタスク新設含む)
- Phase 2: CI を jdx/mise-action に統一 + Dockerfile ARG を mise.toml から導出
- Phase 3: bump 用 cron 2本を mise ベースの 1 本に統合

## 補足

### 主な変更内容

- `mise.toml` 新規作成: go 1.26.4 / node 24.18.0 / golangci-lint 2.3.1 / goimports 0.36.0(いずれも既存ピンと同値)+ shfmt 3.13.1 / shellcheck 0.11.0 / stylua 2.5.2 / hadolint 2.14.0 を厳密ピン
- `README.md` に mise セットアップ手順(brew install / activate / mise install)を追記
- `dotfiles/.zshrc` に `eval "$(mise activate zsh)"` を追加

### 技術的な詳細

- go.mod の `go 1.26` は言語最低バージョンとして温存し、実 toolchain は mise がピン(toolchain directive は追加しない)
- golangci-lint は aqua バイナリ(`go:` backend 不使用でビルド回避)、goimports のみ `go:` backend
- Makefile・CI・bump ワークフローは本 PR では無傷(挙動変更なし)

### 確認事項

- `mise install && mise ls --current` で全ツールがピン通りに入る
- `mise x -- go version` → go1.26.4
- `make ai-bridge-test` が従来どおり green(確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)