### PR TITLE
feat: CI を mise ベースに統一し Dockerfile を mise.toml から導出する (Phase 2)

### DIFF
--- a/.claude/hooks/guard-version-pins.sh
+++ b/.claude/hooks/guard-version-pins.sh
@@ -20,12 +20,21 @@ if not file_path:
     raise SystemExit(0)
 
 DOCKERFILE_SUFFIX = "environment/docker/nvim.dockerfile"
+MISE_TOML_SUFFIX = "mise.toml"
 PIN_MANIFESTS = (
     "environment/tools/go/go-tools.txt",
     "environment/tools/node/package.json",
 )
 
 ARG_PIN = re.compile(r"^\s*ARG\s+[A-Z0-9_]+(?:VERSION|TOOLCHAIN)\s*=", re.MULTILINE)
+# mise.toml: [tools] pins (bare or quoted backend keys) and [env] version values.
+# [tasks.*] entries (run/description/dir/depends) are free to edit. Requires
+# spaces around "=" (tombi style) so shell assignments in task bodies don't match.
+MISE_PIN = re.compile(
+    r"^(?:\"[^\"]+\"|go|node|shfmt|shellcheck|stylua|hadolint|golangci-lint"
+    r"|terraform-ls|tflint|[A-Z0-9_]+(?:VERSION|TOOLCHAIN)) = \"",
+    re.MULTILINE,
+)
 
 
 def edited_text(ti):
@@ -46,6 +55,9 @@ blocked = ""
 if file_path.endswith(DOCKERFILE_SUFFIX):
     if ARG_PIN.search(edited_text(ti)):
         blocked = "nvim.dockerfile の ARG ピン留めバージョン行"
+elif file_path.endswith(MISE_TOML_SUFFIX):
+    if MISE_PIN.search(edited_text(ti)):
+        blocked = "mise.toml の [tools]/[env] ピン留めバージョン行"
 elif any(file_path.endswith(m) for m in PIN_MANIFESTS):
     blocked = "%s（ツールバージョンのピン留めマニフェスト）" % os.path.basename(file_path)
 
@@ -55,6 +67,7 @@ if blocked:
     sys.stderr.write(
         "[guard-version-pins] ブロック: %s を手動編集しようとしています。\n"
         "ピン留めされたツールバージョンは手動で変更しないでください。更新は次のいずれか経由で行ってください:\n"
+        "  - mise use --pin <tool>@<version> （mise.toml の [tools]、Bash 経由）\n"
         "  - environment/tools/go/update-go-tools.sh （Go ツール）\n"
         "  - .github/workflows/bump-tool-versions.yml （Node/Go/Neovim/Rust/npm の週次自動更新）\n"
         % blocked

--- a/.claude/rules/dockerfile-versions.md
+++ b/.claude/rules/dockerfile-versions.md
@@ -1,11 +1,13 @@
 ---
 paths:
+  - "mise.toml"
   - "environment/docker/nvim.dockerfile"
   - "environment/tools/**"
 ---
 
-# Dockerfile / toolchain version rules
+# Toolchain version rules
 
-- Keep `ARG` lines in `environment/docker/nvim.dockerfile` unindented and single-line; CI automation (`bump-tool-versions.yml`) edits them by pattern.
-- Do NOT manually bump pinned tool versions. Update via the version-bump workflows or `environment/tools/go/update-go-tools.sh`. This is enforced deterministically by the `guard-version-pins.sh` PreToolUse hook (`.claude/settings.json`), which blocks edits to `ARG *_VERSION=`/`*_TOOLCHAIN=` lines and to the pin manifests `environment/tools/go/go-tools.txt` and `environment/tools/node/package.json`.
+- `mise.toml` at the repo root is the source of truth for tool versions: host tools in `[tools]`, Docker-only versions (Neovim/npm/Rust/Terraform) in `[env]`.
+- The `ARG` defaults in `environment/docker/nvim.dockerfile` are frozen fallbacks; `mise run docker:build` overrides them via `--build-arg`. Keep `ARG` lines unindented and single-line.
+- Do NOT manually bump pinned tool versions. Update via `mise use --pin <tool>@<version>` (Bash), the version-bump workflows, or `environment/tools/go/update-go-tools.sh`. This is enforced deterministically by the `guard-version-pins.sh` PreToolUse hook (`.claude/settings.json`), which blocks Edit/Write on `mise.toml` `[tools]`/`[env]` pin lines, `ARG *_VERSION=`/`*_TOOLCHAIN=` lines, and the pin manifests `environment/tools/go/go-tools.txt` and `environment/tools/node/package.json`.
 - Rebuild the image after changing tool versions or `environment/tools/node/package.json`.

--- a/.github/workflows/lint_ai_bridge.yml
+++ b/.github/workflows/lint_ai_bridge.yml
@@ -6,38 +6,23 @@ on:
   pull_request:
     paths:
       - "scripts/ai-bridge/**"
+      - mise.toml
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: scripts/ai-bridge
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: scripts/ai-bridge/go.mod
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify generated mocks are up to date
         run: |
-          go generate ./...
-          git diff --exit-code -- .
+          mise run ai-bridge:generate
+          git diff --exit-code -- scripts/ai-bridge
 
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
-
-      - name: Check goimports formatting
-        run: |
-          diff=$(find . -name '*.go' -not -path './internal/usecase/port/mock/*' -exec goimports -d {} +)
-          if [ -n "$diff" ]; then
-            echo "$diff"
-            exit 1
-          fi
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          working-directory: scripts/ai-bridge
+      - name: Run lint
+        run: mise run ai-bridge:lint

--- a/.github/workflows/lint_config_diff.yml
+++ b/.github/workflows/lint_config_diff.yml
@@ -1,17 +1,15 @@
-name: Lint Dockerfile
+name: Lint config-diff
 permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
-      - environment/docker/nvim.dockerfile
-      - .github/workflows/lint_dockerfile.yml
-      - .hadolint.yml
+      - "scripts/config-diff/**"
       - mise.toml
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,5 +19,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run hadolint
-        run: mise run lint:docker
+      - name: Run lint
+        run: mise run config-diff:lint

--- a/.github/workflows/lint_format.yml
+++ b/.github/workflows/lint_format.yml
@@ -11,27 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "25"
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Node tools
-        run: npm --prefix environment/tools/node install
-
-      - name: Run tombi lint
-        run: |
-          export PATH="$PWD/environment/tools/node/node_modules/.bin:$PATH"
-          tombi lint
-
-      - name: Run Prettier check
-        run: |
-          export PATH="$PWD/environment/tools/node/node_modules/.bin:$PATH"
-          prettier --check .
-
-      - name: Run markdownlint-cli2
-        shell: bash
-        run: |
-          export PATH="$PWD/environment/tools/node/node_modules/.bin:$PATH"
-          shopt -s globstar
-          markdownlint-cli2 **/*.md
+      - name: Run tombi, prettier, and markdownlint
+        run: mise run lint:format

--- a/.github/workflows/lint_go_verify.yml
+++ b/.github/workflows/lint_go_verify.yml
@@ -1,17 +1,15 @@
-name: Lint Dockerfile
+name: Lint go-verify
 permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
-      - environment/docker/nvim.dockerfile
-      - .github/workflows/lint_dockerfile.yml
-      - .hadolint.yml
+      - "scripts/go-verify/**"
       - mise.toml
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,5 +19,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run hadolint
-        run: mise run lint:docker
+      - name: Run lint
+        run: mise run go-verify:lint

--- a/.github/workflows/lint_nvim_sync.yml
+++ b/.github/workflows/lint_nvim_sync.yml
@@ -6,33 +6,18 @@ on:
   pull_request:
     paths:
       - "scripts/nvim-sync/**"
+      - mise.toml
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: scripts/nvim-sync
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: scripts/nvim-sync/go.mod
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
-
-      - name: Check goimports formatting
-        run: |
-          diff=$(find . -name '*.go' -exec goimports -d {} +)
-          if [ -n "$diff" ]; then
-            echo "$diff"
-            exit 1
-          fi
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          working-directory: scripts/nvim-sync
+      - name: Run lint
+        run: mise run nvim-sync:lint

--- a/.github/workflows/lint_shell.yml
+++ b/.github/workflows/lint_shell.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "**/*.sh"
       - .github/workflows/lint_shell.yml
+      - mise.toml
 
 jobs:
   shell-lint:
@@ -14,15 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install shfmt
-        run: |
-          go install mvdan.cc/sh/v3/cmd/shfmt@latest
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run shfmt
-        run: shfmt -d .
-
-      - name: Run shellcheck
-        run: |
-          shopt -s globstar
-          shellcheck ./**/*.sh
+      - name: Run shfmt and shellcheck
+        run: mise run lint:shell

--- a/.github/workflows/lint_stylua.yml
+++ b/.github/workflows/lint_stylua.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "**/*.lua"
       - .github/workflows/lint_stylua.yml
+      - mise.toml
 
 jobs:
   lint:
@@ -14,11 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Install stylua
-        run: cargo install stylua
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run stylua check
-        run: stylua --check .
+        run: mise run lint:stylua

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Build image
-        run: |
-          docker build \
-            --file environment/docker/nvim.dockerfile \
-            --progress=plain \
-            .
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image with versions from mise.toml
+        run: mise run docker:build

--- a/.github/workflows/test_ai_bridge.yml
+++ b/.github/workflows/test_ai_bridge.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: scripts/ai-bridge/go.mod
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with coverage
         run: go test $(go list ./... | grep -Ev '/mock$|/cmd/') -v -count=1 -coverprofile=coverage.out

--- a/.github/workflows/test_config_diff.yml
+++ b/.github/workflows/test_config_diff.yml
@@ -1,17 +1,15 @@
-name: Lint Dockerfile
+name: Test config-diff
 permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
-      - environment/docker/nvim.dockerfile
-      - .github/workflows/lint_dockerfile.yml
-      - .hadolint.yml
+      - "scripts/config-diff/**"
       - mise.toml
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,5 +19,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run hadolint
-        run: mise run lint:docker
+      - name: Run tests
+        run: mise run config-diff:test

--- a/.github/workflows/test_go_verify.yml
+++ b/.github/workflows/test_go_verify.yml
@@ -1,17 +1,15 @@
-name: Lint Dockerfile
+name: Test go-verify
 permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
-      - environment/docker/nvim.dockerfile
-      - .github/workflows/lint_dockerfile.yml
-      - .hadolint.yml
+      - "scripts/go-verify/**"
       - mise.toml
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,5 +19,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run hadolint
-        run: mise run lint:docker
+      - name: Run tests
+        run: mise run go-verify:test

--- a/.github/workflows/test_nvim_sync.yml
+++ b/.github/workflows/test_nvim_sync.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: scripts/nvim-sync/go.mod
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with coverage
         run: go test ./... -v -count=1 -coverprofile=coverage.out

--- a/environment/docker/nvim.dockerfile
+++ b/environment/docker/nvim.dockerfile
@@ -1,4 +1,8 @@
 ####################
+# Version pins: mise.toml at the repo root is the source of truth.
+# `mise run docker:build` injects every *_VERSION/*_TOOLCHAIN value via
+# --build-arg; the ARG defaults below are frozen fallbacks for direct builds.
+####################
 # Base image with common dependencies and Japanese fonts
 FROM ubuntu:26.04 AS base
 

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,13 @@ stylua = "2.5.2"
 hadolint = "2.14.0"
 "go:golang.org/x/tools/cmd/goimports" = "0.36.0"
 
+# Docker-only versions, injected as --build-arg by `mise run docker:build`.
+[env]
+NEOVIM_VERSION = "0.12.3"
+NPM_VERSION = "11.17.0"
+RUST_TOOLCHAIN = "stable"
+TERRAFORM_VERSION = "1.15.7"
+
 # ---- ai-bridge (Go) ----
 
 [tasks."ai-bridge:build"]
@@ -322,4 +329,50 @@ description = "Remove the ~/.config/wezterm symlink"
 run = '''
 rm -f "$HOME/.config/wezterm"
 echo "Unlinked $HOME/.config/wezterm"
+'''
+
+# ---- Repo-wide lint (CI parity) ----
+
+[tasks."lint:shell"]
+description = "Run shfmt and shellcheck on all shell scripts"
+run = [
+  "find . -name '*.sh' -not -path './.git/*' -not -path '*/node_modules/*' -exec shfmt -d {} +",
+  "find . -name '*.sh' -not -path './.git/*' -not -path '*/node_modules/*' -exec shellcheck {} +",
+]
+
+[tasks."lint:stylua"]
+description = "Run stylua check on all Lua files"
+run = "stylua --check ."
+
+[tasks."lint:docker"]
+description = "Run hadolint on the nvim Dockerfile"
+run = "hadolint environment/docker/nvim.dockerfile"
+
+[tasks."lint:format"]
+description = "Run tombi, prettier, and markdownlint via environment/tools/node"
+dir = "{{config_root}}"
+run = '''
+npm --prefix environment/tools/node install
+export PATH="$PWD/environment/tools/node/node_modules/.bin:$PATH"
+tombi lint
+prettier --check .
+markdownlint-cli2 "**/*.md"
+'''
+
+# ---- Docker ----
+
+[tasks."docker:build"]
+description = "Build the nvim image with versions injected from mise.toml"
+run = '''
+GO_VERSION="$(go env GOVERSION | sed 's/^go//')"
+NODE_VERSION="$(node --version | sed 's/^v//')"
+docker build \
+  --file environment/docker/nvim.dockerfile \
+  --build-arg GO_VERSION="$GO_VERSION" \
+  --build-arg NODE_VERSION="$NODE_VERSION" \
+  --build-arg NEOVIM_VERSION="$NEOVIM_VERSION" \
+  --build-arg NPM_VERSION="$NPM_VERSION" \
+  --build-arg RUST_TOOLCHAIN="$RUST_TOOLCHAIN" \
+  --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION" \
+  --progress=plain .
 '''


### PR DESCRIPTION
## 実装経緯の説明

mise 一元化の Phase 2(#486 の上に積んだ stacked PR。#486 マージ後に base が main に切り替わる)。CI とローカルで同じ mise タスクを実行し、バージョン参照を `mise.toml` に一本化する。

## 補足

### 主な変更内容

- 全ワークフローを `jdx/mise-action`(v4.2.0、SHA ピン、`GITHUB_TOKEN` 付与)+ `mise run <task>` に統一。setup-go / setup-node / rust-toolchain + `cargo install stylua` / hadolint-action / golangci-lint-action / `goimports@latest` を廃止
- **CI 未カバーだった config-diff / go-verify の test / lint ワークフローを新設**(4本)
- `mise.toml` に `lint:shell` / `lint:stylua` / `lint:format` / `lint:docker` / `docker:build` タスクと `[env]`(NEOVIM / NPM / RUST / TERRAFORM)を追加
- `docker:build` は GO / NODE を mise toolchain から導出し、`[env]` と合わせて `--build-arg` で注入。Dockerfile の ARG デフォルトは fallback として凍結(ヘッダコメントで明記)
- `guard-version-pins.sh` が `mise.toml` の `[tools]` / `[env]` ピン行の手動編集をブロック(`[tasks.*]` は許可)。`dockerfile-versions.md` も更新
- 各 lint/test ワークフローの paths に `mise.toml` を追加(タスク定義やピン変更でも CI が回る)

### 技術的な詳細

- `lint:shell` は globstar でなく find ベース(macOS 標準 bash 3.2 に globstar がない + ローカルの node_modules を shfmt が誤検知するため。`.claude/hooks` 等の隠しディレクトリも対象に入りカバレッジ向上)
- goimports / golangci-lint は mise ピン(goimports 0.36.0 / golangci-lint 2.12.2)を使用し、CI の `@latest` 依存を排除
- guard の mise.toml 判定は `key = "..."` 形式(= の両側スペース、tombi スタイル)に限定し、タスク本文内のシェル代入(`GO_VERSION="$(...)"`)への誤反応を回避

### 確認事項

- ローカルで `mise run lint:shell` / `lint:stylua` / `lint:docker` green(`lint:format` は未コミットのローカル WIP を prettier が拾うため local では fail、CI の clean checkout では影響なし)
- guard フック: ピン行編集 → exit 2、タスク編集/タスク本文編集 → exit 0 を確認済み
- `docker:build` の導出値 6 つが既存 ARG と一致することを確認済み。フルビルドは pr-docker-build.yml(bump PR / dependencies ラベル時)で実行
- 本 PR 自体で新 CI が一通り回るはず(mise.toml / workflows / .sh / dockerfile に触れている)

🤖 Generated with [Claude Code](https://claude.com/claude-code)