### PR TITLE
test: config-diff と go-verify のカバレッジを 80% 以上に引き上げ

### DIFF
--- a/scripts/config-diff/cmd/config-diff/main_test.go
+++ b/scripts/config-diff/cmd/config-diff/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"config-diff/internal/diff"
+)
+
+func TestExecute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, src, dest string)
+		args       func(src, dest string) []string
+		wantCode   int
+		wantOutput []string
+	}{
+		{
+			name: "all entries ok",
+			setup: func(t *testing.T, src, dest string) {
+				t.Helper()
+				writeFile(t, filepath.Join(src, "a.md"), "alpha")
+				writeFile(t, filepath.Join(dest, "a.md"), "alpha")
+			},
+			args:       func(src, dest string) []string { return []string{"agents", src, dest} },
+			wantCode:   0,
+			wantOutput: []string{"ok       a.md"},
+		},
+		{
+			name: "drift exits 1 with note",
+			setup: func(t *testing.T, src, dest string) {
+				t.Helper()
+				writeFile(t, filepath.Join(src, "a.md"), "v1")
+				writeFile(t, filepath.Join(dest, "a.md"), "v2")
+			},
+			args:       func(src, dest string) []string { return []string{"agents", src, dest} },
+			wantCode:   1,
+			wantOutput: []string{"drift    a.md", "content differs"},
+		},
+		{
+			name: "missing exits 1",
+			setup: func(t *testing.T, src, dest string) {
+				t.Helper()
+				writeFile(t, filepath.Join(src, "a.md"), "alpha")
+			},
+			args:       func(src, dest string) []string { return []string{"agents", src, dest} },
+			wantCode:   1,
+			wantOutput: []string{"missing  a.md"},
+		},
+		{
+			name:       "wrong arg count exits 2 with usage",
+			setup:      func(_ *testing.T, _, _ string) {},
+			args:       func(_, _ string) []string { return []string{"agents", "only-two"} },
+			wantCode:   2,
+			wantOutput: []string{"Usage: config-diff <mode> <src> <dest>"},
+		},
+		{
+			name:  "classify error exits 2",
+			setup: func(_ *testing.T, _, _ string) {},
+			args: func(src, dest string) []string {
+				return []string{"agents", filepath.Join(src, "does-not-exist"), dest}
+			},
+			wantCode:   2,
+			wantOutput: []string{"config-diff:", "source directory not found"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := t.TempDir()
+			dest := t.TempDir()
+			tt.setup(t, src, dest)
+
+			var out bytes.Buffer
+			code := execute(tt.args(src, dest), &out)
+			if code != tt.wantCode {
+				t.Fatalf("execute code = %d, want %d (output: %q)", code, tt.wantCode, out.String())
+			}
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("execute output = %q, want it to contain %q", out.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteSummary(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		entries []diff.Entry
+		want    string
+	}{
+		{
+			name:    "no entries",
+			entries: nil,
+			want:    "agents -> /dest\n  (no entries)\n",
+		},
+		{
+			name:    "ok entry",
+			entries: []diff.Entry{{Label: "a.md", State: diff.StateOK}},
+			want:    "agents -> /dest\n  ok       a.md\n",
+		},
+		{
+			name:    "drift entry with note",
+			entries: []diff.Entry{{Label: "s", State: diff.StateDrift, Note: "drift: SKILL.md"}},
+			want:    "agents -> /dest\n  drift    s\n           drift: SKILL.md\n",
+		},
+		{
+			name:    "drift entry without note",
+			entries: []diff.Entry{{Label: "a.md", State: diff.StateDrift}},
+			want:    "agents -> /dest\n  drift    a.md\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			writeSummary(&out, "agents", "/dest", tt.entries)
+			if out.String() != tt.want {
+				t.Fatalf("writeSummary = %q, want %q", out.String(), tt.want)
+			}
+		})
+	}
+}
+
+// writeFile writes content to path, creating parent directories.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), mkErr)
+	}
+	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("WriteFile %s: %v", path, writeErr)
+	}
+}

--- a/scripts/config-diff/internal/diff/diff_test.go
+++ b/scripts/config-diff/internal/diff/diff_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -147,6 +148,148 @@ func TestClassifyMissingSource(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
 	if _, err := Classify("agents", missing, t.TempDir()); err == nil {
 		t.Fatal("Classify with missing source: want error, got nil")
+	}
+}
+
+func TestClassifyTargetIsDirectory(t *testing.T) {
+	t.Parallel()
+	// Deployed target is a directory where a file is expected: comparing the
+	// content must surface a read error instead of misclassifying the entry.
+	src := t.TempDir()
+	dest := t.TempDir()
+	writeFile(t, filepath.Join(src, "a.md"), "alpha")
+	if mkErr := os.MkdirAll(filepath.Join(dest, "a.md"), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	if _, err := Classify("agents", src, dest); err == nil {
+		t.Fatal("Classify with directory target: want error, got nil")
+	}
+}
+
+func TestClassifySkillsDestFileIsDirectory(t *testing.T) {
+	t.Parallel()
+	// Inside a deployed skill, a path that is a file in src but a directory in
+	// dest must surface a read error from the per-file comparison.
+	src := t.TempDir()
+	dest := t.TempDir()
+	writeFile(t, filepath.Join(src, "skill", "SKILL.md"), "v1")
+	if mkErr := os.MkdirAll(filepath.Join(dest, "skill", "SKILL.md"), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	if _, err := Classify("skills", src, dest); err == nil {
+		t.Fatal("Classify with directory in place of a skill file: want error, got nil")
+	}
+}
+
+func TestClassifySourceIsFile(t *testing.T) {
+	t.Parallel()
+	// src exists but is a regular file, so enumerating its children must fail.
+	src := filepath.Join(t.TempDir(), "not-a-dir")
+	writeFile(t, src, "content")
+
+	if _, err := Classify("agents", src, t.TempDir()); err == nil {
+		t.Fatal("Classify with file source: want error, got nil")
+	}
+}
+
+func TestEnumerateErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		fn   func(dir string) error
+	}{
+		{name: "topLevel missing dir", fn: func(dir string) error {
+			_, err := topLevel(dir, func(fs.DirEntry) bool { return true }, false)
+			return err
+		}},
+		{name: "settingsFiles missing dir", fn: func(dir string) error {
+			_, err := settingsFiles(dir)
+			return err
+		}},
+		{name: "relFiles missing dir", fn: func(dir string) error {
+			_, err := relFiles(dir)
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			missing := filepath.Join(t.TempDir(), "does-not-exist")
+			if err := tt.fn(missing); err == nil {
+				t.Fatal("want error for missing directory, got nil")
+			}
+		})
+	}
+}
+
+func TestCompareDirErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		missingSrc  bool
+		missingDest bool
+	}{
+		{name: "missing src", missingSrc: true},
+		{name: "missing dest", missingDest: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := t.TempDir()
+			if tt.missingSrc {
+				src = filepath.Join(src, "does-not-exist")
+			}
+			dest := t.TempDir()
+			if tt.missingDest {
+				dest = filepath.Join(dest, "does-not-exist")
+			}
+
+			if _, err := compareDir(src, dest); err == nil {
+				t.Fatal("compareDir: want error, got nil")
+			}
+		})
+	}
+}
+
+func TestSameFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		contentA string
+		contentB string
+		missingA bool
+		missingB bool
+		want     bool
+		wantErr  bool
+	}{
+		{name: "identical", contentA: "same", contentB: "same", want: true},
+		{name: "different", contentA: "one", contentB: "two", want: false},
+		{name: "first missing", missingA: true, contentB: "b", wantErr: true},
+		{name: "second missing", contentA: "a", missingB: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			pathA := filepath.Join(dir, "a")
+			pathB := filepath.Join(dir, "b")
+			if !tt.missingA {
+				writeFile(t, pathA, tt.contentA)
+			}
+			if !tt.missingB {
+				writeFile(t, pathB, tt.contentB)
+			}
+
+			got, err := sameFile(pathA, pathB)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("sameFile err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("sameFile = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/scripts/go-verify/cmd/go-verify/main.go
+++ b/scripts/go-verify/cmd/go-verify/main.go
@@ -23,12 +23,13 @@ func main() {
 	mod := flag.String("mod", "", "only verify modules whose path contains this substring")
 	flag.Parse()
 
-	os.Exit(execute(*root, *only, *mod, os.Stdout))
+	os.Exit(execute(*root, *only, *mod, defaultRunner, os.Stdout))
 }
 
 // execute runs the verification and writes a summary to out, returning the
 // process exit code (0 = all passed, 1 = a check failed, 2 = usage/setup error).
-func execute(root, only, mod string, out io.Writer) int {
+// Commands are executed through run so tests can stub the toolchain.
+func execute(root, only, mod string, run runner.Runner, out io.Writer) int {
 	names, selErr := runner.SelectChecks(only)
 	if selErr != nil {
 		_, _ = fmt.Fprintln(out, "go-verify:", selErr)
@@ -40,7 +41,7 @@ func execute(root, only, mod string, out io.Writer) int {
 		filter = []string{mod}
 	}
 
-	checks, verifyErr := runner.VerifyAll(root, defaultRunner, names, filter)
+	checks, verifyErr := runner.VerifyAll(root, run, names, filter)
 	if verifyErr != nil {
 		_, _ = fmt.Fprintln(out, "go-verify:", verifyErr)
 		return 2

--- a/scripts/go-verify/cmd/go-verify/main_test.go
+++ b/scripts/go-verify/cmd/go-verify/main_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go-verify/internal/runner"
+)
+
+// passRunner is a stub Runner where every check succeeds.
+func passRunner(_, _ string, _ ...string) ([]byte, error) {
+	return []byte(""), nil
+}
+
+// failRunner is a stub Runner where golangci-lint fails with output.
+func failRunner(_, name string, _ ...string) ([]byte, error) {
+	if name == "golangci-lint" {
+		return []byte("pkg.go:1: issue"), errors.New("exit 1")
+	}
+	return []byte(""), nil
+}
+
+func TestExecute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		modules    []string
+		only       string
+		mod        string
+		run        runner.Runner
+		rootFn     func(root string) string // overrides the module root when set
+		wantCode   int
+		wantOutput []string
+	}{
+		{
+			name:       "all checks pass",
+			modules:    []string{"a"},
+			run:        passRunner,
+			wantCode:   0,
+			wantOutput: []string{"PASS  goimports", "PASS  golangci-lint", "PASS  go test"},
+		},
+		{
+			name:       "check failure exits 1 with indented detail",
+			modules:    []string{"a"},
+			run:        failRunner,
+			wantCode:   1,
+			wantOutput: []string{"FAIL  golangci-lint", "  pkg.go:1: issue"},
+		},
+		{
+			name:       "mod filter narrows modules",
+			modules:    []string{"alpha", "beta"},
+			only:       "test",
+			mod:        "beta",
+			run:        passRunner,
+			wantCode:   0,
+			wantOutput: []string{"PASS  go test        beta"},
+		},
+		{
+			name:       "unknown only value exits 2",
+			modules:    []string{"a"},
+			only:       "bogus",
+			run:        passRunner,
+			wantCode:   2,
+			wantOutput: []string{"unknown -only value"},
+		},
+		{
+			name:       "no modules found exits 2",
+			modules:    nil,
+			run:        passRunner,
+			wantCode:   2,
+			wantOutput: []string{"no Go modules found"},
+		},
+		{
+			name:     "discover error exits 2",
+			modules:  nil,
+			run:      passRunner,
+			rootFn:   func(root string) string { return filepath.Join(root, "does-not-exist") },
+			wantCode: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeModules(t, root, tt.modules)
+			if tt.rootFn != nil {
+				root = tt.rootFn(root)
+			}
+
+			var out bytes.Buffer
+			code := execute(root, tt.only, tt.mod, tt.run, &out)
+			if code != tt.wantCode {
+				t.Fatalf("execute code = %d, want %d (output: %q)", code, tt.wantCode, out.String())
+			}
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("execute output = %q, want it to contain %q", out.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteFilteredModuleDoesNotFail(t *testing.T) {
+	t.Parallel()
+	// A failure in a filtered-out module must not affect the exit code.
+	root := t.TempDir()
+	writeModules(t, root, []string{"alpha", "beta"})
+	run := func(dir, _ string, _ ...string) ([]byte, error) {
+		if filepath.Base(dir) == "alpha" {
+			return []byte("broken"), errors.New("exit 1")
+		}
+		return []byte(""), nil
+	}
+
+	var out bytes.Buffer
+	code := execute(root, "", "beta", run, &out)
+	if code != 0 {
+		t.Fatalf("execute code = %d, want 0 (alpha is filtered out; output: %q)", code, out.String())
+	}
+}
+
+func TestWriteSummary(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		checks []runner.Check
+		want   string
+	}{
+		{
+			name:   "pass line",
+			checks: []runner.Check{{Mod: "a", Name: "go test", OK: true}},
+			want:   "PASS  go test        a\n",
+		},
+		{
+			name:   "fail line with detail",
+			checks: []runner.Check{{Mod: "a", Name: "goimports", OK: false, Output: "x.go\ny.go"}},
+			want:   "FAIL  goimports      a\n  x.go\n  y.go\n",
+		},
+		{
+			name:   "fail line without detail",
+			checks: []runner.Check{{Mod: "a", Name: "go test", OK: false}},
+			want:   "FAIL  go test        a\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			writeSummary(&out, tt.checks)
+			if out.String() != tt.want {
+				t.Fatalf("writeSummary = %q, want %q", out.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestIndent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single line", in: "a", want: "  a"},
+		{name: "multi line", in: "a\nb", want: "  a\n  b"},
+		{name: "empty", in: "", want: "  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := indent(tt.in); got != tt.want {
+				t.Fatalf("indent(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRunner(t *testing.T) {
+	t.Parallel()
+	// go is guaranteed to exist because it is running this test.
+	out, runErr := defaultRunner(t.TempDir(), "go", "version")
+	if runErr != nil {
+		t.Fatalf("defaultRunner(go version): %v", runErr)
+	}
+	if !strings.Contains(string(out), "go version") {
+		t.Fatalf("defaultRunner output = %q, want it to contain %q", out, "go version")
+	}
+
+	if _, missErr := defaultRunner(t.TempDir(), "go-verify-no-such-command"); missErr == nil {
+		t.Fatal("defaultRunner with missing command: want error, got nil")
+	}
+}
+
+// writeModules creates a go.mod under each relative path below root.
+func writeModules(t *testing.T, root string, rels []string) {
+	t.Helper()
+	for _, rel := range rels {
+		dir := filepath.Join(root, rel)
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			t.Fatalf("MkdirAll %s: %v", dir, mkErr)
+		}
+		mod := filepath.Join(dir, "go.mod")
+		if writeErr := os.WriteFile(mod, []byte("module x\n\ngo 1.26\n"), 0o644); writeErr != nil {
+			t.Fatalf("WriteFile %s: %v", mod, writeErr)
+		}
+	}
+}

--- a/scripts/go-verify/internal/runner/runner_test.go
+++ b/scripts/go-verify/internal/runner/runner_test.go
@@ -63,6 +63,14 @@ func TestDiscover(t *testing.T) {
 	}
 }
 
+func TestDiscoverMissingRoot(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := Discover(missing); err == nil {
+		t.Fatal("Discover with missing root: want error, got nil")
+	}
+}
+
 func TestRunCheck(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -146,6 +154,81 @@ func TestVerifyAllModFilter(t *testing.T) {
 	}
 	if checks[0].Mod != "b" {
 		t.Fatalf("filtered check Mod = %q, want %q", checks[0].Mod, "b")
+	}
+}
+
+func TestVerifyAllMissingRoot(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	run := func(_, _ string, _ ...string) ([]byte, error) { return []byte(""), nil }
+	if _, err := VerifyAll(missing, run, []string{"goimports"}, nil); err == nil {
+		t.Fatal("VerifyAll with missing root: want error, got nil")
+	}
+}
+
+func TestAnyFailed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		checks []Check
+		want   bool
+	}{
+		{name: "all ok", checks: []Check{{OK: true}, {OK: true}}, want: false},
+		{name: "one failed", checks: []Check{{OK: true}, {OK: false}}, want: true},
+		{name: "empty", checks: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AnyFailed(tt.checks); got != tt.want {
+				t.Fatalf("AnyFailed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelLabel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		root string
+		mod  string
+		want string
+	}{
+		{name: "nested module", root: "/r", mod: "/r/a/b", want: filepath.Join("a", "b")},
+		{name: "root itself is the module", root: "/r/mod", mod: "/r/mod", want: "mod"},
+		{name: "unrelatable paths fall back to mod", root: "r", mod: "/abs/mod", want: "/abs/mod"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := relLabel(tt.root, tt.mod); got != tt.want {
+				t.Fatalf("relLabel(%q, %q) = %q, want %q", tt.root, tt.mod, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		output string
+		cmdErr error
+		want   string
+	}{
+		{name: "output and error", output: "bad", cmdErr: errors.New("exit 1"), want: "bad\nexit 1"},
+		{name: "output only", output: "bad", want: "bad"},
+		{name: "error only", cmdErr: errors.New("exit 1"), want: "exit 1"},
+		{name: "neither", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := detail(tt.output, tt.cmdErr); got != tt.want {
+				t.Fatalf("detail(%q, %v) = %q, want %q", tt.output, tt.cmdErr, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 実装経緯の説明

#492 で全 Go モジュールにカバレッジ PR コメントが付くようになり、config-diff が 73.2%、go-verify が 57.1% と目標の 80% を下回っていることが可視化された。未カバー領域をテーブルテスト（`t.Parallel()` 付き）で網羅し、両モジュールとも 80% 以上に引き上げる。

## 補足

### 主な変更内容

- go-verify: `cmd/go-verify/main_test.go` を新規追加し、`internal/runner` のテストにエラー枝のケースを追加。カバレッジ **57.1% → 95.2%**（runner パッケージは 100%）
- config-diff: `cmd/config-diff/main_test.go` を新規追加し、`internal/diff` のテストにエラー枝のケースを追加。カバレッジ **73.2% → 96.6%**

### 技術的な詳細

- go-verify の `execute` が実コマンド実行の `defaultRunner` をハードコードしていたため cmd パッケージがテスト不能（0%）だった。`runner.Runner` を引数で注入する形にリファクタ（`main` から `defaultRunner` を渡す）。プロダクションの挙動変更はなし
- `execute` は exit code 0（全パス）/ 1（チェック失敗、インデント付き詳細出力）/ 2（不正な `-only`・モジュール未発見・discover 失敗）の全経路と `-mod` フィルタ（除外モジュールの失敗が exit code に影響しないこと）を検証
- config-diff の `internal/diff` エラー枝は「配置先に同名ディレクトリが存在する」「src が通常ファイル」などの実シナリオで公開 API（`Classify`）経由のテストを優先し、届かない枝（`compareDir` / `settingsFiles` / `relFiles` / `sameFile` の欠落パス）のみ非公開関数を直接テスト
- 未カバーで残るのは両モジュールの `main()` と、WalkDir コールバック内の `filepath.Rel` エラー枝（実質到達不能）のみ

### 確認事項

- CI のカバレッジコメントで config-diff / go-verify がともに 80% 超になっていること
- `mise run config-diff:lint` / `go-verify:lint`（golangci-lint 0 issues / goimports 差分なし）、`config-diff:test` / `go-verify:test` はローカルで通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)