### PR TITLE
feat: Claude Code の自動運転設定を追加

### DIFF
--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -1,5 +1,10 @@
 {
+  "model": "claude-fable-5[1m]",
+  "env": {
+    "SKILL_OBSERVE_HOME": "~/workspace/my-pde"
+  },
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(actionlint:*)",
       "Bash(docker compose:*)",
@@ -17,6 +22,7 @@
       "Bash(ls:*)",
       "Bash(make:*)",
       "Bash(markdownlint-cli2:*)",
+      "Bash(mise:*)",
       "Bash(npm run lint)",
       "Bash(npm run test *)",
       "Bash(npx markdownlint-cli2:*)",
@@ -53,10 +59,6 @@
       "Read(**/*.key)",
       "Read(**/*.pem)"
     ]
-  },
-  "model": "opus",
-  "env": {
-    "SKILL_OBSERVE_HOME": "~/workspace/my-pde"
   },
   "hooks": {
     "PreToolUse": [
@@ -130,6 +132,20 @@
       }
     ]
   },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.githubusercontent.com",
+        "proxy.golang.org",
+        "sum.golang.org",
+        "registry.npmjs.org"
+      ]
+    }
+  },
+  "askUserQuestionTimeout": "5m",
   "statusLine": {
     "type": "command",
     "command": "jq -r '(.model.display_name // \"Claude\") + \" | Context: \" + (.context_window.used_percentage // 0 | tostring) + \"% used\"'"


### PR DESCRIPTION
## 実装経緯の説明

Claude Code での作業中、ファイル編集や Bash コマンドの承認プロンプトで頻繁に手が止まるため、安全性を保ちつつ自律的に動ける設定を settings.json に追加した。

## 補足

### 主な変更内容

- `permissions.defaultMode: "acceptEdits"` を設定し、プロジェクト内のファイル編集を自動承認にした
- `sandbox` を有効化し、`autoAllowBashIfSandboxed: true` でサンドボックス内の Bash コマンドを自動許可にした
- `askUserQuestionTimeout: "5m"` を設定し、AskUserQuestion で止まったままでも 5 分で自動続行するようにした

### 技術的な詳細

- サンドボックスのネットワークは `allowedDomains` で github.com / *.githubusercontent.com / proxy.golang.org / sum.golang.org / registry.npmjs.org のみに制限
- 既存の allow/deny リストと `guard-dangerous-bash.sh` PreToolUse フックはそのまま維持しており、危険コマンドの守りは変わらない
- jq による構文チェックと prettier --check は通過済み

### 確認事項

デプロイ後や動作確認時のチェックポイント

- `/deploy-ai-config` で `~/.claude/settings.json` へ反映すること
- サンドボックスのネットワーク制限で `go test` や `npm install` 等が失敗する場合は `sandbox.network.allowedDomains` にドメインを追記する

🤖 Generated with [Claude Code](https://claude.com/claude-code)