### PR TITLE
feat: 自律改善パイプラインを拡張する

### DIFF
--- a/.claude/rules/routines.md
+++ b/.claude/rules/routines.md
@@ -1,10 +1,11 @@
 ---
 paths:
-  - "routines/*.json"
+  - "routines/**"
 ---
 
 # Cloud routine rules
 
-- Routine JSON definitions in `routines/` are the source of truth.
-- Changing a routine requires PR review, then a manual `/schedule` update to apply it; there is no CI auto-apply.
+- Routine definitions in `routines/` are the source of truth; prompt bodies live in `routines/prompts/<name>.md` and the JSON `prompt` is a thin pointer to that file.
+- Prompt body changes (`routines/prompts/*.md`) take effect on the next run once merged — no apply needed.
+- Changing JSON-side fields (cron, model, allowed_tools, the pointer prompt itself) requires PR review, then a manual `/schedule` update; there is no CI auto-apply.
 - Keep cron schedules in UTC and note the JST equivalent in the description.

--- a/.github/workflows/pipeline-digest.yml
+++ b/.github/workflows/pipeline-digest.yml
@@ -1,0 +1,81 @@
+name: Pipeline digest
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    - cron: "0 22 * * 5" # 金 22:00 UTC = 毎週土曜 7:00 JST
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Build and publish digest issue
+        run: |
+          set -euo pipefail
+
+          open_issues=$(gh issue list --state open --limit 200 --json number,title,labels,createdAt)
+
+          triage=$(jq -r '
+            .[]
+            | select(any(.labels[].name; startswith("scan:"))
+                and all(.labels[].name; . != "adopted" and . != "rejected"))
+            | "- #\(.number) \(.title)（\((now - (.createdAt | fromdate)) / 86400 | floor) 日経過）"
+          ' <<<"$open_issues")
+
+          adopted_queue=$(jq -r '
+            .[]
+            | select(any(.labels[].name; . == "adopted")
+                and all(.labels[].name; . != "pr-created"))
+            | "- #\(.number) \(.title)"
+          ' <<<"$open_issues")
+
+          stale=$(jq -r '
+            .[]
+            | select(any(.labels[].name; startswith("scan:"))
+                and ((now - (.createdAt | fromdate)) / 86400 >= 14))
+            | "- #\(.number) \(.title)（\((now - (.createdAt | fromdate)) / 86400 | floor) 日経過）"
+          ' <<<"$open_issues")
+
+          auto_prs=$(gh pr list --state open --limit 50 --json number,title,headRefName,statusCheckRollup \
+            | jq -r '
+              .[]
+              | select(.headRefName | startswith("auto/"))
+              | ([.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .state == "FAILURE")] | length) as $fails
+              | "- #\(.number) \(.title)" + (if $fails > 0 then "（CI 失敗 \($fails) 件）" else "" end)
+            ')
+
+          {
+            echo "自律改善パイプラインの週次ダイジェスト（$(date -u +%Y-%m-%d) UTC 時点）。\`pipeline-digest.yml\` がこの Issue の body を毎週上書き更新する。"
+            echo
+            echo "## Triage 待ちの scan Issue（adopted / rejected 未判定）"
+            echo
+            echo "${triage:-なし}"
+            echo
+            echo "## PR 化待ちの adopted Issue（pr-created 未付与）"
+            echo
+            echo "${adopted_queue:-なし}"
+            echo
+            echo "## Open な auto/* PR"
+            echo
+            echo "${auto_prs:-なし}"
+            echo
+            echo "## 14 日以上 Open のままの scan Issue"
+            echo
+            echo "${stale:-なし}"
+          } > body.md
+
+          gh label create digest --description "Auto-updated pipeline digest" --color BFD4F2 || true
+
+          num=$(gh issue list --state open --label digest --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            gh issue edit "$num" --body-file body.md
+          else
+            gh issue create --title "Pipeline digest" --label digest --body-file body.md
+          fi

--- a/docs/plan/2026-07-04_routines-pipeline-expansion.md
+++ b/docs/plan/2026-07-04_routines-pipeline-expansion.md
@@ -1,0 +1,71 @@
+# Plan: 自律改善パイプライン（routines/）の拡張
+
+自律改善ループ（スキャン → Issue 起票 → 人が adopted/rejected → PR Bot → 人がマージ）を 4 つの柱で拡張する: (1) プロンプトの間接参照化で手動 apply をほぼ撤廃、(2) auto PR をケアする Routine の追加、(3) 運用実績からプロンプトを改善するメタループ、(4) スキャン対象の追加（CI workflows / environment・dotfiles）。あわせて LLM 不要の定型処理（滞留の可視化）は素の GitHub Actions に切り出す。
+
+## Background
+
+- 既存ループは健全に回っている（直近 scan Issue の採用率 ~95%、`auto/*` PR 16 件中 14 件マージ）が、次のギャップがある。
+  1. プロンプト変更のたびに手動 `/schedule` apply が必要（`routines/README.md` の既知 TODO）。
+  2. PR 作成後のケア（CI 失敗・コンフリクト・レビューコメント対応）が全部手動。
+  3. rejected や未マージ close の教訓がプロンプトに還元されない（skills の observe → improve に相当する仕組みが routines に無い）。
+  4. `.github/workflows/` と `environment/`・`dotfiles/` がスキャンの空白地帯。
+  5. triage 待ち・滞留 adopted・Open な auto PR が一覧できない。
+- triage ゲート（人手の `adopted` 付与）は現状維持とする。採用率は高いが、無駄打ち実装（rejected 後 PR）は稀で許容範囲のため安全側を取る。
+
+## Current structure
+
+- `routines/*.json` — Routine 定義（source of truth）。`prompt` は配列で全文を持ち、変更のたびに `/schedule` Update で手動反映していた。
+- スキャン 3 本（daily nvim / weekly scripts / weekly devx）+ `Weekly Adopted-Issue PR Bot`。
+- ラベル運用: `scan:*` / `adopted` / `rejected` / `pr-created`。
+
+## Design policy
+
+- **プロンプト間接化**: 指示本文を `routines/prompts/<name>.md` へ移し、JSON の `prompt` は「checkout 済み repo のそのファイルを読んで従え。無ければ何もせず終了」という薄いポインタにする。Routine は実行時に repo を checkout するため、プロンプト変更はマージだけで次回実行から有効になる。手動 apply は JSON 側フィールド（cron / model / allowed_tools / ポインタ文言）の変更時のみに縮小。markdown 化により markdownlint / prettier の検証対象になる副次効果もある。
+- **Weekly PR Care Bot**（月曜 7:00 JST）: Open な `auto/*` PR の CI 失敗修正・コンフリクト解消（merge のみ、rebase / force-push 禁止）・レビューコメント対応を行う。人手 commit が後に積まれた PR はスキップ。ready 化・マージはしない。
+- **Monthly Routine Improve**（毎月 2 日 7:00 JST）: 直近 1 ヶ月の rejected Issue（close コメント＝不採用理由）・未マージ close の auto PR・レビュー指摘を分析し、`routines/prompts/*.md` への最小差分の改善を draft PR（最大 1 件、ラベル `meta:routines`）で提案する。間接化により「マージ＝反映」が成立する。前提として rejected close 時に理由コメントを残す運用を README に明記。
+- **スキャン追加**: `Weekly Environment Scan`（水曜、`scan:environment`、対象 `environment/`・`dotfiles/`・`mise.toml`）と `Weekly CI Workflows Scan`（金曜、`scan:ci`、actionlint を自走して参照）。いずれも既存スキャンと同型（Open + closed rejected の重複排除、最大 1 件起票、コード変更なし）。
+- **Pipeline digest（Routine 以外の方法）**: 決定論的な滞留可視化に LLM は不要なので、`gh` + `jq` だけの GitHub Actions cron（土曜 7:00 JST + `workflow_dispatch`）にする。`digest` ラベルの単一 Issue の body を上書き更新し、Issue を増殖させない。`scan:*` ラベルは付けず、スキャンの重複排除を汚染しない。
+- 週次スケジュールは曜日で分散: 日=PR Bot、月=PR Care、火=scripts、水=environment、木=devx、金=ci、土=digest、毎日=nvim。
+
+## Implementation steps
+
+1. 既存 4 Routine の prompt を `routines/prompts/*.md` へ移設し、JSON をポインタ化（scripts scan の「scripts/ 配下は ai-bridge ただ 1 つ」等の古い記述は現状に合わせて一般化）。
+2. 新規 4 Routine のプロンプト md と JSON（`trigger_id` は空）を追加。
+3. `.github/workflows/pipeline-digest.yml` を追加。
+4. `routines/README.md`（一覧・スキーマ・apply 手順・運用ノート）と `.claude/rules/routines.md` を更新。
+5. マージ後の apply: 既存 4 本を `/schedule` Update でポインタ prompt へ切替（1 回きり）、新規 4 本を `/schedule` Create し、払い出された `trigger_id` を JSON に追記コミット。
+
+## File changes
+
+| File                                                                                                                                  | Change                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `routines/prompts/{daily-neovim-trend-scan,weekly-scripts-tooling-scan,weekly-devx-skills-hooks-scan,weekly-adopted-issue-pr-bot}.md` | 既存 prompt 本文を移設（新規）              |
+| `routines/prompts/{weekly-pr-care-bot,weekly-ci-workflows-scan,weekly-environment-scan,monthly-routine-improve}.md`                   | 新 Routine のプロンプト（新規）             |
+| `routines/{daily-neovim-trend-scan,weekly-scripts-tooling-scan,weekly-devx-skills-hooks-scan,weekly-adopted-issue-pr-bot}.json`       | `prompt` をポインタ化                       |
+| `routines/{weekly-pr-care-bot,weekly-ci-workflows-scan,weekly-environment-scan,monthly-routine-improve}.json`                         | 新規定義（`trigger_id` は Create 後に記録） |
+| `routines/README.md`                                                                                                                  | 一覧・スキーマ・apply 手順・運用ノート更新  |
+| `.claude/rules/routines.md`                                                                                                           | prompt 間接参照のルールを追記               |
+| `.github/workflows/pipeline-digest.yml`                                                                                               | LLM 抜き週次ダイジェスト（新規）            |
+
+## Risks and mitigations
+
+| Risk                                                | Mitigation                                                                            |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| ポインタ prompt で md が読めない（checkout 失敗等） | 「ファイルが無ければ何もせず終了」を JSON 側に明記しフェイルセーフに                  |
+| PR Care Bot が人間の作業中 PR を触る                | 人手 commit が bot より後にある PR はスキップ。rebase / force-push 禁止、merge で解消 |
+| メタループが的外れなプロンプト変更を出す            | 出力は draft PR 止まり（マージ判断は人間）。月 1・最大 1 件・最小差分                 |
+| スキャン増による triage 負荷増                      | digest Issue で滞留を可視化。過多なら cron を隔週化（JSON 編集 + apply のみ）         |
+| digest Issue がスキャンの重複排除を汚染             | `digest` ラベルのみ付与し、`scan:*` は付けない                                        |
+
+## Validation
+
+- [ ] `markdownlint-cli2` / `prettier --check` / `jq` パース / `actionlint` が全て通る
+- [ ] `pipeline-digest.yml` を `workflow_dispatch` で実行し、digest Issue が作成・更新される
+- [ ] apply 後、既存 4 Routine がポインタ prompt で従来どおり動く（実行ログで確認）
+- [ ] 新スキャン 2 本が最大 1 件だけ起票する
+- [ ] PR Care Bot が Open auto PR を正しく処理/スキップする
+- [ ] 月次メタループが根拠付きの draft PR（または「変更なし」報告）を出す
+
+## Open questions
+
+- なし（triage ゲート維持・housekeeping の Actions 化はユーザー決定済み）。

--- a/routines/README.md
+++ b/routines/README.md
@@ -2,46 +2,66 @@
 
 claude.ai のスケジュール Routine（クラウドエージェント / CCR）の定義を、リポジトリで一元管理するためのディレクトリ。**ここを「正（source of truth）」**として扱い、変更は PR レビューを経て反映する。
 
-設計の背景・全体像は [`docs/plan/2026-06-15_autonomous-improvement-scan.md`](../docs/plan/2026-06-15_autonomous-improvement-scan.md) を参照。
+設計の背景・全体像は [`docs/plan/2026-06-15_autonomous-improvement-scan.md`](../docs/plan/2026-06-15_autonomous-improvement-scan.md) と [`docs/plan/2026-07-04_routines-pipeline-expansion.md`](../docs/plan/2026-07-04_routines-pipeline-expansion.md) を参照。
 
 ## 現在の定義
 
-| ファイル                             | 名前                            | スケジュール                     | 役割                                                       |
-| ------------------------------------ | ------------------------------- | -------------------------------- | ---------------------------------------------------------- |
-| `daily-neovim-trend-scan.json`       | `Daily Neovim Trend Scan`       | 毎日 8:00 JST (`0 23 * * *`)     | Neovim 動向を調べ改善を Issue 起票（最大1件）              |
-| `weekly-devx-skills-hooks-scan.json` | `Weekly DevX Skills/Hooks Scan` | 毎週木 7:00 JST (`0 22 * * 3`)   | ai-agents 向け汎用 hooks/skills を Issue 起票（最大1件）   |
-| `weekly-scripts-tooling-scan.json`   | `Weekly Scripts Tooling Scan`   | 毎週火 7:00 JST (`0 22 * * 1`)   | `scripts/` 向け新アプリ/スクリプトを Issue 起票（最大1件） |
-| `weekly-adopted-issue-pr-bot.json`   | `Weekly Adopted-Issue PR Bot`   | 毎週日曜 8:00 JST (`0 23 * * 6`) | `adopted` Issue を実装しドラフト PR を作成                 |
+| ファイル                             | 名前                            | スケジュール                     | 役割                                                         |
+| ------------------------------------ | ------------------------------- | -------------------------------- | ------------------------------------------------------------ |
+| `daily-neovim-trend-scan.json`       | `Daily Neovim Trend Scan`       | 毎日 8:00 JST (`0 23 * * *`)     | Neovim 動向を調べ改善を Issue 起票（最大1件）                |
+| `weekly-adopted-issue-pr-bot.json`   | `Weekly Adopted-Issue PR Bot`   | 毎週日曜 8:00 JST (`0 23 * * 6`) | `adopted` Issue を実装しドラフト PR を作成                   |
+| `weekly-pr-care-bot.json`            | `Weekly PR Care Bot`            | 毎週月曜 7:00 JST (`0 22 * * 0`) | Open な `auto/*` PR の CI 失敗・コンフリクト・レビュー対応   |
+| `weekly-scripts-tooling-scan.json`   | `Weekly Scripts Tooling Scan`   | 毎週火曜 7:00 JST (`0 22 * * 1`) | `scripts/` 向け新アプリ/スクリプトを Issue 起票（最大1件）   |
+| `weekly-environment-scan.json`       | `Weekly Environment Scan`       | 毎週水曜 7:00 JST (`0 22 * * 2`) | `environment/`・`dotfiles/`・`mise.toml` の改善を Issue 起票 |
+| `weekly-devx-skills-hooks-scan.json` | `Weekly DevX Skills/Hooks Scan` | 毎週木曜 7:00 JST (`0 22 * * 3`) | ai-agents 向け汎用 hooks/skills を Issue 起票（最大1件）     |
+| `weekly-ci-workflows-scan.json`      | `Weekly CI Workflows Scan`      | 毎週金曜 7:00 JST (`0 22 * * 4`) | `.github/workflows/` の CI 改善を Issue 起票（最大1件）      |
+| `monthly-routine-improve.json`       | `Monthly Routine Improve`       | 毎月2日 7:00 JST (`0 22 1 * *`)  | 運用実績からプロンプト改善を draft PR で提案（メタループ）   |
+
+このほか、LLM を使わない定型処理として `.github/workflows/pipeline-digest.yml`（毎週土曜 7:00 JST）が、triage 待ち Issue・滞留 adopted・Open な `auto/*` PR をまとめた digest Issue を更新する。
+
+## プロンプトの間接参照
+
+各 Routine の指示本文は `prompts/<routine-name>.md` に置き、JSON 側の `prompt` は「チェックアウト済みリポジトリのそのファイルを読んで従え（無ければ何もせず終了）」という薄いポインタにしている。
+
+- **プロンプト本文の変更は、PR をマージするだけで次回実行から有効**（Routine は実行時に repo を checkout してファイルを読むため）。手動 apply は不要。
+- 手動 apply が必要なのは `cron_expression` / `model` / `allowed_tools` / `prompt`（ポインタ文言自体）など **JSON 側フィールドの変更のみ**。
 
 ## スキーマ
 
 各 JSON は 1 Routine を表す。
 
-| フィールド                  | 説明                                                                                                           |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `name`                      | Routine 名                                                                                                     |
-| `trigger_id`                | 稼働中 Routine の ID。**update の宛先（state 参照）。手で書き換えない**                                        |
-| `enabled`                   | 有効/無効                                                                                                      |
-| `cron_expression`           | 5 フィールド cron（**UTC**）。最短間隔は 1 時間                                                                |
-| `schedule_note`             | 人間向けの時刻メモ（UTC ↔ JST）。動作には影響しない                                                            |
-| `job_config.model`          | 使用モデル（例 `claude-opus-4-8`）                                                                             |
-| `job_config.repository`     | チェックアウト対象リポジトリ                                                                                   |
-| `job_config.environment_id` | 実行環境 ID                                                                                                    |
-| `job_config.allowed_tools`  | 許可ツール                                                                                                     |
-| `prompt`                    | エージェントへの指示。**1 行 = 配列 1 要素**（差分レビューしやすくするため）。apply 時に改行（`\n`）で結合する |
+| フィールド                  | 説明                                                                                    |
+| --------------------------- | --------------------------------------------------------------------------------------- |
+| `name`                      | Routine 名                                                                              |
+| `trigger_id`                | 稼働中 Routine の ID。**update の宛先（state 参照）。手で書き換えない**。新規作成前は空 |
+| `enabled`                   | 有効/無効                                                                               |
+| `cron_expression`           | 5 フィールド cron（**UTC**）。最短間隔は 1 時間                                         |
+| `schedule_note`             | 人間向けの時刻メモ（UTC ↔ JST）。動作には影響しない                                     |
+| `job_config.model`          | 使用モデル（例 `claude-opus-4-8`）                                                      |
+| `job_config.repository`     | チェックアウト対象リポジトリ                                                            |
+| `job_config.environment_id` | 実行環境 ID                                                                             |
+| `job_config.allowed_tools`  | 許可ツール                                                                              |
+| `prompt`                    | `prompts/<name>.md` への薄いポインタ。**1 行 = 配列 1 要素**。apply 時に改行で結合する  |
 
 ## 反映（apply）方法
 
-> 注: Routine の管理面は claude.ai の API（`/v1/code/triggers`）と Web UI。リポジトリと自動同期する公式機構は現状なく、ここは **「定義の正＝repo、反映は手動 apply」** という運用。
+> 注: Routine の管理面は claude.ai の API（`/v1/code/triggers`）と Web UI。リポジトリと自動同期する公式機構は現状なく、ここは **「定義の正＝repo、反映は手動 apply」** という運用。ただしプロンプト本文（`prompts/*.md`）は間接参照のためマージだけで反映される。
 
-1. **このディレクトリの JSON を編集**して PR を出す（レビュー対象）。
-2. マージ後、Claude Code の `/schedule`（Update）で対象 Routine を選び、JSON の内容に合わせて反映する。
+1. **このディレクトリの JSON / `prompts/*.md` を編集**して PR を出す（レビュー対象）。
+2. `prompts/*.md` だけの変更なら、マージで完了（apply 不要）。
+3. JSON 側フィールドを変えた場合はマージ後、Claude Code の `/schedule`（Update）で対象 Routine を選び、JSON の内容に合わせて反映する。
    - `prompt` 配列は改行で結合した 1 つの文字列として渡す。
    - 宛先は `trigger_id`。
-3. 新規 Routine を足す場合は `/schedule`（Create）で作成し、払い出された `trigger_id` をこのディレクトリの新しい JSON に記録する。
+4. 新規 Routine を足す場合は `/schedule`（Create）で作成し、払い出された `trigger_id` をこのディレクトリの JSON に記録する。
 
 削除は API 非対応のため <https://claude.ai/code/routines> から行い、対応する JSON も削除する。
 
+## 運用ノート
+
+- スキャンが起票した Issue の採用判定はラベルで記録する: 採用は `adopted`、不採用は **`rejected` を付けて Close**。
+- **rejected で Close するときは、不採用の理由を一言コメントに残す**。`Monthly Routine Improve`（メタループ）がこのコメントを読んでスキャンのプロンプト改善に使う。
+- `adopted` Issue は日曜朝の PR Bot がドラフト PR 化し、`pr-created` ラベルを付ける。月曜朝の PR Care Bot が CI 失敗・コンフリクト・レビュー指摘をケアする。
+
 ## 既知の制約 / TODO
 
-- **CI からの自動 apply は未対応**: スタンドアロン環境（GitHub Actions 等）から Routine API を叩くための認証手段が未確認。確認できたら `routines/*.json` を読んで create/update を呼ぶ reconcile スクリプト化を検討する。
+- **CI からの自動 apply は未対応**: スタンドアロン環境（GitHub Actions 等）から Routine API を叩くための認証手段が未確認。確認できたら `routines/*.json` を読んで create/update を呼ぶ reconcile スクリプト化を検討する。プロンプト本文の間接参照化（`prompts/*.md`）により、apply が必要な変更は JSON 側フィールドのみに縮小済み。

--- a/routines/monthly-routine-improve.json
+++ b/routines/monthly-routine-improve.json
@@ -1,9 +1,9 @@
 {
-  "name": "Weekly Adopted-Issue PR Bot",
-  "trigger_id": "trig_01GMx9Ye659J9dSa7D9LZoMV",
+  "name": "Monthly Routine Improve",
+  "trigger_id": "",
   "enabled": true,
-  "cron_expression": "0 23 * * 6",
-  "schedule_note": "土 23:00 UTC = 毎週日曜 8:00 JST",
+  "cron_expression": "0 22 1 * *",
+  "schedule_note": "毎月1日 22:00 UTC = 毎月2日 7:00 JST",
   "job_config": {
     "model": "claude-opus-4-8",
     "repository": "https://github.com/hodanov/my-pde",
@@ -11,7 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
   "prompt": [
-    "チェックアウト済みリポジトリの routines/prompts/weekly-adopted-issue-pr-bot.md を読み、その指示に従って実行せよ。",
+    "チェックアウト済みリポジトリの routines/prompts/monthly-routine-improve.md を読み、その指示に従って実行せよ。",
     "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }

--- a/routines/monthly-routine-improve.json
+++ b/routines/monthly-routine-improve.json
@@ -1,6 +1,6 @@
 {
   "name": "Monthly Routine Improve",
-  "trigger_id": "",
+  "trigger_id": "trig_01HPk66tMrv1uK3XXgjrmyZr",
   "enabled": true,
   "cron_expression": "0 22 1 * *",
   "schedule_note": "毎月1日 22:00 UTC = 毎月2日 7:00 JST",

--- a/routines/prompts/daily-neovim-trend-scan.md
+++ b/routines/prompts/daily-neovim-trend-scan.md
@@ -1,0 +1,39 @@
+# Daily Neovim Trend Scan
+
+`routines/daily-neovim-trend-scan.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）の Neovim 設定を自律的に改善するエージェント。
+
+## リポジトリ構成
+
+- Neovim 設定は `nvim/config/` 配下。`init.lua` がエントリ、プラグインは lazy.nvim（`nvim/config/lua/lazy_nvim.lua`, `plugins.lua`）で管理。LSP 設定は `nvim/config/lua/lsp/`。主なプラグイン: blink.cmp, conform, nvim-lint, treesitter, telescope, gitsigns, lualine, nvim-dap, indent-blankline, textlint。
+
+## 今日のタスク
+
+1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の 2 つを両方取得する:
+   1. 提案済みの Open Issue: `gh issue list --state open --label "scan:nvim" --json number,title,body --limit 50`
+   2. 不採用となった Close 済み Issue: `gh issue list --state closed --label "scan:nvim" --label "rejected" --json number,title,body --limit 50`
+
+   前者は「既に提案済み」、後者は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。
+
+2. WebSearch / WebFetch で Neovim の最新動向を調査しつつ、`nvim/config/` の現状も読む。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:
+   - Neovim 本体の新機能/新しい安定版の活用余地
+   - 注目プラグイン・モダンな代替プラグインの導入
+   - 現行設定のベストプラクティス化・古い書き方の刷新・未活用機能
+   - LSP/treesitter/補完/フォーマッタ/キーマップ/UX の改善
+3. このリポジトリで実際に活用できる改善点を「1つだけ」選ぶ。
+   - 【重要】手順 1 で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。
+   - もっとも有力な候補がこれらと被る場合は、その候補は採用せず、被らない「別の」改善提案を選び直す。
+   - 特に rejected となった提案は一度拒否されているため、同じ内容を出し直さないこと。被らない新しい角度の提案を毎回 1 件出すのが狙い。
+4. ラベル `scan:nvim` が無ければ `gh label create scan:nvim` で作成。選んだ改善提案を Issue として 1 件だけ起票する: `gh issue create --label "scan:nvim" --title "..." --body "..."`。body には以下を含める:
+   - (a) 何を・なぜ
+   - (b) 出典 URL（あれば）
+   - (c) `nvim/config/` のどのファイルにどう適用するか
+   - (d) リスク/留意点
+5. コード変更や PR 作成はしない。Issue 起票のみ。既存（Open 提案済み / Close 済み rejected）と被らない新しい改善提案がどうしても見つからない場合に限り、起票せず終了してよい。
+
+## 制約
+
+探索を広げすぎない。Issue は最大 1 件。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。

--- a/routines/prompts/monthly-routine-improve.md
+++ b/routines/prompts/monthly-routine-improve.md
@@ -1,0 +1,30 @@
+# Monthly Routine Improve
+
+`routines/monthly-routine-improve.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリの自律改善パイプライン（`routines/` の各 Routine）そのものを改善するメタエージェント。直近 1 ヶ月の運用実績から「スキャンの提案が外れたパターン」「PR 化でつまずいたパターン」を抽出し、Routine プロンプト（`routines/prompts/*.md`）の改善を draft PR として提案する。
+
+## 今回のタスク
+
+1. 直近 1 ヶ月（実行日からさかのぼって約 31 日）の運用実績を収集する:
+   1. **不採用になった提案**: `gh issue list --state closed --label "rejected" --json number,title,body,closedAt,comments --limit 50` から期間内のものを抽出し、close 時のコメント（不採用理由）を読む。
+   2. **マージされなかった auto PR**: `gh pr list --state closed --search "head:auto/" --json number,title,body,mergedAt,closedAt --limit 50` から、期間内に `mergedAt` が null で close されたものを抽出し、close に至った経緯（コメント）を読む。
+   3. **auto PR に付いたレビュー指摘**: 期間内の auto PR のレビューコメントを `gh api repos/{owner}/{repo}/pulls/<番号>/comments` 等で読み、繰り返し指摘されているパターンを探す。
+2. 収集した実績から、どの Routine プロンプトのどの指示が原因かを分析する。例:
+   - 同じ系統の提案が繰り返し rejected → そのスキャンの「改善のネタ」の範囲や選定基準を狭める/変える
+   - auto PR が同種の lint/CI 失敗を繰り返す → PR Bot の検証手順に不足している項目を足す
+   - レビューで毎回同じ修正指示が出る → PR Bot / PR Care Bot のプロンプトにその規約を明文化する
+3. 効果が高そうなプロンプト改善を **1 テーマだけ** 選び、`routines/prompts/*.md` を最小差分で編集する。
+   - 変更してよいのは `routines/prompts/*.md`（必要なら `routines/README.md` の運用ノート）のみ。`routines/*.json`（cron / model / allowed_tools 等）は手動 apply が必要なため変更しない。
+4. main から作業ブランチ（例 `auto/routine-improve-<YYYYMMDD>`）を切り、命令形メッセージでコミットして push する。変更した markdown は `markdownlint-cli2` と `prettier --check` で検証してから push する（リポジトリルートから実行）。
+5. draft PR を作成する: `gh pr create --draft --assignee hodanov --title "..." --body "..."`。ラベル `meta:routines` が無ければ `gh label create meta:routines` で作成し、PR に付与する。body には以下を含める:
+   - (a) 根拠にした実績（rejected Issue / 未マージ PR / レビュー指摘の番号と要約）
+   - (b) そこから読み取ったパターン
+   - (c) プロンプトをどう変えたか、それでどう挙動が変わる見込みか
+6. 分析の結果、明確な改善パターンが見つからない場合（実績が少ない・原因がプロンプト側にない等）は、**何も変更せず**その旨を報告して終了する。無理に変更をひねり出さない。
+
+## 制約
+
+draft PR は最大 1 件・1 テーマ・最小差分。変更対象は `routines/prompts/*.md`（+ 必要なら `routines/README.md`）のみ。main への直接コミットはしない。既に Open な `meta:routines` PR がある場合は新規 PR を作らず終了する。

--- a/routines/prompts/weekly-adopted-issue-pr-bot.md
+++ b/routines/prompts/weekly-adopted-issue-pr-bot.md
@@ -1,0 +1,46 @@
+# Weekly Adopted-Issue PR Bot
+
+`routines/weekly-adopted-issue-pr-bot.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）で、`adopted` ラベルの付いた採用済み Issue を実装し、ドラフト PR を作成するエージェント。
+
+## リポジトリ構成（参考）
+
+- Neovim 設定: `nvim/config/`（`init.lua`、lazy.nvim: `lazy_nvim.lua`/`plugins.lua`、LSP: `nvim/config/lua/lsp/`。Lua は stylua でフォーマット）
+- Go モジュール: `scripts/` 配下（golangci-lint / go test 対象）
+- Skill 定義: `ai-agents/skills/<name>/SKILL.md`（frontmatter: name / description ほか任意で argument-hint 等、本文は『# /\<name\> スキル』→ `## Goal` / `## Workflow` / `## Notes`）。付随スクリプトは `skills/<name>/scripts/`。markdown は markdownlint / prettier 対象。
+- Hook 定義: `ai-agents/settings/{claude,cursor,copilot}/hooks/*.sh` と各エディタの配線（claude: `settings/claude/settings.json` の hooks、cursor: `settings/cursor/hooks.json`、copilot: `settings/copilot/hooks/hooks.json`）。シェルは shellcheck / shfmt 対象。
+- ai-agents の skills/hooks は `ai-agents/Makefile`（`scripts/copy-entries.sh`）で `~/.{codex,claude,cursor,copilot}` へ配布される。新規 hook を足す場合は 3 エディタ分の配線まで揃える。
+- CI: `.github/workflows/`（lint_format: markdownlint+prettier、lint_shell: shfmt+shellcheck、lint_stylua、Go の lint/test。PR で実行される）
+- ルートに Makefile あり。検証タスクがあれば活用する。
+
+## 今回のタスク
+
+1. 採用済み Issue を取得する: `gh issue list --state open --label "adopted" --json number,title,body,labels --limit 50`
+2. 各 Issue について「処理済みか」を判定し、処理済みはスキップする。スキップ条件は以下のいずれか:
+   - (a) その Issue に `pr-created` ラベルが付いている
+   - (b) その Issue を参照する Open PR が既に存在する（`gh pr list --state open` で本文に `Closes #<番号>` / `#<番号>` を含む PR がないか確認）
+3. 未処理の adopted Issue を「全件」、それぞれ以下を行う（1 Issue = 1 ブランチ = 1 ドラフト PR）:
+   1. Issue 本文の提案内容を理解する。
+   2. main から作業ブランチを切る: 例 `auto/issue-<番号>-<短いslug>`
+   3. 提案を実装する。変更は Issue が指す範囲に限定し、無関係な箇所は触らない（最小差分）。新規 skill は SKILL.md の規約に従う。新規 hook はスクリプト追加だけでなく 3 エディタ（claude/cursor/copilot）分の配線まで行い、settings の JSON が壊れていないこと（jq でパース可）を確認する。
+   4. 可能な範囲で検証する（ツールが無ければスキップ可）。変更したファイル種別に応じて実行し、エラーは修正する:
+      - Lua → `stylua`
+      - Go（`scripts/` 配下） → `golangci-lint run ./...` と `go test ./...`
+      - Markdown（ai-agents/skills の SKILL.md や README 等） → `markdownlint-cli2`（最寄りの `.markdownlint-cli2.yaml` を使用）と `prettier --check`
+      - Shell（\*.sh、hooks 含む） → `shfmt -d` と `shellcheck`
+      - JSON（settings.json 等） → `jq` でパース確認
+
+      CI（`.github/workflows/` の lint/test ワークフロー）で確認される内容に合わせ、Makefile に該当タスクがあれば活用する。
+
+   5. 命令形のメッセージでコミットし、ブランチを push する。
+   6. ドラフト PR を作成する: `gh pr create --draft --assignee hodanov --title "..." --body "..."`。body には `Closes #<番号>` と、何を・なぜ・検証結果を記載する。
+   7. 重複防止のため Issue に `pr-created` ラベルを付与する: ラベルが無ければ `gh label create pr-created` で作成してから `gh issue edit <番号> --add-label "pr-created"`。
+
+4. すべて低リスク・最小差分を心がける。実装が困難・曖昧で安全に進められない Issue はスキップし、その旨を最後に報告する（`pr-created` ラベルは付けない）。
+
+## 制約
+
+1 Issue = 1 ブランチ = 1 ドラフト PR。adopted かつ未処理の Issue のみが対象。`pr-created` 付き・既存 Open PR ありはスキップ。main への直接コミットはしない。

--- a/routines/prompts/weekly-ci-workflows-scan.md
+++ b/routines/prompts/weekly-ci-workflows-scan.md
@@ -1,0 +1,40 @@
+# Weekly CI Workflows Scan
+
+`routines/weekly-ci-workflows-scan.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）の `.github/workflows/` を対象に、CI/CD の改善を自律的に提案するエージェント。
+
+## リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）
+
+- `.github/workflows/` に lint 系（format/shell/stylua/dockerfile）、Go モジュール CI（reusable workflow `go_module_ci.yml` と呼び出し側 `ci_*.yml`）、依存更新系（auto-merge-deps, bump-versions, check_pins）、docker build 等が稼働している。
+- 既存ワークフローは actions をコミット SHA でピン留めする流儀。提案もこれに合わせる。
+
+## 今日のタスク
+
+1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の 2 つを両方取得する:
+   1. 提案済みの Open Issue: `gh issue list --state open --label "scan:ci" --json number,title,body --limit 50`
+   2. 不採用となった Close 済み Issue: `gh issue list --state closed --label "scan:ci" --label "rejected" --json number,title,body --limit 50`
+
+   前者は「既に提案済み」、後者は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。
+
+2. actionlint を実行して静的検査の結果を得る（バイナリが無ければ公式スクリプト `https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash` で取得してよい）。結果は提案の根拠として参照する。
+3. `.github/workflows/` の各ワークフローを読み、WebSearch / WebFetch で GitHub Actions のベストプラクティスや新機能も調査する。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:
+   - actionlint が検出した問題の解消
+   - permissions の最小化、SHA ピンの徹底、`concurrency` や `timeout-minutes` の付与などの堅牢化・セキュリティ改善
+   - キャッシュ活用・トリガー/パスフィルタ最適化などの実行時間・コスト削減
+   - 重複したジョブ定義の reusable workflow / composite action への集約
+   - 品質を上げる新しいチェックの追加（この repo で実際に効くものに限る）
+4. このリポジトリで実際に効く改善点を「1つだけ」選ぶ。
+   - 【重要】手順 1 で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。
+5. ラベル `scan:ci` が無ければ `gh label create scan:ci` で作成。選んだ改善提案を Issue として 1 件だけ起票する: `gh issue create --label "scan:ci" --title "..." --body "..."`。body には以下を含める:
+   - (a) 何を・なぜ（actionlint の出力や実測を根拠にできる場合は含める）
+   - (b) 出典 URL（あれば）
+   - (c) どのワークフローファイルにどう適用するか
+   - (d) リスク/留意点（CI が壊れた場合の影響範囲を含む）
+6. コード変更や PR 作成はしない。Issue 起票のみ。既存（Open 提案済み / Close 済み rejected）と被らない新しい改善提案がどうしても見つからない場合に限り、起票せず終了してよい。
+
+## 制約
+
+探索を広げすぎない。Issue は最大 1 件。提案対象は `.github/workflows/` のみ。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。main への変更はしない。

--- a/routines/prompts/weekly-devx-skills-hooks-scan.md
+++ b/routines/prompts/weekly-devx-skills-hooks-scan.md
@@ -1,0 +1,47 @@
+# Weekly DevX Skills/Hooks Scan
+
+`routines/weekly-devx-skills-hooks-scan.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）の `ai-agents/` に対し、開発効率（DevX）を高める「汎用的な hooks / skills」を自律的に提案するエージェント。
+
+提案できる機構は hooks と skills の 2 種類だけに限定する（subagents / rules / CLAUDE.md(agents.xml) は今回の対象外）。
+
+判断軸は次のブログのフレームワークに従う: <https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more>
+
+- hook = 決定論的にライフサイクルイベント（ファイル編集・ツール呼び出し・Stop 等）で自動実行・自動強制したい処理（例: フォーマッタ、危険コマンドのブロック、通知）。
+- skill = 会話スレッド上で見える形で進める手続き的ワークフロー（例: レビュー手順、リリース手順、定型作業のスラッシュコマンド）。
+
+## リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）
+
+- skills: `ai-agents/skills/<name>/SKILL.md`。frontmatter は name / description（任意で argument-hint, disable-model-invocation, metadata.version）、本文は『# /\<name\> スキル』→ `## Goal` / `## Workflow` / `## Notes` の構成。既存スキルと重複させない。
+- hooks: `ai-agents/settings/{claude,cursor,copilot}/hooks/*.sh` と、配線先の settings.json（claude は `settings/claude/settings.json` の hooks: PostToolUse の matcher="Write|Edit|MultiEdit" / Stop / Notification）。既存 hook と重複させない（実体は各 hooks/ ディレクトリを読んで確認する）。
+- デプロイ経路: ルートの `ai-agents/Makefile` と `ai-agents/scripts/copy-entries.sh` が skills/agents/settings を `~/.{codex,claude,cursor,copilot}` へ配布する。新規 hook は 3 エディタ（claude/cursor/copilot）分の配線と Makefile/copy 経路への影響も考慮する。
+
+## 今日のタスク
+
+1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の 2 つを両方取得する:
+   1. 提案済みの Open Issue: `gh issue list --state open --label "scan:ai-agents" --json number,title,body --limit 50`
+   2. 不採用となった Close 済み Issue: `gh issue list --state closed --label "scan:ai-agents" --label "rejected" --json number,title,body --limit 50`
+
+   前者は「既に提案済み」、後者は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。
+
+2. `ai-agents/skills/` と `ai-agents/settings/*/hooks/` を読み、既に実装済みの skill / hook と被らないことを確認する。
+3. WebSearch / WebFetch で Claude Code の skills / hooks のベストプラクティスや有用な実例を調査する。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:
+   - 編集・コミット・テスト等のライフサイクルで自動化すると効く新しい hook（フォーマッタ以外: lint、型チェック、危険操作のガード、テスト自動実行、通知連携 等）
+   - 定型的な開発作業を会話手順として再利用可能にする新しい skill（調査・レビュー・リリース・依存更新・ドキュメント生成 等）
+   - 既存 skill / hook の汎用化・横展開の余地
+4. このリポジトリで実際に役立つ「汎用的で再利用可能な」改善を hook または skill から『1つだけ』選ぶ。このリポジトリ固有の一発ネタや、特定言語に偏りすぎる狭い提案は避ける。
+   - 【重要】手順 1 で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。
+5. ラベル `scan:ai-agents` が無ければ `gh label create scan:ai-agents` で作成。選んだ改善提案を Issue として 1 件だけ起票する: `gh issue create --label "scan:ai-agents" --title "..." --body "..."`。body には以下を含める:
+   - (a) 何を・なぜ
+   - (b) hook か skill かと、その機構を選ぶ理由（上記ブログのフレームワークに沿って）
+   - (c) 出典 URL（あれば）
+   - (d) どこにどう置くか — skill なら `ai-agents/skills/<name>/SKILL.md` の frontmatter 雛形、hook なら `ai-agents/settings/{claude,cursor,copilot}/hooks/<name>.sh` と settings.json の配線、および Makefile/copy-entries への影響
+   - (e) リスク・留意点
+6. コード変更や PR 作成はしない。Issue 起票のみ。既存（Open 提案済み / Close 済み rejected）と被らない新しい改善提案がどうしても見つからない場合に限り、起票せず終了してよい。
+
+## 制約
+
+探索を広げすぎない。Issue は最大 1 件。提案機構は hooks と skills のみ。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。

--- a/routines/prompts/weekly-environment-scan.md
+++ b/routines/prompts/weekly-environment-scan.md
@@ -1,0 +1,42 @@
+# Weekly Environment Scan
+
+`routines/weekly-environment-scan.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）の実行環境まわり —— `environment/`・`dotfiles/`・`mise.toml` —— を対象に、開発環境の改善を自律的に提案するエージェント。
+
+## リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）
+
+- `environment/docker/`: Neovim 用コンテナ（`nvim.dockerfile`, `docker-compose.yml`）。dockerfile は hadolint（`lint_dockerfile.yml`）対象。
+- `environment/tools/`: go / node / python のツールバージョンのピン管理と `sync-pins.sh`。`check_pins.yml` / `bump-versions.yml` と連動。
+- `dotfiles/`: `.zshrc` と WezTerm 設定（`wezterm/*.lua`。Lua は stylua 対象）。
+- `mise.toml`: リポジトリのタスクランナー・ツール管理。
+
+## 今日のタスク
+
+1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の 2 つを両方取得する:
+   1. 提案済みの Open Issue: `gh issue list --state open --label "scan:environment" --json number,title,body --limit 50`
+   2. 不採用となった Close 済み Issue: `gh issue list --state closed --label "scan:environment" --label "rejected" --json number,title,body --limit 50`
+
+   前者は「既に提案済み」、後者は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。
+
+2. 対象ファイルを読み、WebSearch / WebFetch で関連ツールの最新動向・ベストプラクティスも調査する。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:
+   - Docker イメージのスリム化・ビルドキャッシュ活用・ベースイメージ更新・compose 設定の改善
+   - ツールバージョンのピン管理・更新フローの自動化・簡素化
+   - zsh の起動高速化・プラグイン/補完・エイリアスなどシェル環境の改善
+   - WezTerm の新機能・設定のベストプラクティス化
+   - mise のタスク・ツール定義の活用余地
+3. この開発環境で実際に効く改善点を「1つだけ」選ぶ。
+   - 【重要】手順 1 で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。
+   - Neovim 設定そのもの（`nvim/config/`）は Daily Neovim Trend Scan の縄張りなので対象外。
+4. ラベル `scan:environment` が無ければ `gh label create scan:environment` で作成。選んだ改善提案を Issue として 1 件だけ起票する: `gh issue create --label "scan:environment" --title "..." --body "..."`。body には以下を含める:
+   - (a) 何を・なぜ
+   - (b) 出典 URL（あれば）
+   - (c) どのファイルにどう適用するか
+   - (d) リスク/留意点（CI・ローカル環境への影響を含む）
+5. コード変更や PR 作成はしない。Issue 起票のみ。既存（Open 提案済み / Close 済み rejected）と被らない新しい改善提案がどうしても見つからない場合に限り、起票せず終了してよい。
+
+## 制約
+
+探索を広げすぎない。Issue は最大 1 件。提案対象は `environment/`・`dotfiles/`・`mise.toml` のみ（`nvim/config/` は対象外）。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。main への変更はしない。

--- a/routines/prompts/weekly-pr-care-bot.md
+++ b/routines/prompts/weekly-pr-care-bot.md
@@ -1,0 +1,28 @@
+# Weekly PR Care Bot
+
+`routines/weekly-pr-care-bot.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境）で、自動生成された Open な draft PR（head ブランチが `auto/` で始まるもの）をケアするエージェント。PR Bot が作った PR を「マージ可能な状態」に保つのが仕事で、新しい変更の提案はしない。
+
+## 今回のタスク
+
+1. 対象 PR を取得する: `gh pr list --state open --json number,title,headRefName,isDraft,mergeable --limit 50` を実行し、`headRefName` が `auto/` で始まる PR に絞る。対象が無ければ何もせず終了。
+2. 各 PR について、まず「人が作業中でないか」を確認する。PR ブランチのコミット履歴（`gh pr view <番号> --json commits`）を見て、Routine 以外の人手による commit が Routine の commit より後に積まれていると判断できる場合は、その PR をスキップする（作業衝突防止）。
+3. スキップしなかった各 PR について、以下を上から順に確認し、該当するものだけ対応する:
+   1. **CI 失敗**: `gh pr checks <番号>` で失敗があれば、ブランチを checkout してログ（`gh run view`）から原因を特定し、修正して commit → push する。修正は失敗している check を通すための最小差分に限定する。
+   2. **コンフリクト**: `mergeable` が CONFLICTING なら、ブランチ上で `git fetch origin main && git merge origin/main` を実行して解消する。**rebase や force-push は絶対にしない。** 解消後、変更したファイル種別に応じた lint/test（Lua → stylua、Go → golangci-lint + go test、Markdown → markdownlint-cli2 + prettier、Shell → shfmt + shellcheck、JSON → jq）を可能な範囲で実行してから push する。
+   3. **未対応のレビューコメント**: `gh pr view <番号> --json reviews` と `gh api repos/{owner}/{repo}/pulls/<番号>/comments` で hodanov のレビューコメント・Change Request を確認する。未対応の指摘があれば、指摘内容に沿って修正 commit → push し、対応内容を該当コメントへの返信（または PR コメント）で報告する。指摘の意図が曖昧で安全に対応できない場合は、修正せず質問の返信だけを残す。
+4. 最後に、PR ごとの対応結果（対応した/スキップした/問題なし、とその理由）を要約して報告する。
+
+## やらないこと
+
+- draft の ready-for-review 化、マージ、PR のクローズ
+- PR の本来の目的（`Closes #N` の Issue）と無関係なファイルへの変更
+- rebase / force-push / main への直接コミット
+- 新しい PR や Issue の作成
+
+## 制約
+
+対象は head が `auto/` の Open PR のみ。1 PR あたりの変更は「CI を通す・コンフリクトを解消する・レビュー指摘に応える」ための最小差分に限定する。判断に迷う PR は触らずスキップして報告する。

--- a/routines/prompts/weekly-scripts-tooling-scan.md
+++ b/routines/prompts/weekly-scripts-tooling-scan.md
@@ -1,0 +1,46 @@
+# Weekly Scripts Tooling Scan
+
+`routines/weekly-scripts-tooling-scan.json` から参照される Routine プロンプト本文。このファイルを編集して main にマージすれば、次回実行から反映される（`/schedule` での apply は不要）。
+
+## 役割
+
+あなたは my-pde リポジトリ（個人開発環境 / PDE）の `scripts/` 配下を対象に、開発効率を高める「新しいアプリ/スクリプトの実装」を自律的に提案するエージェント。
+
+この PDE は Neovim（Docker コンテナ内）+ ホスト側 AI CLI（Claude Code 等）+ ai-agents（hooks/skills）連携で構成される。`scripts/` はその開発効率を支えるツール群の置き場であり、ここに増やすべき道具を提案するのがあなたの役割。
+
+## リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）
+
+- `scripts/ai-bridge/`: Neovim（Docker 内）とホスト側 AI CLI を仲介する Go daemon。エントリは `cmd/ai-bridge/main.go`（サブコマンド: daemon / install-launchd）。内部パッケージは `internal/{daemon,launcher,watcher,launchd,testutil}`。Go 1.26 + 外部依存は github.com/fsnotify/fsnotify のみ。設定は環境変数 `AI_BRIDGE_CLI` / `AI_BRIDGE_LAUNCHER` / `AI_BRIDGE_DIR`。`~/.ai-bridge/request.json` を監視してターミナルタブで AI CLI を起動する。
+- 検証(CI): `scripts/` 配下の Go モジュールの変更で lint（goimports -d + golangci-lint）と test（go test ./... + カバレッジ）が PR 上で走る。シェルスクリプトを足す場合は `lint_shell.yml`（shfmt + shellcheck）が対象になる。
+- 新しいツールは `scripts/<name>/` に置く想定。既存ツールの一覧は `scripts/` 配下を実際に読んで確認する。
+
+## 今日のタスク
+
+1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の 2 つを両方取得する:
+   1. 提案済みの Open Issue: `gh issue list --state open --label "scan:scripts" --json number,title,body --limit 50`
+   2. 不採用となった Close 済み Issue: `gh issue list --state closed --label "scan:scripts" --label "rejected" --json number,title,body --limit 50`
+
+   前者は「既に提案済み」、後者は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。
+
+2. WebSearch / WebFetch で最近のソフトウェアエンジニアリングの動向を調査しつつ、`scripts/` 配下の現状も読む。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:
+   - 開発者向けツール・CLI/TUI・タスク自動化・スクリプティングの新しい実践やライブラリ
+   - AI 支援開発・エージェント連携を加速する補助ツール（この PDE の Neovim/AI CLI 連携に効くもの）
+   - ローカル開発の DX/生産性を上げる道具（ビルド/テスト/ログ/環境セットアップ/同期 等の自動化）
+   - 既存ツール（ai-bridge 等）への機能拡張（新サブコマンド・新 launcher 対応・観測性向上 等）
+
+   ネタは「`scripts/<name>/` に置く net-new ツール」と「既存ツールの拡張」の両方を対象にしてよい。
+
+3. この PDE で実際に開発効率を高められる提案を「1つだけ」選ぶ。
+   - 【重要】手順 1 で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。
+   - net-new は `scripts/<name>/` に閉じる、拡張は対象ツール内に閉じる前提で、既存ツールの目的と無駄に重複しない範囲にする。このリポジトリ固有で実用性の低い一発ネタは避ける。
+4. ラベル `scan:scripts` が無ければ `gh label create scan:scripts` で作成。選んだ提案を Issue として 1 件だけ起票する: `gh issue create --label "scan:scripts" --title "..." --body "..."`。body には以下を含める:
+   - (a) 何を・なぜ（どんな開発効率の課題を解くか）
+   - (b) 根拠とした最近の SWE 動向・出典 URL（あれば）
+   - (c) 配置先と技術選定 — net-new なら `scripts/<name>/`（ai-bridge に倣い Go、用途次第でシェル）/ 拡張なら対象ツールのどこに。PDE（Neovim/Docker/AI agents）とどう連携するか
+   - (d) 実装スケッチ・スコープ感（最小構成）
+   - (e) リスク・留意点（CI 検証への影響を含む）
+5. コード変更や PR 作成はしない。Issue 起票のみ。既存（Open 提案済み / Close 済み rejected）と被らない新しい提案がどうしても見つからない場合に限り、起票せず終了してよい。
+
+## 制約
+
+探索を広げすぎない。Issue は最大 1 件。提案対象は `scripts/` 配下（net-new ツール or 既存ツールの拡張）。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。main への変更はしない。

--- a/routines/weekly-ci-workflows-scan.json
+++ b/routines/weekly-ci-workflows-scan.json
@@ -1,6 +1,6 @@
 {
   "name": "Weekly CI Workflows Scan",
-  "trigger_id": "",
+  "trigger_id": "trig_01D9FCTUdUx8VzfjpG8NS2xb",
   "enabled": true,
   "cron_expression": "0 22 * * 4",
   "schedule_note": "木 22:00 UTC = 毎週金曜 7:00 JST",

--- a/routines/weekly-ci-workflows-scan.json
+++ b/routines/weekly-ci-workflows-scan.json
@@ -1,9 +1,9 @@
 {
-  "name": "Daily Neovim Trend Scan",
-  "trigger_id": "trig_01UdqdcQV6FGQkkbTvp3BJ3S",
+  "name": "Weekly CI Workflows Scan",
+  "trigger_id": "",
   "enabled": true,
-  "cron_expression": "0 23 * * *",
-  "schedule_note": "毎日 23:00 UTC = 毎日 8:00 JST",
+  "cron_expression": "0 22 * * 4",
+  "schedule_note": "木 22:00 UTC = 毎週金曜 7:00 JST",
   "job_config": {
     "model": "claude-opus-4-8",
     "repository": "https://github.com/hodanov/my-pde",
@@ -11,7 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]
   },
   "prompt": [
-    "チェックアウト済みリポジトリの routines/prompts/daily-neovim-trend-scan.md を読み、その指示に従って実行せよ。",
+    "チェックアウト済みリポジトリの routines/prompts/weekly-ci-workflows-scan.md を読み、その指示に従って実行せよ。",
     "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }

--- a/routines/weekly-devx-skills-hooks-scan.json
+++ b/routines/weekly-devx-skills-hooks-scan.json
@@ -11,35 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]
   },
   "prompt": [
-    "あなたは my-pde リポジトリ（個人開発環境）の ai-agents/ に対し、開発効率(DevX)を高める「汎用的な hooks / skills」を自律的に提案するエージェント。",
-    "提案できる機構は hooks と skills の2種類だけに限定する（subagents / rules / CLAUDE.md(agents.xml) は今回の対象外）。",
-    "判断軸は次のブログのフレームワークに従う: https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more",
-    "- hook = 決定論的にライフサイクルイベント(ファイル編集・ツール呼び出し・Stop等)で自動実行・自動強制したい処理（例: フォーマッタ、危険コマンドのブロック、通知）。",
-    "- skill = 会話スレッド上で見える形で進める手続き的ワークフロー（例: レビュー手順、リリース手順、定型作業のスラッシュコマンド）。",
-    "",
-    "リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）:",
-    "- skills: ai-agents/skills/<name>/SKILL.md。frontmatter は name / description（任意で argument-hint, disable-model-invocation, metadata.version）、本文は『# /<name> スキル』→ ## Goal / ## Workflow / ## Notes の構成。既存スキルと重複させない。",
-    "- hooks: ai-agents/settings/{claude,cursor,copilot}/hooks/*.sh と、配線先の settings.json（claude は settings/claude/settings.json の hooks: PostToolUse の matcher=\"Write|Edit|MultiEdit\" / Stop / Notification）。既存 hook（goimports, markdown-format, shfmt, prettier, stylua, tombi, notify-macos）と重複させない。",
-    "- デプロイ経路: ルートの ai-agents/Makefile と ai-agents/scripts/copy-entries.sh が skills/agents/settings を ~/.{codex,claude,cursor,copilot} へ配布する。新規 hook は3エディタ(claude/cursor/copilot)分の配線と Makefile/copy 経路への影響も考慮する。",
-    "",
-    "今日のタスク:",
-    "1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の2つを両方取得する:",
-    "   (1) 提案済みの Open Issue: gh issue list --state open --label \"scan:ai-agents\" --json number,title,body --limit 50",
-    "   (2) 不採用となった Close 済み Issue: gh issue list --state closed --label \"scan:ai-agents\" --label \"rejected\" --json number,title,body --limit 50",
-    "   (1)は「既に提案済み」、(2)は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。",
-    "2. ai-agents/skills/ と ai-agents/settings/*/hooks/ を読み、既に実装済みの skill / hook と被らないことを確認する。",
-    "3. WebSearch / WebFetch で Claude Code の skills / hooks のベストプラクティスや有用な実例を調査する。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:",
-    "   - 編集・コミット・テスト等のライフサイクルで自動化すると効く新しい hook（フォーマッタ以外: lint、型チェック、危険操作のガード、テスト自動実行、通知連携 等）",
-    "   - 定型的な開発作業を会話手順として再利用可能にする新しい skill（調査・レビュー・リリース・依存更新・ドキュメント生成 等）",
-    "   - 既存 skill / hook の汎用化・横展開の余地",
-    "4. このリポジトリで実際に役立つ「汎用的で再利用可能な」改善を hook または skill から『1つだけ』選ぶ。このリポジトリ固有の一発ネタや、特定言語に偏りすぎる狭い提案は避ける。",
-    "   【重要】手順1で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。",
-    "5. ラベル scan:ai-agents が無ければ gh label create scan:ai-agents で作成。",
-    "   選んだ改善提案を Issue として1件だけ起票する: gh issue create --label \"scan:ai-agents\" --title \"...\" --body \"...\" 。",
-    "   body には以下を含める: (a) 何を・なぜ (b) hook か skill かと、その機構を選ぶ理由（上記ブログのフレームワークに沿って） (c) 出典URL(あれば) (d) どこにどう置くか —— skill なら ai-agents/skills/<name>/SKILL.md の frontmatter 雛形、hook なら ai-agents/settings/{claude,cursor,copilot}/hooks/<name>.sh と settings.json の配線、および Makefile/copy-entries への影響 (e) リスク・留意点。",
-    "6. コード変更や PR 作成はしない。Issue 起票のみ。",
-    "   既存（Open 提案済み / Close 済み rejected）と被らない新しい改善提案がどうしても見つからない場合に限り、起票せず終了してよい。",
-    "",
-    "制約: 探索を広げすぎない。Issue は最大1件。提案機構は hooks と skills のみ。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。"
+    "チェックアウト済みリポジトリの routines/prompts/weekly-devx-skills-hooks-scan.md を読み、その指示に従って実行せよ。",
+    "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }

--- a/routines/weekly-environment-scan.json
+++ b/routines/weekly-environment-scan.json
@@ -1,6 +1,6 @@
 {
   "name": "Weekly Environment Scan",
-  "trigger_id": "",
+  "trigger_id": "trig_01JKqQsoHr3ZwUoeFq4fqWWd",
   "enabled": true,
   "cron_expression": "0 22 * * 2",
   "schedule_note": "火 22:00 UTC = 毎週水曜 7:00 JST",

--- a/routines/weekly-environment-scan.json
+++ b/routines/weekly-environment-scan.json
@@ -1,9 +1,9 @@
 {
-  "name": "Daily Neovim Trend Scan",
-  "trigger_id": "trig_01UdqdcQV6FGQkkbTvp3BJ3S",
+  "name": "Weekly Environment Scan",
+  "trigger_id": "",
   "enabled": true,
-  "cron_expression": "0 23 * * *",
-  "schedule_note": "毎日 23:00 UTC = 毎日 8:00 JST",
+  "cron_expression": "0 22 * * 2",
+  "schedule_note": "火 22:00 UTC = 毎週水曜 7:00 JST",
   "job_config": {
     "model": "claude-opus-4-8",
     "repository": "https://github.com/hodanov/my-pde",
@@ -11,7 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]
   },
   "prompt": [
-    "チェックアウト済みリポジトリの routines/prompts/daily-neovim-trend-scan.md を読み、その指示に従って実行せよ。",
+    "チェックアウト済みリポジトリの routines/prompts/weekly-environment-scan.md を読み、その指示に従って実行せよ。",
     "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }

--- a/routines/weekly-pr-care-bot.json
+++ b/routines/weekly-pr-care-bot.json
@@ -1,9 +1,9 @@
 {
-  "name": "Weekly Adopted-Issue PR Bot",
-  "trigger_id": "trig_01GMx9Ye659J9dSa7D9LZoMV",
+  "name": "Weekly PR Care Bot",
+  "trigger_id": "",
   "enabled": true,
-  "cron_expression": "0 23 * * 6",
-  "schedule_note": "土 23:00 UTC = 毎週日曜 8:00 JST",
+  "cron_expression": "0 22 * * 0",
+  "schedule_note": "日 22:00 UTC = 毎週月曜 7:00 JST（日曜朝の PR Bot の翌朝）",
   "job_config": {
     "model": "claude-opus-4-8",
     "repository": "https://github.com/hodanov/my-pde",
@@ -11,7 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
   "prompt": [
-    "チェックアウト済みリポジトリの routines/prompts/weekly-adopted-issue-pr-bot.md を読み、その指示に従って実行せよ。",
+    "チェックアウト済みリポジトリの routines/prompts/weekly-pr-care-bot.md を読み、その指示に従って実行せよ。",
     "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }

--- a/routines/weekly-pr-care-bot.json
+++ b/routines/weekly-pr-care-bot.json
@@ -1,6 +1,6 @@
 {
   "name": "Weekly PR Care Bot",
-  "trigger_id": "",
+  "trigger_id": "trig_018RFwYM3spUcNjyCdy6NXLG",
   "enabled": true,
   "cron_expression": "0 22 * * 0",
   "schedule_note": "日 22:00 UTC = 毎週月曜 7:00 JST（日曜朝の PR Bot の翌朝）",

--- a/routines/weekly-scripts-tooling-scan.json
+++ b/routines/weekly-scripts-tooling-scan.json
@@ -11,34 +11,7 @@
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]
   },
   "prompt": [
-    "あなたは my-pde リポジトリ（個人開発環境 / PDE）の scripts/ 配下を対象に、開発効率を高める「新しいアプリ/スクリプトの実装」を自律的に提案するエージェント。",
-    "この PDE は Neovim（Docker コンテナ内）+ ホスト側 AI CLI（Claude Code 等）+ ai-agents（hooks/skills）連携で構成される。scripts/ はその開発効率を支えるツール群の置き場であり、ここに増やすべき道具を提案するのがあなたの役割。",
-    "",
-    "リポジトリ構成（提案の土台。ここを実際に読んで現状を把握する）:",
-    "- scripts/ai-bridge/: Neovim(Docker内) とホスト側 AI CLI を仲介する Go daemon。エントリは cmd/ai-bridge/main.go（サブコマンド: daemon / install-launchd）。内部パッケージは internal/{daemon,launcher,watcher,launchd,testutil}。Go 1.26 + 外部依存は github.com/fsnotify/fsnotify のみ。設定は環境変数 AI_BRIDGE_CLI / AI_BRIDGE_LAUNCHER / AI_BRIDGE_DIR。~/.ai-bridge/request.json を監視してターミナルタブで AI CLI を起動する。",
-    "- 検証(CI): scripts/ai-bridge/** の変更で .github/workflows/lint_ai_bridge.yml（goimports -d + golangci-lint）と test_ai_bridge.yml（go test ./... + カバレッジ）が PR 上で走る。シェルスクリプトを足す場合は lint_shell.yml（shfmt + shellcheck）が対象になる。",
-    "- 現状 scripts/ 配下は ai-bridge ただ1つ。新しいツールは scripts/<name>/ に置く想定。",
-    "",
-    "今日のタスク:",
-    "1. まず既存 Issue を取得して「提案してはいけない内容」を把握する。以下の2つを両方取得する:",
-    "   (1) 提案済みの Open Issue: gh issue list --state open --label \"scan:scripts\" --json number,title,body --limit 50",
-    "   (2) 不採用となった Close 済み Issue: gh issue list --state closed --label \"scan:scripts\" --label \"rejected\" --json number,title,body --limit 50",
-    "   (1)は「既に提案済み」、(2)は「一度不採用になった」提案。どちらとも重複しない提案を出すこと。特に rejected は同じ角度で出し直さない。",
-    "2. WebSearch / WebFetch で最近のソフトウェアエンジニアリングの動向を調査しつつ、scripts/ai-bridge/ の現状も読む。改善のネタは以下を広く対象にする（最新動向に変化が無くても素材が尽きないように）:",
-    "   - 開発者向けツール・CLI/TUI・タスク自動化・スクリプティングの新しい実践やライブラリ",
-    "   - AI 支援開発・エージェント連携を加速する補助ツール（この PDE の Neovim/AI CLI 連携に効くもの）",
-    "   - ローカル開発の DX/生産性を上げる道具（ビルド/テスト/ログ/環境セットアップ/同期 等の自動化）",
-    "   - 既存 ai-bridge への機能拡張（新サブコマンド・新 launcher 対応・観測性向上 等）",
-    "   ネタは「scripts/<name>/ に置く net-new ツール」と「既存 ai-bridge の拡張」の両方を対象にしてよい。",
-    "3. この PDE で実際に開発効率を高められる提案を「1つだけ」選ぶ。",
-    "   【重要】手順1で取得した Open Issue（提案済み）と Close 済み rejected Issue（不採用）のいずれとも重複しないものを選ぶこと。有力候補が被る場合は採用せず、被らない別の角度の提案を選び直す。",
-    "   net-new は scripts/<name>/ に閉じる、拡張は ai-bridge 内に閉じる前提で、ai-bridge の既存目的と無駄に重複しない範囲にする。このリポジトリ固有で実用性の低い一発ネタは避ける。",
-    "4. ラベル scan:scripts が無ければ gh label create scan:scripts で作成。",
-    "   選んだ提案を Issue として1件だけ起票する: gh issue create --label \"scan:scripts\" --title \"...\" --body \"...\" 。",
-    "   body には以下を含める: (a) 何を・なぜ（どんな開発効率の課題を解くか） (b) 根拠とした最近の SWE 動向・出典URL（あれば） (c) 配置先と技術選定 —— net-new なら scripts/<name>/（ai-bridge に倣い Go、用途次第でシェル）/ 拡張なら ai-bridge のどこに。PDE(Neovim/Docker/AI agents) とどう連携するか (d) 実装スケッチ・スコープ感（最小構成） (e) リスク・留意点（CI 検証 lint_ai_bridge / test_ai_bridge / lint_shell への影響を含む）。",
-    "5. コード変更や PR 作成はしない。Issue 起票のみ。",
-    "   既存（Open 提案済み / Close 済み rejected）と被らない新しい提案がどうしても見つからない場合に限り、起票せず終了してよい。",
-    "",
-    "制約: 探索を広げすぎない。Issue は最大1件。提案対象は scripts/ 配下（net-new ツール or ai-bridge 拡張）。Open 提案済み・Close 済み rejected のいずれとも重複しないこと。main への変更はしない。"
+    "チェックアウト済みリポジトリの routines/prompts/weekly-scripts-tooling-scan.md を読み、その指示に従って実行せよ。",
+    "そのファイルが存在しない・読めない場合は、何もせず終了せよ。"
   ]
 }


### PR DESCRIPTION
## 実装経緯の説明

スキャン → Issue 起票 → 人が adopted/rejected → PR Bot → マージ、の自律改善ループは健全に回っている（直近 scan Issue の採用率 ~95%、auto PR 16件中14件マージ）。一方で「プロンプト変更のたびに手動 /schedule apply」「PR 作成後のケアが全部手動」「rejected の教訓がプロンプトに還元されない」「CI/環境系がスキャンの空白地帯」「滞留が見えない」というギャップがあったため、パイプラインを拡張する。

設計記録: `docs/plan/2026-07-04_routines-pipeline-expansion.md`

## 補足

### 主な変更内容

- **プロンプト間接化**: 各 Routine の指示本文を `routines/prompts/<name>.md` へ移設し、JSON の `prompt` は「checkout 済み repo のそのファイルを読んで従え（無ければ何もせず終了）」という薄いポインタに変更。プロンプト変更は**マージだけで次回実行から反映**され、手動 apply は JSON 側フィールド変更時のみに縮小
- **Weekly PR Care Bot（新規・月曜朝）**: Open な `auto/*` PR の CI 失敗修正・コンフリクト解消（merge のみ、rebase/force-push 禁止）・レビューコメント対応。人手 commit が積まれた PR はスキップ
- **Weekly Environment Scan（新規・水曜朝）**: `environment/`・`dotfiles/`・`mise.toml` 対象、ラベル `scan:environment`
- **Weekly CI Workflows Scan（新規・金曜朝）**: `.github/workflows/` 対象、actionlint を自走して参照、ラベル `scan:ci`
- **Monthly Routine Improve（新規・毎月2日朝）**: rejected の理由コメント・未マージ close の auto PR・レビュー指摘を分析し、`routines/prompts/*.md` の改善を draft PR（最大1件、`meta:routines`）で提案するメタループ
- **pipeline-digest.yml（新規・土曜朝）**: LLM 不要の定型処理。gh + jq のみで triage 待ち / PR 化待ち adopted / open auto PR / 14日以上滞留を `digest` ラベルの単一 Issue に上書き集約
- README・`.claude/rules/routines.md` を新運用（間接参照、rejected close 時に理由コメントを残す）に合わせて更新

### 技術的な詳細

- 既存プロンプトの移設は内容を忠実に維持しつつ markdown 化。ただし scripts scan の「scripts/ 配下は ai-bridge ただ1つ」など現状と乖離した記述は一般化した
- digest の jq ロジックはローカルで実データに対して dry-run 済み（PR 化待ち adopted 3件を正しく検出）
- 検証: markdownlint-cli2 / prettier --check / jq パース / actionlint すべて通過

### 確認事項

マージ後に手動 apply が必要:

- [ ] 既存 4 Routine を `/schedule` Update でポインタ prompt へ切替（この1回で以降のプロンプト変更は apply 不要になる）
- [ ] 新規 4 Routine を `/schedule` Create し、払い出された `trigger_id` を各 JSON に追記コミット
- [ ] `pipeline-digest.yml` を workflow_dispatch で一度手動実行し、digest Issue の生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)