### PR TITLE
nvim-lint: actionlint で GitHub Actions ワークフローを編集時に静的検査する

### DIFF
--- a/nvim/config/lua/nvim_lint.lua
+++ b/nvim/config/lua/nvim_lint.lua
@@ -1,9 +1,21 @@
 local lint = require("lint")
 
+-- .github/workflows/ 配下のファイルだけ複合 filetype "yaml.ghaction" にする。
+-- こうすると通常の yaml (docker-compose.yml 等) には actionlint が走らず、
+-- yamlls による汎用 YAML 検査 (yaml 成分) と actionlint (ghaction 成分) が両立する。
+vim.filetype.add({
+	pattern = {
+		[".*/%.github/workflows/.*%.ya?ml"] = "yaml.ghaction",
+	},
+})
+
 lint.linters_by_ft = {
 	markdown = { "markdownlint-cli2" },
 	dockerfile = { "hadolint" },
 	terraform = { "tflint" },
+	-- GitHub Actions ワークフロー専用。複合 filetype の "ghaction" 成分を key にすることで
+	-- 通常の yaml には作用させない。actionlint 未インストール時は nvim-lint が黙ってスキップする。
+	ghaction = { "actionlint" },
 }
 
 -- Run it when you open, save or exit insert mode (you can adjust the events to your liking).


### PR DESCRIPTION
Closes #491

## 何を

`nvim/config/lua/nvim_lint.lua` に actionlint を追加し、`.github/workflows/` 配下のワークフロー YAML を編集/読み込み時に nvim-lint 経由で静的検査する。

- `vim.filetype.add` で `.github/workflows/*.{yml,yaml}` にだけ複合 filetype `yaml.ghaction` を割り当てる。
- `linters_by_ft.ghaction = { "actionlint" }` を追加。既存の markdown / dockerfile / terraform はそのまま維持。

## なぜ

このリポジトリは `.github/workflows/` に多数のワークフローを持ち、編集頻度が高い。従来は yamlls の汎用 YAML 検査しか効かず、GitHub Actions 固有の誤り（式の型・`needs` 参照・埋め込みシェル等）を編集中に検出できなかった。複合 filetype の `ghaction` 成分だけに actionlint を紐付けることで、`docker-compose.yml` 等の通常 YAML には誤検出させず、ワークフローにだけ actionlint を適用する。

## 検証

- ローカル環境に stylua/mise が無いため自動フォーマット検査は未実行。追加分は既存ファイルと同じタブインデントで、stylua デフォルト（tabs / width 120）に準拠。コメントは stylua の整形対象外。CI（`lint_stylua.yml`）で最終確認される。
- actionlint バイナリ未インストール時は nvim-lint が当該リンタを黙ってスキップするだけで、他 filetype の lint や既存挙動には影響しない（開発コンテナへの actionlint 追加は本 PR のスコープ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114bangtSvc7BV2trUPPPfo)_