### PR TITLE
ci: PR トリガーの lint/CI ワークフローに concurrency を付与する

### DIFF
--- a/.github/workflows/check_pins.yml
+++ b/.github/workflows/check_pins.yml
@@ -10,6 +10,10 @@ on:
       - environment/tools/sync-pins.sh
       - environment/docker/nvim.dockerfile
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_ai_bridge.yml
+++ b/.github/workflows/ci_ai_bridge.yml
@@ -9,6 +9,10 @@ on:
       - "scripts/ai-bridge/**"
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/go_module_ci.yml

--- a/.github/workflows/ci_config_diff.yml
+++ b/.github/workflows/ci_config_diff.yml
@@ -9,6 +9,10 @@ on:
       - "scripts/config-diff/**"
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/go_module_ci.yml

--- a/.github/workflows/ci_go_verify.yml
+++ b/.github/workflows/ci_go_verify.yml
@@ -9,6 +9,10 @@ on:
       - "scripts/go-verify/**"
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/go_module_ci.yml

--- a/.github/workflows/ci_nvim_sync.yml
+++ b/.github/workflows/ci_nvim_sync.yml
@@ -9,6 +9,10 @@ on:
       - "scripts/nvim-sync/**"
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/go_module_ci.yml

--- a/.github/workflows/lint_format.yml
+++ b/.github/workflows/lint_format.yml
@@ -5,6 +5,10 @@ permissions:
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_shell.yml
+++ b/.github/workflows/lint_shell.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/lint_shell.yml
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   shell-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_stylua.yml
+++ b/.github/workflows/lint_stylua.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/lint_stylua.yml
       - mise.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #497

## 何を

PR で走る以下の lint / CI ワークフローのトップレベル（`on:` と `jobs:` の間）に `concurrency` を追加した:

- `lint_format.yml`
- `lint_shell.yml`
- `lint_stylua.yml`
- `check_pins.yml`
- `ci_ai_bridge.yml` / `ci_config_diff.yml` / `ci_go_verify.yml` / `ci_nvim_sync.yml`（`go_module_ci.yml` の呼び出し側）

追加した block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

## なぜ

これまで concurrency を持つのは `pr-docker-build.yml` の 1 本だけだった。concurrency が無いと、同じ PR に立て続けに push した際に古い commit の run が最後まで走り続け、Actions 時間（特に `go_module_ci` の lint+test ×4 モジュール）を無駄に消費し、最新 commit の結果表示も遅くなる。既存 `pr-docker-build.yml` と同じ流儀を軽量な PR ワークフローに広げる一貫性のある改善。

group key を `github.head_ref || github.run_id` にすることで、PR への後続 push でのみ旧 run をキャンセルし、main への push や手動 dispatch は `run_id` へフォールバックして巻き込まない設計。`github.workflow` を含めることでワークフロー間の相互キャンセルも起きない。

reusable 本体の `go_module_ci.yml` には付けず（group を呼び出し側の文脈で分けたいため）、呼び出し側の `ci_*.yml` に付与した。`lint_dockerfile.yml`（push トリガー）と `auto-merge-deps.yml`（短命ジョブ）は恩恵が小さいため対象外。

## 検証

- 各対象ファイルを Python `yaml.safe_load` でパース確認（8 件すべて OK）
- `prettier --check .github/workflows/*.yml` → All matched files use Prettier code style
- CI ロジック自体は変更していないため、影響範囲は実行のスケジューリングのみ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz3yjSvFe9R6KeU3hYeUZn)_