### PR TITLE
feat(scripts): add scaffold generator for new Go modules

### DIFF
--- a/.github/workflows/ci_scaffold.yml
+++ b/.github/workflows/ci_scaffold.yml
@@ -1,0 +1,16 @@
+name: CI scaffold
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - "scripts/scaffold/**"
+      - mise.toml
+
+jobs:
+  ci:
+    uses: ./.github/workflows/go_module_ci.yml
+    with:
+      module: scaffold

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - contextcheck # context の伝播漏れ
     - makezero # make + append の初期長バグ
     - wastedassign # 使われない代入
+    - modernize # モダン API への置換提案（strings.Cut / min-max / slices 等）。gopls の指摘を CI でも担保する
     # --- 規約・品質（maintainability） ---
     - gocritic # 高シグナルな診断群
     - revive # golint 後継

--- a/ai-agents/settings/claude/rules/encapsulation.md
+++ b/ai-agents/settings/claude/rules/encapsulation.md
@@ -3,22 +3,22 @@ paths:
   - "**/*.{go,py,ts,tsx,js,jsx,rb,rs,java,kt,lua}"
 ---
 
-# Encapsulation & factory rules
+# カプセル化・ファクトリー規約
 
-When a data structure carries invariants (validated fields, preconditions):
+不変条件（バリデーション済みフィールド、事前条件）を持つデータ構造を扱うとき:
 
-- Construct it only through a factory function (`NewX` / `from_*`) that checks
-  every precondition and fails early — never as a raw literal at call sites.
-- Make invariants unbypassable: keep fields private, and hide the type itself
-  where the language allows (e.g. a Go unexported type returned by an exported
-  factory), so the factory is the only construction path — including
-  zero-value/default construction.
-- Code receiving a factory-built value must not re-validate what construction
-  already guarantees.
-- Attach behavior as methods on the structure instead of free functions that
-  take it as an argument, so related logic stays cohesive.
-- Keep factories and planning logic pure: inject side effects (filesystem,
-  clock, network) as function/interface parameters so tests stay table-driven.
-- If a linter flags the intentional shape (e.g. revive `unexported-return` in
-  Go), suppress it locally with a reasoned inline directive instead of
-  disabling the rule globally.
+- 生成は、すべての事前条件を検証して早期に失敗するファクトリー関数
+  （`NewX` / `from_*`）経由のみとする。呼び出し側で生の構造体リテラルとして
+  組み立てない。
+- 不変条件をバイパス不能にする: フィールドは非公開にし、言語が許すなら型自体も
+  隠す（例: Go で exported なファクトリーが unexported な型を返す）。これにより
+  ゼロ値・デフォルト構築を含め、ファクトリーが唯一の生成経路になる。
+- ファクトリー経由で生成された値を受け取る側は、生成時に保証済みの条件を
+  再検証しない。
+- 振る舞いは、その構造体を引数に取る自由関数ではなくメソッドとして定義し、
+  関連ロジックを凝集させる。
+- ファクトリーや計画系ロジックは純粋に保つ: 副作用（ファイルシステム・時刻・
+  ネットワーク）は関数/インターフェースの引数として注入し、テストを
+  テーブル駆動のまま維持する。
+- 意図的なこの形をリンタが咎める場合（例: Go の revive `unexported-return`）は、
+  ルールを全体で無効化せず、理由コメント付きのインライン抑制で局所対応する。

--- a/ai-agents/settings/claude/rules/encapsulation.md
+++ b/ai-agents/settings/claude/rules/encapsulation.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "**/*.{go,py,ts,tsx,js,jsx,rb,rs,java,kt,lua}"
+---
+
+# Encapsulation & factory rules
+
+When a data structure carries invariants (validated fields, preconditions):
+
+- Construct it only through a factory function (`NewX` / `from_*`) that checks
+  every precondition and fails early — never as a raw literal at call sites.
+- Make invariants unbypassable: keep fields private, and hide the type itself
+  where the language allows (e.g. a Go unexported type returned by an exported
+  factory), so the factory is the only construction path — including
+  zero-value/default construction.
+- Code receiving a factory-built value must not re-validate what construction
+  already guarantees.
+- Attach behavior as methods on the structure instead of free functions that
+  take it as an argument, so related logic stays cohesive.
+- Keep factories and planning logic pure: inject side effects (filesystem,
+  clock, network) as function/interface parameters so tests stay table-driven.
+- If a linter flags the intentional shape (e.g. revive `unexported-return` in
+  Go), suppress it locally with a reasoned inline directive instead of
+  disabling the rule globally.

--- a/mise.toml
+++ b/mise.toml
@@ -166,6 +166,37 @@ description = "Remove go-verify build artifacts"
 dir = "scripts/go-verify"
 run = "rm -f go-verify coverage.out"
 
+# ---- scaffold (Go) ----
+
+[tasks."scaffold:build"]
+description = "Build the scaffold binary"
+dir = "scripts/scaffold"
+run = "go build -o scaffold ./cmd/scaffold"
+
+[tasks."scaffold:test"]
+description = "Run scaffold Go tests"
+dir = "scripts/scaffold"
+run = "go test ./..."
+
+[tasks."scaffold:lint"]
+description = "Run golangci-lint and goimports check for scaffold"
+dir = "scripts/scaffold"
+run = [
+  "golangci-lint run --allow-parallel-runners",
+  '''
+diff=$(find . -name '*.go' -exec goimports -d {} +)
+if [ -n "$diff" ]; then
+  echo "$diff"
+  exit 1
+fi
+''',
+]
+
+[tasks."scaffold:clean"]
+description = "Remove scaffold build artifacts"
+dir = "scripts/scaffold"
+run = "rm -f scaffold coverage.out"
+
 # ---- Aggregates ----
 
 [tasks."go:test"]
@@ -174,7 +205,8 @@ depends = [
   "ai-bridge:test",
   "nvim-sync:test",
   "config-diff:test",
-  "go-verify:test"
+  "go-verify:test",
+  "scaffold:test"
 ]
 
 [tasks."go:lint"]
@@ -183,7 +215,8 @@ depends = [
   "ai-bridge:lint",
   "nvim-sync:lint",
   "config-diff:lint",
-  "go-verify:lint"
+  "go-verify:lint",
+  "scaffold:lint"
 ]
 
 # ---- AI agents deploy: agents.xml symlinks ----

--- a/scripts/scaffold/README.md
+++ b/scripts/scaffold/README.md
@@ -1,0 +1,50 @@
+# scaffold
+
+`scripts/` 配下に**新しい Go モジュールを 1 コマンドで生成する**ジェネレータ。Go 骨格
+（`go.mod` / `cmd/<name>/main.go` + テスト / `README.md`）に加え、対になる CI ワークフロー
+（`.github/workflows/ci_<name>.yml`）を生成し、`mise.toml` へ貼るタスクブロックを標準出力に出す。
+
+新モジュールを足すたびに CI ワークフローと mise タスクを手作業でコピペ・書き換えする運用は、
+ペアのワークフローを作り忘れるとそのモジュールが **CI のパススコープから丸ごと外れる**（検証
+されない）取りこぼしを生む。scaffold は **CI 配線とタスク雛形を生成時に構造的に用意**して
+このクラスのミスを消す。
+
+## 使い方
+
+```sh
+# リポジトリルートで実行する
+scaffold new <name> [--from <module>] [--root <dir>]
+
+# 例
+scaffold new log-tail
+```
+
+- `<name>` はモジュール名（lowercase kebab-case、例 `log-tail`）。
+- `--from` は CI / mise のテンプレート元モジュール（既定 `config-diff`）。
+- `--root` はテンプレートを読み・生成物を書くリポジトリルート（既定 `.`）。
+
+生成後の手順:
+
+1. 出力された mise タスクブロックを `mise.toml` 末尾へ貼る。
+2. `go:test` / `go:lint` の `depends` に `<name>:test` / `<name>:lint` を追加する。
+3. `cmd/<name>/main.go` の `execute` に実装を書き、`mise run <name>:test` / `<name>:lint` で検証する。
+
+## 設計
+
+- **外部依存ゼロ**（標準ライブラリのみ）。生成は一発実行。
+- **テンプレートは生きた既存ファイルから**取る。CI ワークフローと mise タスクは
+  テンプレート元モジュール（既定 `config-diff`）の実ファイルを読み、モジュール名トークンを
+  置換して生成するため、pinned action SHA や `paths:` などの現行規約が自動的に引き継がれ、
+  テンプレートがリポジトリの実体から drift しない。Go 骨格だけは pinned SHA を持たない
+  最小テンプレート。
+- **安全性**：生成は付加のみ。生成先が既に存在する場合は**上書きせず非ゼロ終了**し、
+  既存ファイルは一切 mutate しない。`mise.toml` も in-place 編集はせず、貼るべきブロックを
+  stdout に出すだけ。
+- 生成ロジック（`internal/gen`）は reader / exists コールバックを受ける純粋関数で、
+  `t.TempDir()` 非依存の table-driven テストで網羅する。
+
+## 終了コード
+
+- `0` — 生成成功
+- `1` — 生成エラー（テンプレート読み込み失敗・生成先の衝突など）
+- `2` — 使用方法エラー

--- a/scripts/scaffold/cmd/scaffold/main.go
+++ b/scripts/scaffold/cmd/scaffold/main.go
@@ -56,6 +56,13 @@ func run(args []string, out, errOut io.Writer) int {
 		_, statErr := os.Stat(filepath.Join(*root, rel))
 		return statErr == nil
 	}
+	write := func(rel string, content []byte) error {
+		abs := filepath.Join(*root, rel)
+		if mkErr := os.MkdirAll(filepath.Dir(abs), 0o755); mkErr != nil {
+			return fmt.Errorf("mkdir: %w", mkErr)
+		}
+		return os.WriteFile(abs, content, 0o644)
+	}
 
 	spec, specErr := gen.NewSpec(name, *from, exists)
 	if specErr != nil {
@@ -69,38 +76,13 @@ func run(args []string, out, errOut io.Writer) int {
 		return 1
 	}
 
-	if writeErr := writeFiles(*root, result.Files); writeErr != nil {
+	if writeErr := result.Write(write); writeErr != nil {
 		_, _ = fmt.Fprintln(errOut, "scaffold:", writeErr)
 		return 1
 	}
 
-	report(out, name, result)
+	result.Report(out)
 	return 0
-}
-
-// writeFiles creates each planned file under root, making parent directories.
-func writeFiles(root string, files []gen.File) error {
-	for _, f := range files {
-		abs := filepath.Join(root, f.Path)
-		if mkErr := os.MkdirAll(filepath.Dir(abs), 0o755); mkErr != nil {
-			return fmt.Errorf("mkdir for %s: %w", f.Path, mkErr)
-		}
-		if writeErr := os.WriteFile(abs, []byte(f.Content), 0o644); writeErr != nil {
-			return fmt.Errorf("write %s: %w", f.Path, writeErr)
-		}
-	}
-	return nil
-}
-
-// report prints the created files, the mise block to paste, and next steps.
-func report(out io.Writer, name string, result gen.Result) {
-	_, _ = fmt.Fprintf(out, "Created module %s:\n", name)
-	for _, f := range result.Files {
-		_, _ = fmt.Fprintf(out, "  %s\n", f.Path)
-	}
-	_, _ = fmt.Fprintln(out, "\nAppend this block to mise.toml:")
-	_, _ = fmt.Fprintln(out, result.MiseBlock)
-	_, _ = fmt.Fprintf(out, "Then add %s:test / %s:lint to the go:test / go:lint depends lists.\n", name, name)
 }
 
 // usage prints command usage.

--- a/scripts/scaffold/cmd/scaffold/main.go
+++ b/scripts/scaffold/cmd/scaffold/main.go
@@ -1,0 +1,105 @@
+// Command scaffold generates a new scripts/ Go module together with its CI
+// workflow and mise task block, so adding a module no longer means copying and
+// hand-editing files. The CI workflow and mise block are rendered from a live
+// template module (config-diff by default) so pinned action SHAs and workflow
+// structure follow the repository instead of drifting from a hard-coded copy.
+//
+// Usage:
+//
+//	scaffold new <name> [--from <module>] [--root <dir>]
+//
+// Generation is additive: it never overwrites an existing file and exits
+// non-zero if any target already exists. The mise task block is printed to
+// stdout for manual append (mise.toml is not edited in place).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"scaffold/internal/gen"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run parses arguments and drives generation, returning the process exit code
+// (0 = generated, 1 = generation error/collision, 2 = usage error).
+func run(args []string, out, errOut io.Writer) int {
+	// Expect: new <name> [flags]. Taking the name before flag parsing lets the
+	// name precede flags (Go's flag package stops at the first positional arg).
+	if len(args) < 2 || args[0] != "new" || strings.HasPrefix(args[1], "-") {
+		usage(errOut)
+		return 2
+	}
+	name := args[1]
+
+	fs := flag.NewFlagSet("scaffold new", flag.ContinueOnError)
+	fs.SetOutput(errOut)
+	from := fs.String("from", "config-diff", "existing module to use as the CI/mise template")
+	root := fs.String("root", ".", "repository root to read templates from and write into")
+	if parseErr := fs.Parse(args[2:]); parseErr != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		usage(errOut)
+		return 2
+	}
+
+	spec := gen.Spec{Name: name, From: *from}
+	read := func(rel string) ([]byte, error) { return os.ReadFile(filepath.Join(*root, rel)) }
+	exists := func(rel string) bool {
+		_, statErr := os.Stat(filepath.Join(*root, rel))
+		return statErr == nil
+	}
+
+	result, planErr := gen.Plan(spec, read, exists)
+	if planErr != nil {
+		_, _ = fmt.Fprintln(errOut, "scaffold:", planErr)
+		return 1
+	}
+
+	if writeErr := writeFiles(*root, result.Files); writeErr != nil {
+		_, _ = fmt.Fprintln(errOut, "scaffold:", writeErr)
+		return 1
+	}
+
+	report(out, name, result)
+	return 0
+}
+
+// writeFiles creates each planned file under root, making parent directories.
+func writeFiles(root string, files []gen.File) error {
+	for _, f := range files {
+		abs := filepath.Join(root, f.Path)
+		if mkErr := os.MkdirAll(filepath.Dir(abs), 0o755); mkErr != nil {
+			return fmt.Errorf("mkdir for %s: %w", f.Path, mkErr)
+		}
+		if writeErr := os.WriteFile(abs, []byte(f.Content), 0o644); writeErr != nil {
+			return fmt.Errorf("write %s: %w", f.Path, writeErr)
+		}
+	}
+	return nil
+}
+
+// report prints the created files, the mise block to paste, and next steps.
+func report(out io.Writer, name string, result gen.Result) {
+	_, _ = fmt.Fprintf(out, "Created module %s:\n", name)
+	for _, f := range result.Files {
+		_, _ = fmt.Fprintf(out, "  %s\n", f.Path)
+	}
+	_, _ = fmt.Fprintln(out, "\nAppend this block to mise.toml:")
+	_, _ = fmt.Fprintln(out, result.MiseBlock)
+	_, _ = fmt.Fprintf(out, "Then add %s:test / %s:lint to the go:test / go:lint depends lists.\n", name, name)
+}
+
+// usage prints command usage.
+func usage(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "Usage: scaffold new <name> [--from <module>] [--root <dir>]")
+	_, _ = fmt.Fprintln(out, "  Generates scripts/<name>/, .github/workflows/ci_<name>.yml, and a mise block.")
+}

--- a/scripts/scaffold/cmd/scaffold/main.go
+++ b/scripts/scaffold/cmd/scaffold/main.go
@@ -51,14 +51,19 @@ func run(args []string, out, errOut io.Writer) int {
 		return 2
 	}
 
-	spec := gen.Spec{Name: name, From: *from}
 	read := func(rel string) ([]byte, error) { return os.ReadFile(filepath.Join(*root, rel)) }
 	exists := func(rel string) bool {
 		_, statErr := os.Stat(filepath.Join(*root, rel))
 		return statErr == nil
 	}
 
-	result, planErr := gen.Plan(spec, read, exists)
+	spec, specErr := gen.NewSpec(name, *from, exists)
+	if specErr != nil {
+		_, _ = fmt.Fprintln(errOut, "scaffold:", specErr)
+		return 1
+	}
+
+	result, planErr := spec.Plan(read, exists)
 	if planErr != nil {
 		_, _ = fmt.Fprintln(errOut, "scaffold:", planErr)
 		return 1

--- a/scripts/scaffold/cmd/scaffold/main_test.go
+++ b/scripts/scaffold/cmd/scaffold/main_test.go
@@ -18,6 +18,8 @@ func writeTemplates(t *testing.T, root string) {
 		"# ---- next (Go) ----\n"
 	mustWrite(t, filepath.Join(root, ".github", "workflows", "ci_config_diff.yml"), ci)
 	mustWrite(t, filepath.Join(root, "mise.toml"), mise)
+	// NewSpec requires the --from module to exist under scripts/.
+	mustWrite(t, filepath.Join(root, "scripts", "config-diff", "go.mod"), "module config-diff\n")
 }
 
 func mustWrite(t *testing.T, abs, content string) {

--- a/scripts/scaffold/cmd/scaffold/main_test.go
+++ b/scripts/scaffold/cmd/scaffold/main_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTemplates lays down the minimal template files run() reads from root.
+func writeTemplates(t *testing.T, root string) {
+	t.Helper()
+	ci := "name: CI config-diff\n" +
+		"on:\n  pull_request:\n    paths:\n      - \"scripts/config-diff/**\"\n" +
+		"jobs:\n  ci:\n    uses: ./.github/workflows/go_module_ci.yml\n    with:\n      module: config-diff\n"
+	mise := "# ---- config-diff (Go) ----\n\n" +
+		"[tasks.\"config-diff:build\"]\ndir = \"scripts/config-diff\"\n\n" +
+		"# ---- next (Go) ----\n"
+	mustWrite(t, filepath.Join(root, ".github", "workflows", "ci_config_diff.yml"), ci)
+	mustWrite(t, filepath.Join(root, "mise.toml"), mise)
+}
+
+func mustWrite(t *testing.T, abs, content string) {
+	t.Helper()
+	if mkErr := os.MkdirAll(filepath.Dir(abs), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(abs), mkErr)
+	}
+	if writeErr := os.WriteFile(abs, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("WriteFile %s: %v", abs, writeErr)
+	}
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		args     func(root string) []string
+		setup    func(t *testing.T, root string)
+		wantCode int
+		wantFile string // repository-relative path expected to exist after a successful run
+	}{
+		{
+			name:     "generates module",
+			args:     func(root string) []string { return []string{"new", "log-tail", "--root", root} },
+			setup:    writeTemplates,
+			wantCode: 0,
+			wantFile: "scripts/log-tail/cmd/log-tail/main.go",
+		},
+		{
+			name:     "no subcommand is usage error",
+			args:     func(string) []string { return nil },
+			setup:    func(*testing.T, string) {},
+			wantCode: 2,
+		},
+		{
+			name:     "wrong arg count is usage error",
+			args:     func(root string) []string { return []string{"new", "--root", root} },
+			setup:    writeTemplates,
+			wantCode: 2,
+		},
+		{
+			name:     "missing templates is generation error",
+			args:     func(root string) []string { return []string{"new", "log-tail", "--root", root} },
+			setup:    func(*testing.T, string) {},
+			wantCode: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			var out, errOut bytes.Buffer
+			code := run(tt.args(root), &out, &errOut)
+			if code != tt.wantCode {
+				t.Fatalf("run code = %d, want %d (stderr: %q)", code, tt.wantCode, errOut.String())
+			}
+			if tt.wantFile != "" {
+				if _, statErr := os.Stat(filepath.Join(root, tt.wantFile)); statErr != nil {
+					t.Fatalf("expected %s to exist: %v", tt.wantFile, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestRunRefusesOverwrite(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTemplates(t, root)
+	// Pre-create a target file so generation must refuse.
+	mustWrite(t, filepath.Join(root, "scripts", "log-tail", "go.mod"), "module log-tail\n")
+
+	var out, errOut bytes.Buffer
+	code := run([]string{"new", "log-tail", "--root", root}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("run code = %d, want 1", code)
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("already exists")) {
+		t.Fatalf("stderr = %q, want it to mention already exists", errOut.String())
+	}
+}

--- a/scripts/scaffold/go.mod
+++ b/scripts/scaffold/go.mod
@@ -1,0 +1,3 @@
+module scaffold
+
+go 1.26

--- a/scripts/scaffold/internal/gen/gen.go
+++ b/scripts/scaffold/internal/gen/gen.go
@@ -1,0 +1,240 @@
+// Package gen builds the file set for a new scripts/ Go module from live
+// templates in the repository, so a new module inherits the current CI wiring
+// and mise task conventions instead of a hand-maintained, drift-prone copy.
+//
+// The Go skeleton (go.mod / cmd / README) is a minimal fixed template — it
+// carries no pinned action SHAs and a blank starting point is the point. The
+// CI workflow and mise task block are rendered from the live files of an
+// existing "template" module (config-diff by default) by replacing the module
+// name token, so pinned SHAs and workflow structure follow the repository.
+//
+// Plan is pure: it takes reader/exists callbacks and never touches the
+// filesystem itself, so it is fully exercised from t.TempDir()-independent
+// table-driven tests.
+package gen
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// nameRe constrains a module name to a lowercase kebab-case token so it is a
+// safe path segment, Go module path, and replacement token.
+var nameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
+
+// Spec describes a scaffold request.
+type Spec struct {
+	// Name is the new module name (e.g. "log-tail").
+	Name string
+	// From is the existing module whose CI/mise are used as the template.
+	From string
+}
+
+// File is one file to be written, with a repository-relative path.
+type File struct {
+	Path    string
+	Content string
+}
+
+// Result is the full plan for a scaffold request.
+type Result struct {
+	// Files is the set of files to create (never mutating existing ones).
+	Files []File
+	// MiseBlock is the mise task block to append to mise.toml by hand.
+	MiseBlock string
+}
+
+// ReadFunc reads a repository-relative file, returning its bytes.
+type ReadFunc func(relPath string) ([]byte, error)
+
+// ExistsFunc reports whether a repository-relative path already exists.
+type ExistsFunc func(relPath string) bool
+
+// Plan assembles the files and mise block for spec, reading the template
+// module's live CI workflow and mise.toml through read. It returns an error if
+// the spec is invalid, a template cannot be read, or any target path already
+// exists (generation is additive and never overwrites).
+func Plan(spec Spec, read ReadFunc, exists ExistsFunc) (Result, error) {
+	if validateErr := validate(spec); validateErr != nil {
+		return Result{}, validateErr
+	}
+
+	ciSrcPath := workflowPath(spec.From)
+	ciSrc, readCIErr := read(ciSrcPath)
+	if readCIErr != nil {
+		return Result{}, fmt.Errorf("read template workflow %s: %w", ciSrcPath, readCIErr)
+	}
+
+	miseSrc, readMiseErr := read("mise.toml")
+	if readMiseErr != nil {
+		return Result{}, fmt.Errorf("read mise.toml: %w", readMiseErr)
+	}
+	miseSection, sectionErr := extractMiseSection(string(miseSrc), spec.From)
+	if sectionErr != nil {
+		return Result{}, sectionErr
+	}
+
+	files := []File{
+		{Path: modulePath(spec.Name, "go.mod"), Content: goModContent(spec.Name)},
+		{Path: modulePath(spec.Name, path.Join("cmd", spec.Name, "main.go")), Content: mainContent(spec.Name)},
+		{Path: modulePath(spec.Name, path.Join("cmd", spec.Name, "main_test.go")), Content: mainTestContent(spec.Name)},
+		{Path: modulePath(spec.Name, "README.md"), Content: readmeContent(spec.Name)},
+		{Path: workflowPath(spec.Name), Content: renderToken(string(ciSrc), spec.From, spec.Name)},
+	}
+
+	if collideErr := ensureNoCollisions(files, exists); collideErr != nil {
+		return Result{}, collideErr
+	}
+
+	return Result{
+		Files:     files,
+		MiseBlock: renderToken(miseSection, spec.From, spec.Name),
+	}, nil
+}
+
+// validate checks the spec's names against the kebab-case rule.
+func validate(spec Spec) error {
+	if !nameRe.MatchString(spec.Name) {
+		return fmt.Errorf("invalid module name %q: want lowercase kebab-case (e.g. log-tail)", spec.Name)
+	}
+	if !nameRe.MatchString(spec.From) {
+		return fmt.Errorf("invalid --from module %q: want lowercase kebab-case", spec.From)
+	}
+	if spec.Name == spec.From {
+		return errors.New("module name and --from must differ")
+	}
+	return nil
+}
+
+// ensureNoCollisions fails if any planned file already exists.
+func ensureNoCollisions(files []File, exists ExistsFunc) error {
+	for _, f := range files {
+		if exists(f.Path) {
+			return fmt.Errorf("target already exists, refusing to overwrite: %s", f.Path)
+		}
+	}
+	return nil
+}
+
+// workflowPath returns the CI workflow path for a module. The filename uses
+// underscores (ci_config_diff.yml) while the in-file token stays kebab-case.
+func workflowPath(module string) string {
+	return path.Join(".github", "workflows", "ci_"+strings.ReplaceAll(module, "-", "_")+".yml")
+}
+
+// modulePath joins a repository-relative path under scripts/<module>/.
+func modulePath(module, rel string) string {
+	return path.Join("scripts", module, rel)
+}
+
+// renderToken replaces every occurrence of the from module token with to.
+func renderToken(src, from, to string) string {
+	return strings.ReplaceAll(src, from, to)
+}
+
+// extractMiseSection returns the "# ---- <from> (Go) ----" marker block from
+// mise.toml, up to (but excluding) the next "# ---- " marker.
+func extractMiseSection(mise, from string) (string, error) {
+	marker := "# ---- " + from + " (Go) ----"
+	start := strings.Index(mise, marker)
+	if start < 0 {
+		return "", fmt.Errorf("mise.toml has no %q section to use as a template", marker)
+	}
+	rest := mise[start+len(marker):]
+	next := strings.Index(rest, "# ---- ")
+	section := rest
+	if next >= 0 {
+		section = rest[:next]
+	}
+	return marker + strings.TrimRight(section, "\n") + "\n", nil
+}
+
+// goModContent renders the module's go.mod, matching the Go version other
+// scripts/ modules pin.
+func goModContent(name string) string {
+	return fmt.Sprintf("module %s\n\ngo 1.26\n", name)
+}
+
+// mainContent renders a minimal, testable command skeleton.
+func mainContent(name string) string {
+	return fmt.Sprintf(`// Command %[1]s is a scaffold-generated scripts/ tool. Replace this
+// description and the execute body with the real behaviour.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	os.Exit(execute(os.Args[1:], os.Stdout))
+}
+
+// execute is the testable entry point: it returns the process exit code so
+// tests can drive the command without spawning a process.
+func execute(args []string, out io.Writer) int {
+	_, _ = fmt.Fprintf(out, "%[1]s: %%d args\n", len(args))
+	return 0
+}
+`, name)
+}
+
+// mainTestContent renders a table-driven test for the skeleton, following the
+// scripts/ai-bridge/AGENTS.md conventions (t.Parallel on function and subtests,
+// no err reuse).
+func mainTestContent(name string) string {
+	return fmt.Sprintf(`package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestExecute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode int
+		wantOut  string
+	}{
+		{name: "no args", args: nil, wantCode: 0, wantOut: "%[1]s: 0 args\n"},
+		{name: "two args", args: []string{"a", "b"}, wantCode: 0, wantOut: "%[1]s: 2 args\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			code := execute(tt.args, &out)
+			if code != tt.wantCode {
+				t.Fatalf("execute code = %%d, want %%d", code, tt.wantCode)
+			}
+			if out.String() != tt.wantOut {
+				t.Fatalf("execute out = %%q, want %%q", out.String(), tt.wantOut)
+			}
+		})
+	}
+}
+`, name)
+}
+
+// readmeContent renders a starter README for the generated module.
+func readmeContent(name string) string {
+	return fmt.Sprintf(`# %[1]s
+
+`+"`scripts/%[1]s`"+` の Go ツール雛形。scaffold で生成された。CI ワークフロー
+（`+"`.github/workflows/ci_%[2]s.yml`"+`）と mise タスク（`+"`%[1]s:build|test|lint|clean`"+`）が
+生成時に配線されている。
+
+## 次の手順
+
+1. `+"`cmd/%[1]s/main.go`"+` の `+"`execute`"+` に実装を書く。
+2. mise タスクブロックを `+"`mise.toml`"+` 末尾へ貼り、`+"`go:test`"+` / `+"`go:lint`"+` の
+   `+"`depends`"+` に `+"`%[1]s:test`"+` / `+"`%[1]s:lint`"+` を追加する。
+3. `+"`mise run %[1]s:test`"+` と `+"`mise run %[1]s:lint`"+` で検証する。
+`, name, strings.ReplaceAll(name, "-", "_"))
+}

--- a/scripts/scaffold/internal/gen/gen.go
+++ b/scripts/scaffold/internal/gen/gen.go
@@ -184,16 +184,13 @@ func renderToken(src, from, to string) string {
 // mise.toml, up to (but excluding) the next "# ---- " marker.
 func extractMiseSection(mise, from string) (string, error) {
 	marker := "# ---- " + from + " (Go) ----"
-	start := strings.Index(mise, marker)
-	if start < 0 {
+	_, rest, found := strings.Cut(mise, marker)
+	if !found {
 		return "", fmt.Errorf("mise.toml has no %q section to use as a template", marker)
 	}
-	rest := mise[start+len(marker):]
-	next := strings.Index(rest, "# ---- ")
-	section := rest
-	if next >= 0 {
-		section = rest[:next]
-	}
+	// Cut returns rest unchanged when no next marker exists, which is exactly
+	// the "section runs to end of file" case.
+	section, _, _ := strings.Cut(rest, "# ---- ")
 	return marker + strings.TrimRight(section, "\n") + "\n", nil
 }
 

--- a/scripts/scaffold/internal/gen/gen.go
+++ b/scripts/scaffold/internal/gen/gen.go
@@ -8,14 +8,15 @@
 // existing "template" module (config-diff by default) by replacing the module
 // name token, so pinned SHAs and workflow structure follow the repository.
 //
-// NewSpec and the Plan method are pure: they take reader/exists callbacks and
-// never touch the filesystem themselves, so they are fully exercised from
-// t.TempDir()-independent table-driven tests.
+// NewSpec, the Plan method, and the result methods are pure: they take
+// reader/exists/writer callbacks and never touch the filesystem themselves,
+// so they are fully exercised from t.TempDir()-independent table-driven tests.
 package gen
 
 import (
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"regexp"
 	"strings"
@@ -63,18 +64,22 @@ func NewSpec(name, from string, exists ExistsFunc) (spec, error) {
 	return spec{name: name, from: from}, nil
 }
 
-// File is one file to be written, with a repository-relative path.
-type File struct {
-	Path    string
-	Content string
+// file is one file to be written, with a repository-relative path.
+type file struct {
+	path    string
+	content string
 }
 
-// Result is the full plan for a scaffold request.
-type Result struct {
-	// Files is the set of files to create (never mutating existing ones).
-	Files []File
-	// MiseBlock is the mise task block to append to mise.toml by hand.
-	MiseBlock string
+// result is the full plan for a scaffold request. The type is unexported for
+// the same reason as spec: Plan is the only way to obtain one, so every
+// result in existence is collision-checked and fully rendered.
+type result struct {
+	// name is the new module name the plan was built for.
+	name string
+	// files is the set of files to create (never mutating existing ones).
+	files []file
+	// miseBlock is the mise task block to append to mise.toml by hand.
+	miseBlock string
 }
 
 // ReadFunc reads a repository-relative file, returning its bytes.
@@ -83,50 +88,77 @@ type ReadFunc func(relPath string) ([]byte, error)
 // ExistsFunc reports whether a repository-relative path already exists.
 type ExistsFunc func(relPath string) bool
 
+// WriteFunc creates a repository-relative file with the given content,
+// making any parent directories.
+type WriteFunc func(relPath string, content []byte) error
+
 // Plan assembles the files and mise block for the spec, reading the template
 // module's live CI workflow and mise.toml through read. It returns an error if
 // a template cannot be read or any target path already exists (generation is
 // additive and never overwrites). Name validity is already guaranteed by
 // NewSpec.
-func (s spec) Plan(read ReadFunc, exists ExistsFunc) (Result, error) {
+func (s spec) Plan(read ReadFunc, exists ExistsFunc) (result, error) {
 	ciSrcPath := workflowPath(s.from)
 	ciSrc, readCIErr := read(ciSrcPath)
 	if readCIErr != nil {
-		return Result{}, fmt.Errorf("read template workflow %s: %w", ciSrcPath, readCIErr)
+		return result{}, fmt.Errorf("read template workflow %s: %w", ciSrcPath, readCIErr)
 	}
 
 	miseSrc, readMiseErr := read("mise.toml")
 	if readMiseErr != nil {
-		return Result{}, fmt.Errorf("read mise.toml: %w", readMiseErr)
+		return result{}, fmt.Errorf("read mise.toml: %w", readMiseErr)
 	}
 	miseSection, sectionErr := extractMiseSection(string(miseSrc), s.from)
 	if sectionErr != nil {
-		return Result{}, sectionErr
+		return result{}, sectionErr
 	}
 
-	files := []File{
-		{Path: modulePath(s.name, "go.mod"), Content: goModContent(s.name)},
-		{Path: modulePath(s.name, path.Join("cmd", s.name, "main.go")), Content: mainContent(s.name)},
-		{Path: modulePath(s.name, path.Join("cmd", s.name, "main_test.go")), Content: mainTestContent(s.name)},
-		{Path: modulePath(s.name, "README.md"), Content: readmeContent(s.name)},
-		{Path: workflowPath(s.name), Content: renderToken(string(ciSrc), s.from, s.name)},
+	files := []file{
+		{path: modulePath(s.name, "go.mod"), content: goModContent(s.name)},
+		{path: modulePath(s.name, path.Join("cmd", s.name, "main.go")), content: mainContent(s.name)},
+		{path: modulePath(s.name, path.Join("cmd", s.name, "main_test.go")), content: mainTestContent(s.name)},
+		{path: modulePath(s.name, "README.md"), content: readmeContent(s.name)},
+		{path: workflowPath(s.name), content: renderToken(string(ciSrc), s.from, s.name)},
 	}
 
 	if collideErr := ensureNoCollisions(files, exists); collideErr != nil {
-		return Result{}, collideErr
+		return result{}, collideErr
 	}
 
-	return Result{
-		Files:     files,
-		MiseBlock: renderToken(miseSection, s.from, s.name),
+	return result{
+		name:      s.name,
+		files:     files,
+		miseBlock: renderToken(miseSection, s.from, s.name),
 	}, nil
 }
 
+// Write creates every planned file through the injected write callback, so
+// the plan stays pure and the filesystem effect lives with the caller.
+func (r result) Write(write WriteFunc) error {
+	for _, f := range r.files {
+		if writeErr := write(f.path, []byte(f.content)); writeErr != nil {
+			return fmt.Errorf("write %s: %w", f.path, writeErr)
+		}
+	}
+	return nil
+}
+
+// Report prints the created files, the mise block to paste, and next steps.
+func (r result) Report(out io.Writer) {
+	_, _ = fmt.Fprintf(out, "Created module %s:\n", r.name)
+	for _, f := range r.files {
+		_, _ = fmt.Fprintf(out, "  %s\n", f.path)
+	}
+	_, _ = fmt.Fprintln(out, "\nAppend this block to mise.toml:")
+	_, _ = fmt.Fprintln(out, r.miseBlock)
+	_, _ = fmt.Fprintf(out, "Then add %s:test / %s:lint to the go:test / go:lint depends lists.\n", r.name, r.name)
+}
+
 // ensureNoCollisions fails if any planned file already exists.
-func ensureNoCollisions(files []File, exists ExistsFunc) error {
+func ensureNoCollisions(files []file, exists ExistsFunc) error {
 	for _, f := range files {
-		if exists(f.Path) {
-			return fmt.Errorf("target already exists, refusing to overwrite: %s", f.Path)
+		if exists(f.path) {
+			return fmt.Errorf("target already exists, refusing to overwrite: %s", f.path)
 		}
 	}
 	return nil

--- a/scripts/scaffold/internal/gen/gen.go
+++ b/scripts/scaffold/internal/gen/gen.go
@@ -8,8 +8,8 @@
 // existing "template" module (config-diff by default) by replacing the module
 // name token, so pinned SHAs and workflow structure follow the repository.
 //
-// NewSpec and Spec.Plan are pure: they take reader/exists callbacks and never
-// touch the filesystem themselves, so they are fully exercised from
+// NewSpec and the Plan method are pure: they take reader/exists callbacks and
+// never touch the filesystem themselves, so they are fully exercised from
 // t.TempDir()-independent table-driven tests.
 package gen
 
@@ -25,37 +25,42 @@ import (
 // safe path segment, Go module path, and replacement token.
 var nameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
 
-// Spec describes a validated scaffold request. The zero value is not usable;
-// build one through NewSpec so every Spec that exists satisfies the
-// preconditions (valid names, --from present, new module absent).
-type Spec struct {
+// spec describes a validated scaffold request. The type is unexported so the
+// only way for callers to obtain one is NewSpec, which means every spec in
+// existence satisfies the preconditions (valid names, --from present, new
+// module absent) — including that a zero-value bypass is impossible outside
+// this package.
+type spec struct {
 	// name is the new module name (e.g. "log-tail").
 	name string
 	// from is the existing module whose CI/mise are used as the template.
 	from string
 }
 
-// NewSpec validates a scaffold request and returns a Spec that is guaranteed
+// NewSpec validates a scaffold request and returns a spec that is guaranteed
 // to satisfy the generation preconditions: both names are lowercase
 // kebab-case, the --from module exists under scripts/ (it is the template to
 // read), and the new module does not exist yet (generation never overwrites).
-func NewSpec(name, from string, exists ExistsFunc) (Spec, error) {
+// the only way to obtain a spec, so the preconditions above always hold.
+//
+//nolint:revive // Returning the unexported type is deliberate: it makes NewSpec
+func NewSpec(name, from string, exists ExistsFunc) (spec, error) {
 	if !nameRe.MatchString(name) {
-		return Spec{}, fmt.Errorf("invalid module name %q: want lowercase kebab-case (e.g. log-tail)", name)
+		return spec{}, fmt.Errorf("invalid module name %q: want lowercase kebab-case (e.g. log-tail)", name)
 	}
 	if !nameRe.MatchString(from) {
-		return Spec{}, fmt.Errorf("invalid --from module %q: want lowercase kebab-case", from)
+		return spec{}, fmt.Errorf("invalid --from module %q: want lowercase kebab-case", from)
 	}
 	if name == from {
-		return Spec{}, errors.New("module name and --from must differ")
+		return spec{}, errors.New("module name and --from must differ")
 	}
 	if !exists(modulePath(from, "")) {
-		return Spec{}, fmt.Errorf("--from module %q not found under scripts/", from)
+		return spec{}, fmt.Errorf("--from module %q not found under scripts/", from)
 	}
 	if exists(modulePath(name, "")) {
-		return Spec{}, fmt.Errorf("%s already exists, refusing to overwrite", modulePath(name, ""))
+		return spec{}, fmt.Errorf("%s already exists, refusing to overwrite", modulePath(name, ""))
 	}
-	return Spec{name: name, from: from}, nil
+	return spec{name: name, from: from}, nil
 }
 
 // File is one file to be written, with a repository-relative path.
@@ -83,7 +88,7 @@ type ExistsFunc func(relPath string) bool
 // a template cannot be read or any target path already exists (generation is
 // additive and never overwrites). Name validity is already guaranteed by
 // NewSpec.
-func (s Spec) Plan(read ReadFunc, exists ExistsFunc) (Result, error) {
+func (s spec) Plan(read ReadFunc, exists ExistsFunc) (Result, error) {
 	ciSrcPath := workflowPath(s.from)
 	ciSrc, readCIErr := read(ciSrcPath)
 	if readCIErr != nil {

--- a/scripts/scaffold/internal/gen/gen.go
+++ b/scripts/scaffold/internal/gen/gen.go
@@ -8,9 +8,9 @@
 // existing "template" module (config-diff by default) by replacing the module
 // name token, so pinned SHAs and workflow structure follow the repository.
 //
-// Plan is pure: it takes reader/exists callbacks and never touches the
-// filesystem itself, so it is fully exercised from t.TempDir()-independent
-// table-driven tests.
+// NewSpec and Spec.Plan are pure: they take reader/exists callbacks and never
+// touch the filesystem themselves, so they are fully exercised from
+// t.TempDir()-independent table-driven tests.
 package gen
 
 import (
@@ -25,12 +25,37 @@ import (
 // safe path segment, Go module path, and replacement token.
 var nameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
 
-// Spec describes a scaffold request.
+// Spec describes a validated scaffold request. The zero value is not usable;
+// build one through NewSpec so every Spec that exists satisfies the
+// preconditions (valid names, --from present, new module absent).
 type Spec struct {
-	// Name is the new module name (e.g. "log-tail").
-	Name string
-	// From is the existing module whose CI/mise are used as the template.
-	From string
+	// name is the new module name (e.g. "log-tail").
+	name string
+	// from is the existing module whose CI/mise are used as the template.
+	from string
+}
+
+// NewSpec validates a scaffold request and returns a Spec that is guaranteed
+// to satisfy the generation preconditions: both names are lowercase
+// kebab-case, the --from module exists under scripts/ (it is the template to
+// read), and the new module does not exist yet (generation never overwrites).
+func NewSpec(name, from string, exists ExistsFunc) (Spec, error) {
+	if !nameRe.MatchString(name) {
+		return Spec{}, fmt.Errorf("invalid module name %q: want lowercase kebab-case (e.g. log-tail)", name)
+	}
+	if !nameRe.MatchString(from) {
+		return Spec{}, fmt.Errorf("invalid --from module %q: want lowercase kebab-case", from)
+	}
+	if name == from {
+		return Spec{}, errors.New("module name and --from must differ")
+	}
+	if !exists(modulePath(from, "")) {
+		return Spec{}, fmt.Errorf("--from module %q not found under scripts/", from)
+	}
+	if exists(modulePath(name, "")) {
+		return Spec{}, fmt.Errorf("%s already exists, refusing to overwrite", modulePath(name, ""))
+	}
+	return Spec{name: name, from: from}, nil
 }
 
 // File is one file to be written, with a repository-relative path.
@@ -53,16 +78,13 @@ type ReadFunc func(relPath string) ([]byte, error)
 // ExistsFunc reports whether a repository-relative path already exists.
 type ExistsFunc func(relPath string) bool
 
-// Plan assembles the files and mise block for spec, reading the template
+// Plan assembles the files and mise block for the spec, reading the template
 // module's live CI workflow and mise.toml through read. It returns an error if
-// the spec is invalid, a template cannot be read, or any target path already
-// exists (generation is additive and never overwrites).
-func Plan(spec Spec, read ReadFunc, exists ExistsFunc) (Result, error) {
-	if validateErr := validate(spec); validateErr != nil {
-		return Result{}, validateErr
-	}
-
-	ciSrcPath := workflowPath(spec.From)
+// a template cannot be read or any target path already exists (generation is
+// additive and never overwrites). Name validity is already guaranteed by
+// NewSpec.
+func (s Spec) Plan(read ReadFunc, exists ExistsFunc) (Result, error) {
+	ciSrcPath := workflowPath(s.from)
 	ciSrc, readCIErr := read(ciSrcPath)
 	if readCIErr != nil {
 		return Result{}, fmt.Errorf("read template workflow %s: %w", ciSrcPath, readCIErr)
@@ -72,17 +94,17 @@ func Plan(spec Spec, read ReadFunc, exists ExistsFunc) (Result, error) {
 	if readMiseErr != nil {
 		return Result{}, fmt.Errorf("read mise.toml: %w", readMiseErr)
 	}
-	miseSection, sectionErr := extractMiseSection(string(miseSrc), spec.From)
+	miseSection, sectionErr := extractMiseSection(string(miseSrc), s.from)
 	if sectionErr != nil {
 		return Result{}, sectionErr
 	}
 
 	files := []File{
-		{Path: modulePath(spec.Name, "go.mod"), Content: goModContent(spec.Name)},
-		{Path: modulePath(spec.Name, path.Join("cmd", spec.Name, "main.go")), Content: mainContent(spec.Name)},
-		{Path: modulePath(spec.Name, path.Join("cmd", spec.Name, "main_test.go")), Content: mainTestContent(spec.Name)},
-		{Path: modulePath(spec.Name, "README.md"), Content: readmeContent(spec.Name)},
-		{Path: workflowPath(spec.Name), Content: renderToken(string(ciSrc), spec.From, spec.Name)},
+		{Path: modulePath(s.name, "go.mod"), Content: goModContent(s.name)},
+		{Path: modulePath(s.name, path.Join("cmd", s.name, "main.go")), Content: mainContent(s.name)},
+		{Path: modulePath(s.name, path.Join("cmd", s.name, "main_test.go")), Content: mainTestContent(s.name)},
+		{Path: modulePath(s.name, "README.md"), Content: readmeContent(s.name)},
+		{Path: workflowPath(s.name), Content: renderToken(string(ciSrc), s.from, s.name)},
 	}
 
 	if collideErr := ensureNoCollisions(files, exists); collideErr != nil {
@@ -91,22 +113,8 @@ func Plan(spec Spec, read ReadFunc, exists ExistsFunc) (Result, error) {
 
 	return Result{
 		Files:     files,
-		MiseBlock: renderToken(miseSection, spec.From, spec.Name),
+		MiseBlock: renderToken(miseSection, s.from, s.name),
 	}, nil
-}
-
-// validate checks the spec's names against the kebab-case rule.
-func validate(spec Spec) error {
-	if !nameRe.MatchString(spec.Name) {
-		return fmt.Errorf("invalid module name %q: want lowercase kebab-case (e.g. log-tail)", spec.Name)
-	}
-	if !nameRe.MatchString(spec.From) {
-		return fmt.Errorf("invalid --from module %q: want lowercase kebab-case", spec.From)
-	}
-	if spec.Name == spec.From {
-		return errors.New("module name and --from must differ")
-	}
-	return nil
 }
 
 // ensureNoCollisions fails if any planned file already exists.

--- a/scripts/scaffold/internal/gen/gen_test.go
+++ b/scripts/scaffold/internal/gen/gen_test.go
@@ -55,14 +55,14 @@ func noneExist(string) bool { return false }
 // valid state for NewSpec: --from exists, the new module does not.
 func fromOnlyExists(rel string) bool { return rel == "scripts/config-diff" }
 
-// mustSpec builds a valid Spec through the factory, failing the test on error.
-func mustSpec(t *testing.T, name, from string) Spec {
+// mustSpec builds a valid spec through the factory, failing the test on error.
+func mustSpec(t *testing.T, name, from string) spec {
 	t.Helper()
-	spec, newErr := NewSpec(name, from, fromOnlyExists)
+	s, newErr := NewSpec(name, from, fromOnlyExists)
 	if newErr != nil {
 		t.Fatalf("NewSpec(%q, %q) returned error: %v", name, from, newErr)
 	}
-	return spec
+	return s
 }
 
 func TestNewSpecErrors(t *testing.T) {
@@ -169,19 +169,19 @@ func TestPlanErrors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		spec    Spec
+		spec    spec
 		read    ReadFunc
 		exists  ExistsFunc
 		wantSub string
 	}{
 		{
 			name: "missing template workflow",
-			spec: func() Spec {
-				spec, newErr := NewSpec("log-tail", "ghost", func(rel string) bool { return rel == "scripts/ghost" })
+			spec: func() spec {
+				s, newErr := NewSpec("log-tail", "ghost", func(rel string) bool { return rel == "scripts/ghost" })
 				if newErr != nil {
 					panic(newErr)
 				}
-				return spec
+				return s
 			}(),
 			read:    fakeRead,
 			exists:  noneExist,
@@ -208,11 +208,11 @@ func TestPlanErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			spec := tt.spec
-			if spec == (Spec{}) {
-				spec = mustSpec(t, "log-tail", "config-diff")
+			s := tt.spec
+			if s == (spec{}) {
+				s = mustSpec(t, "log-tail", "config-diff")
 			}
-			_, planErr := spec.Plan(tt.read, tt.exists)
+			_, planErr := s.Plan(tt.read, tt.exists)
 			if planErr == nil {
 				t.Fatalf("Plan returned nil error, want error containing %q", tt.wantSub)
 			}

--- a/scripts/scaffold/internal/gen/gen_test.go
+++ b/scripts/scaffold/internal/gen/gen_test.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -131,6 +132,16 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("Plan returned error: %v", planErr)
 	}
 
+	// Observe the planned files through Write with a recording callback, the
+	// same way main consumes the plan.
+	written := map[string]string{}
+	if writeErr := res.Write(func(rel string, content []byte) error {
+		written[rel] = string(content)
+		return nil
+	}); writeErr != nil {
+		t.Fatalf("Write returned error: %v", writeErr)
+	}
+
 	wantPaths := map[string]bool{
 		"scripts/log-tail/go.mod":                    false,
 		"scripts/log-tail/cmd/log-tail/main.go":      false,
@@ -138,14 +149,14 @@ func TestPlan(t *testing.T) {
 		"scripts/log-tail/README.md":                 false,
 		".github/workflows/ci_log_tail.yml":          false,
 	}
-	for _, f := range res.Files {
-		if _, ok := wantPaths[f.Path]; !ok {
-			t.Errorf("unexpected file %q", f.Path)
+	for p, content := range written {
+		if _, ok := wantPaths[p]; !ok {
+			t.Errorf("unexpected file %q", p)
 			continue
 		}
-		wantPaths[f.Path] = true
-		if strings.Contains(f.Content, "config-diff") {
-			t.Errorf("file %q still contains template token config-diff", f.Path)
+		wantPaths[p] = true
+		if strings.Contains(content, "config-diff") {
+			t.Errorf("file %q still contains template token config-diff", p)
 		}
 	}
 	for p, seen := range wantPaths {
@@ -154,14 +165,36 @@ func TestPlan(t *testing.T) {
 		}
 	}
 
-	if !strings.Contains(res.MiseBlock, `[tasks."log-tail:build"]`) {
-		t.Errorf("mise block missing renamed task: %q", res.MiseBlock)
+	var report bytes.Buffer
+	res.Report(&report)
+	got := report.String()
+	if !strings.Contains(got, `[tasks."log-tail:build"]`) {
+		t.Errorf("report missing renamed mise task: %q", got)
 	}
-	if strings.Contains(res.MiseBlock, "go-verify") {
-		t.Errorf("mise block leaked the next section: %q", res.MiseBlock)
+	if strings.Contains(got, "go-verify") {
+		t.Errorf("report leaked the next mise section: %q", got)
 	}
-	if strings.Contains(res.MiseBlock, "config-diff") {
-		t.Errorf("mise block still contains template token: %q", res.MiseBlock)
+	if strings.Contains(got, "config-diff") {
+		t.Errorf("report still contains template token: %q", got)
+	}
+	if !strings.Contains(got, "Created module log-tail:") {
+		t.Errorf("report missing header: %q", got)
+	}
+}
+
+func TestWritePropagatesError(t *testing.T) {
+	t.Parallel()
+	res, planErr := mustSpec(t, "log-tail", "config-diff").Plan(fakeRead, noneExist)
+	if planErr != nil {
+		t.Fatalf("Plan returned error: %v", planErr)
+	}
+
+	writeErr := res.Write(func(string, []byte) error { return errors.New("disk full") })
+	if writeErr == nil {
+		t.Fatal("Write returned nil error, want error")
+	}
+	if !strings.Contains(writeErr.Error(), "write scripts/log-tail/go.mod") || !strings.Contains(writeErr.Error(), "disk full") {
+		t.Fatalf("Write error = %q, want it to name the file and wrap the cause", writeErr.Error())
 	}
 }
 

--- a/scripts/scaffold/internal/gen/gen_test.go
+++ b/scripts/scaffold/internal/gen/gen_test.go
@@ -1,0 +1,234 @@
+package gen
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeCITemplate is a minimal stand-in for .github/workflows/ci_config_diff.yml.
+const fakeCITemplate = `name: CI config-diff
+on:
+  pull_request:
+    paths:
+      - "scripts/config-diff/**"
+      - mise.toml
+jobs:
+  ci:
+    uses: ./.github/workflows/go_module_ci.yml
+    with:
+      module: config-diff
+`
+
+// fakeMise is a minimal stand-in for mise.toml with two module sections.
+const fakeMise = `# ---- config-diff (Go) ----
+
+[tasks."config-diff:build"]
+dir = "scripts/config-diff"
+run = "go build -o config-diff ./cmd/config-diff"
+
+[tasks."config-diff:clean"]
+run = "rm -f config-diff coverage.out"
+
+# ---- go-verify (Go) ----
+
+[tasks."go-verify:build"]
+dir = "scripts/go-verify"
+`
+
+// fakeRead returns the fake templates keyed by repository-relative path.
+func fakeRead(rel string) ([]byte, error) {
+	switch rel {
+	case ".github/workflows/ci_config_diff.yml":
+		return []byte(fakeCITemplate), nil
+	case "mise.toml":
+		return []byte(fakeMise), nil
+	default:
+		return nil, errors.New("no such file: " + rel)
+	}
+}
+
+// noneExist reports every path as absent.
+func noneExist(string) bool { return false }
+
+func TestPlan(t *testing.T) {
+	t.Parallel()
+	res, planErr := Plan(Spec{Name: "log-tail", From: "config-diff"}, fakeRead, noneExist)
+	if planErr != nil {
+		t.Fatalf("Plan returned error: %v", planErr)
+	}
+
+	wantPaths := map[string]bool{
+		"scripts/log-tail/go.mod":                    false,
+		"scripts/log-tail/cmd/log-tail/main.go":      false,
+		"scripts/log-tail/cmd/log-tail/main_test.go": false,
+		"scripts/log-tail/README.md":                 false,
+		".github/workflows/ci_log_tail.yml":          false,
+	}
+	for _, f := range res.Files {
+		if _, ok := wantPaths[f.Path]; !ok {
+			t.Errorf("unexpected file %q", f.Path)
+			continue
+		}
+		wantPaths[f.Path] = true
+		if strings.Contains(f.Content, "config-diff") {
+			t.Errorf("file %q still contains template token config-diff", f.Path)
+		}
+	}
+	for p, seen := range wantPaths {
+		if !seen {
+			t.Errorf("missing expected file %q", p)
+		}
+	}
+
+	if !strings.Contains(res.MiseBlock, `[tasks."log-tail:build"]`) {
+		t.Errorf("mise block missing renamed task: %q", res.MiseBlock)
+	}
+	if strings.Contains(res.MiseBlock, "go-verify") {
+		t.Errorf("mise block leaked the next section: %q", res.MiseBlock)
+	}
+	if strings.Contains(res.MiseBlock, "config-diff") {
+		t.Errorf("mise block still contains template token: %q", res.MiseBlock)
+	}
+}
+
+func TestPlanErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    Spec
+		read    ReadFunc
+		exists  ExistsFunc
+		wantSub string
+	}{
+		{
+			name:    "invalid name",
+			spec:    Spec{Name: "Bad_Name", From: "config-diff"},
+			read:    fakeRead,
+			exists:  noneExist,
+			wantSub: "invalid module name",
+		},
+		{
+			name:    "invalid from",
+			spec:    Spec{Name: "log-tail", From: "Bad"},
+			read:    fakeRead,
+			exists:  noneExist,
+			wantSub: "invalid --from",
+		},
+		{
+			name:    "same name and from",
+			spec:    Spec{Name: "config-diff", From: "config-diff"},
+			read:    fakeRead,
+			exists:  noneExist,
+			wantSub: "must differ",
+		},
+		{
+			name:    "missing template workflow",
+			spec:    Spec{Name: "log-tail", From: "ghost"},
+			read:    fakeRead,
+			exists:  noneExist,
+			wantSub: "read template workflow",
+		},
+		{
+			name: "missing mise section",
+			spec: Spec{Name: "log-tail", From: "config-diff"},
+			read: func(rel string) ([]byte, error) {
+				if rel == "mise.toml" {
+					return []byte("# ---- other (Go) ----\n"), nil
+				}
+				return fakeRead(rel)
+			},
+			exists:  noneExist,
+			wantSub: "no",
+		},
+		{
+			name:    "collision refuses overwrite",
+			spec:    Spec{Name: "log-tail", From: "config-diff"},
+			read:    fakeRead,
+			exists:  func(rel string) bool { return rel == "scripts/log-tail/go.mod" },
+			wantSub: "already exists",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, planErr := Plan(tt.spec, tt.read, tt.exists)
+			if planErr == nil {
+				t.Fatalf("Plan returned nil error, want error containing %q", tt.wantSub)
+			}
+			if !strings.Contains(planErr.Error(), tt.wantSub) {
+				t.Fatalf("Plan error = %q, want it to contain %q", planErr.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestExtractMiseSection(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		mise     string
+		from     string
+		wantSub  string
+		wantErr  bool
+		wantTail string
+	}{
+		{
+			name:     "extracts bounded section",
+			mise:     fakeMise,
+			from:     "config-diff",
+			wantSub:  `[tasks."config-diff:build"]`,
+			wantTail: "\n",
+		},
+		{
+			name:    "missing section errors",
+			mise:    "# ---- other (Go) ----\n",
+			from:    "config-diff",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, sectionErr := extractMiseSection(tt.mise, tt.from)
+			if tt.wantErr {
+				if sectionErr == nil {
+					t.Fatalf("extractMiseSection error = nil, want error")
+				}
+				return
+			}
+			if sectionErr != nil {
+				t.Fatalf("extractMiseSection error = %v", sectionErr)
+			}
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("section = %q, want it to contain %q", got, tt.wantSub)
+			}
+			if strings.Contains(got, "go-verify") {
+				t.Errorf("section leaked next block: %q", got)
+			}
+			if !strings.HasSuffix(got, tt.wantTail) {
+				t.Errorf("section = %q, want suffix %q", got, tt.wantTail)
+			}
+		})
+	}
+}
+
+func TestWorkflowPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		module string
+		want   string
+	}{
+		{name: "kebab becomes underscore", module: "config-diff", want: ".github/workflows/ci_config_diff.yml"},
+		{name: "single word", module: "doctor", want: ".github/workflows/ci_doctor.yml"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := workflowPath(tt.module); got != tt.want {
+				t.Fatalf("workflowPath(%q) = %q, want %q", tt.module, got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/scaffold/internal/gen/gen_test.go
+++ b/scripts/scaffold/internal/gen/gen_test.go
@@ -51,9 +51,82 @@ func fakeRead(rel string) ([]byte, error) {
 // noneExist reports every path as absent.
 func noneExist(string) bool { return false }
 
+// fromOnlyExists reports only the template module directory as present, the
+// valid state for NewSpec: --from exists, the new module does not.
+func fromOnlyExists(rel string) bool { return rel == "scripts/config-diff" }
+
+// mustSpec builds a valid Spec through the factory, failing the test on error.
+func mustSpec(t *testing.T, name, from string) Spec {
+	t.Helper()
+	spec, newErr := NewSpec(name, from, fromOnlyExists)
+	if newErr != nil {
+		t.Fatalf("NewSpec(%q, %q) returned error: %v", name, from, newErr)
+	}
+	return spec
+}
+
+func TestNewSpecErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		modName string
+		from    string
+		exists  ExistsFunc
+		wantSub string
+	}{
+		{
+			name:    "invalid name",
+			modName: "Bad_Name",
+			from:    "config-diff",
+			exists:  fromOnlyExists,
+			wantSub: "invalid module name",
+		},
+		{
+			name:    "invalid from",
+			modName: "log-tail",
+			from:    "Bad",
+			exists:  fromOnlyExists,
+			wantSub: "invalid --from",
+		},
+		{
+			name:    "same name and from",
+			modName: "config-diff",
+			from:    "config-diff",
+			exists:  fromOnlyExists,
+			wantSub: "must differ",
+		},
+		{
+			name:    "from module missing",
+			modName: "log-tail",
+			from:    "ghost",
+			exists:  fromOnlyExists,
+			wantSub: "not found",
+		},
+		{
+			name:    "new module already exists",
+			modName: "log-tail",
+			from:    "config-diff",
+			exists:  func(string) bool { return true },
+			wantSub: "already exists",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, newErr := NewSpec(tt.modName, tt.from, tt.exists)
+			if newErr == nil {
+				t.Fatalf("NewSpec returned nil error, want error containing %q", tt.wantSub)
+			}
+			if !strings.Contains(newErr.Error(), tt.wantSub) {
+				t.Fatalf("NewSpec error = %q, want it to contain %q", newErr.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
 func TestPlan(t *testing.T) {
 	t.Parallel()
-	res, planErr := Plan(Spec{Name: "log-tail", From: "config-diff"}, fakeRead, noneExist)
+	res, planErr := mustSpec(t, "log-tail", "config-diff").Plan(fakeRead, noneExist)
 	if planErr != nil {
 		t.Fatalf("Plan returned error: %v", planErr)
 	}
@@ -102,36 +175,20 @@ func TestPlanErrors(t *testing.T) {
 		wantSub string
 	}{
 		{
-			name:    "invalid name",
-			spec:    Spec{Name: "Bad_Name", From: "config-diff"},
-			read:    fakeRead,
-			exists:  noneExist,
-			wantSub: "invalid module name",
-		},
-		{
-			name:    "invalid from",
-			spec:    Spec{Name: "log-tail", From: "Bad"},
-			read:    fakeRead,
-			exists:  noneExist,
-			wantSub: "invalid --from",
-		},
-		{
-			name:    "same name and from",
-			spec:    Spec{Name: "config-diff", From: "config-diff"},
-			read:    fakeRead,
-			exists:  noneExist,
-			wantSub: "must differ",
-		},
-		{
-			name:    "missing template workflow",
-			spec:    Spec{Name: "log-tail", From: "ghost"},
+			name: "missing template workflow",
+			spec: func() Spec {
+				spec, newErr := NewSpec("log-tail", "ghost", func(rel string) bool { return rel == "scripts/ghost" })
+				if newErr != nil {
+					panic(newErr)
+				}
+				return spec
+			}(),
 			read:    fakeRead,
 			exists:  noneExist,
 			wantSub: "read template workflow",
 		},
 		{
 			name: "missing mise section",
-			spec: Spec{Name: "log-tail", From: "config-diff"},
 			read: func(rel string) ([]byte, error) {
 				if rel == "mise.toml" {
 					return []byte("# ---- other (Go) ----\n"), nil
@@ -143,7 +200,6 @@ func TestPlanErrors(t *testing.T) {
 		},
 		{
 			name:    "collision refuses overwrite",
-			spec:    Spec{Name: "log-tail", From: "config-diff"},
 			read:    fakeRead,
 			exists:  func(rel string) bool { return rel == "scripts/log-tail/go.mod" },
 			wantSub: "already exists",
@@ -152,7 +208,11 @@ func TestPlanErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, planErr := Plan(tt.spec, tt.read, tt.exists)
+			spec := tt.spec
+			if spec == (Spec{}) {
+				spec = mustSpec(t, "log-tail", "config-diff")
+			}
+			_, planErr := spec.Plan(tt.read, tt.exists)
 			if planErr == nil {
 				t.Fatalf("Plan returned nil error, want error containing %q", tt.wantSub)
 			}


### PR DESCRIPTION
Closes #490

## 何を

`scripts/scaffold/` に、新しい `scripts/` Go モジュールを 1 コマンドで生成する net-new ツールを追加した。

```sh
scaffold new <name> [--from <module>] [--root <dir>]
```

生成物（すべて付加のみ／既存ファイルは一切 mutate しない）:

- `scripts/<name>/` の Go 骨格: `go.mod` / `cmd/<name>/main.go` + table-driven テスト / `README.md`
- 対になる CI ワークフロー `.github/workflows/ci_<name>.yml`
- `mise.toml` に貼るタスクブロック（`<name>:build|test|lint|clean`）を **stdout に出力**（TOML の in-place 編集はしない）

生成先が既に存在する場合は**上書きせず非ゼロ終了**する。scaffold 自身も `ci_scaffold.yml` と mise タスクで self-host した（`go:test` / `go:lint` の depends にも追加済み）。

## なぜ

モジュールを 1 つ足すたびに CI ワークフローと mise タスクを手作業でコピペ・書き換える運用は、ペアのワークフローを作り忘れるとそのモジュールが CI のパススコープから丸ごと外れる（＝検証されない）取りこぼしを生む（#457 / #465 / #472 が繰り返し警告してきた穴）。scaffold は CI 配線とタスク雛形を生成時に構造的に用意し、このクラスのミスを消す。

## 設計上の注意（Issue との差分）

Issue #490 は当時の CI 構成（`lint_<name>.yml` / `test_<name>.yml` のペア複製）を前提に書かれていたが、その後 CI は **薄い `ci_<name>.yml` + 再利用ワークフロー `go_module_ci.yml`** に refactor 済み。本 PR は Issue の核心（**生きたテンプレートから新モジュールと CI/タスク配線を生成する**）を現行構成に合わせて実装した。CI とタスクは既存モジュール（既定 `config-diff`）の実ファイルを読んでトークン置換するため、`go_module_ci.yml` 参照や `paths:` などの現行規約を自動追従する（drift 回避）。Go 骨格のみ pinned SHA を持たない最小テンプレート。

`internal/gen` の生成ロジックは reader / exists コールバックを受ける純粋関数で、`t.TempDir()` 非依存の table-driven テストで網羅している（scripts/ai-bridge/AGENTS.md 準拠: `t.Parallel()` / err 使い回し禁止 / 未公開 lowercase）。

## 検証

ローカルに CI と同じ toolchain（go 1.26.4 / golangci-lint 2.12.2 / goimports 0.36.0）を用意して実行:

- `go build ./...` / `go vet ./...` OK
- `go test ./...` → 両パッケージ pass
- `gofmt -l` / `goimports -d` → クリーン
- `golangci-lint run --allow-parallel-runners` → **0 issues**（ローカルの golangci-lint バイナリが go1.25 ビルドで go1.26 target を拒否するため、ruleset 実行時のみ go directive を一時的に 1.25 に下げて検証。1.26 固有機能は未使用のため代表性あり）
- `prettier --check`（`ci_scaffold.yml` / README）・`tombi lint mise.toml`・`markdownlint-cli2`（README）→ すべて pass
- **E2E**: ビルドしたバイナリで `scaffold new log-tail` を実行し、生成された `ci_log_tail.yml` / Go 骨格 / mise ブロックを確認。生成された log-tail モジュール自体も `go test` / `goimports` / `golangci-lint`（0 issues）でクリーンなことをドッグフーディング確認。

生成された `ci_<name>.yml` が参照する mise タスク（`<name>:lint` / `<name>:test`）は、出力されたブロックを `mise.toml` に貼るまで存在しない（MVP の設計どおり手動 append）。次手順は生成 README と stdout に明記している。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz3yjSvFe9R6KeU3hYeUZn)_