### PR TITLE
Enable splitbelow and splitright for intuitive window splits

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -30,6 +30,8 @@ vim.opt.mouse = "" -- Don't use a mouse.
 vim.opt.signcolumn = "yes" -- Always show signcolumn to prevent rattling.
 vim.opt.foldlevelstart = 99 -- Open files fully expanded; folds (treesitter foldexpr) are closed manually when needed.
 vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
+vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current window.
+vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
 
 -- ----------------------------------------
 -- Neovim 0.12 で追加された UI オプション


### PR DESCRIPTION
Closes #510

## 何を

`nvim/config/init.lua` の `vim.opt.*` 設定ブロック（`updatetime` の直後）に 2 行追加した。

```lua
vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current window.
vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
```

## なぜ

Vim/Neovim の既定では `:split` は上・`:vsplit` は左に新ウィンドウを開く。本リポジトリは `<Leader>-`（`:split term://bash`）/ `<Leader>l`（`:vsplit term://bash`）でターミナル分割を日常的に叩くため、「下・右に生える」という一般的な期待と逆になっていた。この 2 オプションを有効化すると、水平分割は下・垂直分割は右に開くようになり直感と揃う。キーマップ自体は変更しないため手の記憶はそのまま。fern ドロワー（`-drawer` で自前配置）・telescope/Undotree（フロート/独自ウィンドウ）には影響しない。完全可逆な変更。

## 検証

- 変更は init.lua の 2 行追加のみ（既存のタブインデント・整列コメントのスタイルに合わせた）。
- stylua はこの環境で未インストールのため未実行。CI の Lint Stylua ワークフローで検証される。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm5RhjEUkABzHrUuHgxYyp)_