### PR TITLE
Enable blink.cmp command-line completion auto-show

### DIFF
--- a/nvim/config/lua/blink_cmp.lua
+++ b/nvim/config/lua/blink_cmp.lua
@@ -45,6 +45,18 @@ require("blink.cmp").setup({
 		},
 	},
 
+	-- コマンドライン (: / 検索) 補完。既定では cmdline は有効だが auto_show が cmdwin 限定なので、
+	-- 通常の : 入力中もメニューが自動表示されるよう auto_show = true にする。
+	-- keymap preset "cmdline" は Tab で挿入/確定、単一候補は自動確定する定番マッピング。
+	cmdline = {
+		enabled = true,
+		keymap = { preset = "cmdline" },
+		sources = { "buffer", "cmdline" },
+		completion = {
+			menu = { auto_show = true },
+		},
+	},
+
 	-- (Default) Rust fuzzy matcher for typo resistance and significantly better performance
 	-- You may use a lua implementation instead by using `implementation = "lua"` or fallback to the lua implementation,
 	-- when the Rust fuzzy matcher is not available, by using `implementation = "prefer_rust"`

--- a/nvim/config/lua/plugins.lua
+++ b/nvim/config/lua/plugins.lua
@@ -78,7 +78,7 @@ return {
 	{ -- Auto completion
 		"saghen/blink.cmp",
 		lazy = true,
-		event = { "BufRead", "BufNewFile" },
+		event = { "BufRead", "BufNewFile", "CmdlineEnter" },
 		version = "1.*",
 		config = function()
 			require("blink_cmp")


### PR DESCRIPTION
Closes #499

## 何を

1. `nvim/config/lua/blink_cmp.lua` の `setup({...})` に `cmdline` テーブルを追加。`completion.menu.auto_show = true` により、通常の `:` 入力中もコマンドライン補完メニューが自動表示される。`keymap = { preset = "cmdline" }` / `sources = { "buffer", "cmdline" }` は既定と同値だが意図を明示。
2. `nvim/config/lua/plugins.lua` の blink.cmp の遅延ロード条件に `CmdlineEnter` を追加。起動直後・ファイル未オープンでも最初の `:` で blink がロードされるようにする。

## なぜ

blink.cmp は導入済みだが、コマンドラインモードの `auto_show` は既定で `cmdwin`（`q:`）限定のため、`:` 入力中は Tab を押すまでメニューが出なかった。`auto_show = true` にすると `:e`（パス）・`:h`（ヘルプタグ）・Ex コマンド名・検索語が挿入補完と同じ fuzzy エンジンで打鍵に追従して自動表示される。`mouse = ""`・キーボード操作前提でコマンドラインを日常的に叩く本構成に合う。新規プラグインは不要。

## 検証

- 変更は Lua 2 ファイル（既存のタブインデントに合わせた）。
- stylua はこの環境で未インストールのため未実行。CI の Lint Stylua ワークフローで検証される。
- 挿入モード側の keymap（`<Tab>`/`<S-Tab>` を無効化済み）や既存の重いリーダーマッピングには影響しない（cmdline preset はコマンドラインモード専用）。煩わしければ `auto_show = false` で即既定へ戻せる。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm5RhjEUkABzHrUuHgxYyp)_