### PR TITLE
Consolidate compinit and skip security audit once per day

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -85,13 +85,19 @@ export PATH="$PATH:/Applications/Docker.app/Contents/Resources/bin/"
 ####################
 zstyle ':completion:*:*:git:*' script ~/.zsh/completion/git-completion.bash
 fpath=(~/.zsh/completion $fpath)
-autoload -Uz compinit && compinit -i
 
 # The following lines have been added by Docker Desktop to enable Docker CLI completions.
 fpath=(/Users/hodanov/.docker/completions $fpath)
-autoload -Uz compinit
-compinit
 # End of Docker CLI completions
+
+# 補完初期化は1回だけ。セキュリティ監査つきの dump 再生成は「24時間より
+# 古いとき」だけ行い、それ以外はキャッシュ済み dump を -C で読んで監査を省略する。
+autoload -Uz compinit
+if [[ -n ${HOME}/.zcompdump(#qN.mh+24) ]]; then
+  compinit -i
+else
+  compinit -C
+fi
 
 ####################
 # anyenv


### PR DESCRIPTION
Closes #506

## 何を

`dotfiles/.zshrc` の補完初期化ブロック（旧 84–94 行）を整理した。

- Docker Desktop の `fpath=(...)` 追加を `compinit` より前に移し、`compinit` の呼び出しを **1 ブロックに集約**（従来は 88 行と 93 行で二重呼び出し）。
- `.zcompdump` が 24 時間より古い or 未生成のときだけ `compinit -i`（セキュリティ監査つき再生成）を実行し、それ以外は `compinit -C`（監査を省略してキャッシュ済み dump を読む）に分岐。

```zsh
autoload -Uz compinit
if [[ -n ${HOME}/.zcompdump(#qN.mh+24) ]]; then
  compinit -i
else
  compinit -C
fi
```

## なぜ

`compinit` は呼ばれるたびに `fpath` 配下の全補完ファイルのパーミッション監査 + `.zcompdump` 再生成を行う。起動ごとに 2 回、しかも毎回フル監査していたため無駄があった。監査を 1 日 1 回に絞ることで、補完候補・git/docker 補完・`compinit -i` の insecure 無視挙動は一切変えずにインタラクティブシェルの起動時間だけを削る。`(#qN.mh+24)` は zsh の glob qualifier（`#q` で明示有効化・`N` nullglob・`.` 通常ファイル・`mh+24` 更新から24時間超）。

## 検証

- `.zshrc` は CI のリンタ対象外（shellcheck は `*.sh` のみ）で、Docker イメージにも含まれない。ローカルのインタラクティブシェル起動のみに効く変更。
- この環境に zsh 未インストールのため `zsh -n` 構文チェックは未実行。ロジックは Issue 記載のとおり定番の ctechols 方式を踏襲。
- stale キャッシュ時は `rm ~/.zcompdump` で次回フル再生成に戻せる（最大1日で自然追随）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm5RhjEUkABzHrUuHgxYyp)_