### PR TITLE
Add timeout-minutes to CI jobs to cap hung runs

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -14,6 +14,7 @@ jobs:
       github.actor == 'dependabot[bot]' ||
       startsWith(github.head_ref, 'chore/bump-tool-versions')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/check_pins.yml
+++ b/.github/workflows/check_pins.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/go_module_ci.yml
+++ b/.github/workflows/go_module_ci.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -43,6 +44,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: scripts/${{ inputs.module }}

--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/lint_format.yml
+++ b/.github/workflows/lint_format.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   lint-format:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/lint_shell.yml
+++ b/.github/workflows/lint_shell.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   shell-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/lint_stylua.yml
+++ b/.github/workflows/lint_stylua.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
Closes #507

## 何を

`timeout-minutes` 未設定だった各ジョブの `runs-on:` 直下に上限を追加した（GitHub Actions のデフォルト 360 分＝6 時間依存を解消）。

| ファイル / ジョブ | timeout-minutes |
| --- | --- |
| `go_module_ci.yml` `lint` | 15 |
| `go_module_ci.yml` `test` | 15 |
| `lint_format.yml` `lint-format` | 10 |
| `lint_shell.yml` `shell-lint` | 10 |
| `lint_stylua.yml` `lint` | 10 |
| `lint_dockerfile.yml` `build` | 10 |
| `check_pins.yml` `check` | 10 |
| `auto-merge-deps.yml` `auto-merge` | 5 |
| `bump-versions.yml` `bump` | 15 |

`go_module_ci.yml` は reusable なので本体の 2 ジョブに付けるだけで 4 呼び出し側すべてに反映される。既に timeout を持つ `pr-docker-build.yml`（120）/ `pipeline-digest.yml`（10）は対象外。

## なぜ

これらのジョブは通常数分で終わるが、`timeout-minutes` が無いとステップがハングした場合（mise のツール DL がネットワークで刺さる、`go test` デッドロック、`bump-versions` の外部 API `curl` 応答待ち、`gh` コマンドの固まり等）に最大 6 時間 runner を占有する。#497 の concurrency は「後続 push で古い run を打ち切る」もので、後続 push が無い scheduled/単発 run や最新 commit 自体のハングには効かない別の失敗モード。両者は補完関係。CI のロジックは変更せず上限を足すだけ。

## 検証

- 変更した全 8 ワークフローを `python3 -c "yaml.safe_load(...)"` でパース確認済み（全て OK）。
- 値は「通常実行時間 + 十分なマージン」の保守的な初期値。required status check を誤爆させないよう長めに設定。実運用 duration を見て調整可。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm5RhjEUkABzHrUuHgxYyp)_