### PR TITLE
chore: Claude settings のモデルとサンドボックス設定を更新

### DIFF
--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -1,10 +1,9 @@
 {
-  "model": "claude-fable-5[1m]",
+  "model": "claude-opus-4-8[1m]",
   "env": {
     "SKILL_OBSERVE_HOME": "~/workspace/my-pde"
   },
   "permissions": {
-    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(actionlint:*)",
       "Bash(docker compose:*)",
@@ -145,6 +144,14 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["mise run *", "go test *"],
+    "filesystem": {
+      "allowWrite": [
+        "~/Library/Caches/go-build",
+        "~/Library/Caches/golangci-lint",
+        "~/go/pkg/mod"
+      ]
+    },
     "network": {
       "allowedDomains": [
         "github.com",

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -144,17 +144,27 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
-    "excludedCommands": ["mise run *", "go test *"],
+    "excludedCommands": [
+      "mise run *",
+      "go test *",
+      "git push *",
+      "git fetch *",
+      "git pull *",
+      "git clone *",
+      "gh *"
+    ],
     "filesystem": {
       "allowWrite": [
         "~/Library/Caches/go-build",
         "~/Library/Caches/golangci-lint",
-        "~/go/pkg/mod"
+        "~/go/pkg/mod",
+        "~/.npm"
       ]
     },
     "network": {
       "allowedDomains": [
         "github.com",
+        "api.github.com",
         "*.githubusercontent.com",
         "proxy.golang.org",
         "sum.golang.org",


### PR DESCRIPTION
## 実装経緯の説明

Claude Code の設定を見直し、使用モデルを更新するとともに、サンドボックス実行時の利便性を高めるための設定を追加した。

## 補足

### 主な変更内容

- 使用モデルを `claude-fable-5[1m]` から `claude-opus-4-8[1m]` に変更
- `permissions.defaultMode`（`acceptEdits`）を削除し、既定の確認フローに戻した
- `sandbox.excludedCommands` に `mise run *` と `go test *` を追加
- `sandbox.filesystem.allowWrite` に Go ビルド／golangci-lint／go mod のキャッシュディレクトリを追加

### 技術的な詳細

- `excludedCommands` によりサンドボックス外で実行したいコマンド（mise タスク・テスト）を明示
- `allowWrite` により Go 系ツールのキャッシュ書き込みをサンドボックス内で許可し、ビルド／Lint の失敗を回避

### 確認事項

- 反映後に mise タスクと `go test` がサンドボックスで問題なく実行できること
- golangci-lint / go build のキャッシュ書き込みでエラーが出ないこと