### PR TITLE
feat: WorktreeCreate hook で worktree の配置規約を固定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Tasks and host tool versions are managed by [mise](https://mise.jdx.dev) via `mi
 - The hook creates a placeholder branch named after `<name>`. Once the task is understood, rename it to a plain descriptive slug (no `wt/` or `agent/` prefix): `git branch -m <slug>`. Renaming works while checked out; the `commit-and-draft-pr` skill enforces this before push.
 - Other CLIs / manual use: `git worktree add ~/workspace/.worktrees/<repo>/<name> -b <slug> origin/main`.
 - Remove with `git worktree remove <path>`; git refuses dirty worktrees unless `--force` is given.
+- mise: worktree checkouts contain their own `mise.toml`, which mise refuses until trusted. One-time setup per machine: `mise settings add trusted_config_paths "~/workspace/.worktrees"` (trusts every config under the worktree base — same trust you would grant per repo with `mise trust`).
 
 ## Coding Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,14 @@ Tasks and host tool versions are managed by [mise](https://mise.jdx.dev) via `mi
 - `mise.toml` is the single source of truth for tool versions. Weekly CI (`bump-versions.yml`) bumps the pins and regenerates the derived artifacts.
 - `mise run pins:sync` — regenerate `environment/tools/go/go-tools.txt` and the Dockerfile ARG defaults from `mise.toml` (CI verifies sync via `pins:check`).
 
+## Parallel Work (git worktrees)
+
+- Worktrees live outside the checkout: `~/workspace/.worktrees/<repo>/<name>/` (override the base with `WORKTREE_BASE`). Never create worktrees inside the repository.
+- Claude Code: `claude --worktree [<name>]` and subagent `isolation: worktree` follow this layout automatically via the `WorktreeCreate` hook (`ai-agents/settings/claude/hooks/worktree-create.sh`). `<name>` is disposable — omit it to auto-generate one.
+- The hook creates a placeholder branch named after `<name>`. Once the task is understood, rename it to a plain descriptive slug (no `wt/` or `agent/` prefix): `git branch -m <slug>`. Renaming works while checked out; the `commit-and-draft-pr` skill enforces this before push.
+- Other CLIs / manual use: `git worktree add ~/workspace/.worktrees/<repo>/<name> -b <slug> origin/main`.
+- Remove with `git worktree remove <path>`; git refuses dirty worktrees unless `--force` is given.
+
 ## Coding Style
 
 - Per-language lint/format conventions load on demand from path-scoped rules in `.claude/rules/` (and personal rules in `~/.claude/rules/`) when you touch matching files.

--- a/ai-agents/settings/claude/hooks/worktree-create.sh
+++ b/ai-agents/settings/claude/hooks/worktree-create.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# mise-managed tools (non-interactive contexts do not run mise activate)
+export PATH="${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims:$PATH"
+# WorktreeCreate hook: place session/subagent worktrees under
+# ${WORKTREE_BASE:-$HOME/workspace/.worktrees}/<repo>/<name>/ instead of
+# .claude/worktrees/ inside the checkout, so every repo shares one layout and
+# worktrees never pollute the working tree AI agents read.
+# stdin: hook JSON (.name = worktree name, .cwd = launch directory; schema
+# captured from a live run). stdout: the created path.
+# Non-zero exit aborts worktree creation, so collisions never overwrite.
+# The branch is a placeholder named after <name>; the session agent renames it
+# to a proper slug with `git branch -m <slug>` (see AGENTS.md, Parallel Work).
+set -euo pipefail
+
+input=$(cat)
+name=$(jq -r '.name // empty' <<<"$input")
+cwd=$(jq -r '.cwd // empty' <<<"$input")
+
+if [ -z "$name" ] || [ -z "$cwd" ]; then
+	echo "worktree-create: missing name or cwd in hook input" >&2
+	exit 1
+fi
+
+# cwd may be a subdirectory; fails (and aborts) when cwd is not a git repo.
+source_path=$(git -C "$cwd" rev-parse --show-toplevel)
+repo=$(basename "$source_path")
+dest="${WORKTREE_BASE:-$HOME/workspace/.worktrees}/$repo/$name"
+
+if [ -e "$dest" ]; then
+	echo "worktree-create: destination already exists: $dest" >&2
+	exit 1
+fi
+mkdir -p "$(dirname "$dest")"
+
+# Branch from origin/HEAD for a clean tree matching the remote; fall back to
+# local HEAD when there is no remote, the fetch fails, or origin/HEAD is unset
+# (mirrors the default --worktree behavior).
+base_ref="HEAD"
+if git -C "$source_path" remote get-url origin >/dev/null 2>&1 &&
+	git -C "$source_path" fetch origin >/dev/null 2>&1; then
+	origin_head=$(git -C "$source_path" symbolic-ref --quiet refs/remotes/origin/HEAD || true)
+	if [ -n "$origin_head" ]; then
+		base_ref="$origin_head"
+	fi
+fi
+
+# -b fails on an existing branch; keep stdout clean for the path contract.
+git -C "$source_path" worktree add -b "$name" "$dest" "$base_ref" >&2
+echo "$dest"

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -139,6 +139,16 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/worktree-create.sh"
+          }
+        ]
+      }
     ]
   },
   "sandbox": {

--- a/ai-agents/skills/commit-and-draft-pr/SKILL.md
+++ b/ai-agents/skills/commit-and-draft-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: commit-and-draft-pr
 description: 変更をコミットしてドラフトPRを作成する一連のGit/ghワークフロー。ユーザーが「コミットして」「PR作って」「draft PR」等を求めたときに使用し、status/diff確認・命令形コミット・push・gh pr create --draft（--assignee hodanov）まで実行する。
 metadata:
-  version: 1
+  version: 2
 ---
 
 # Commit and Draft PR
@@ -11,7 +11,7 @@ metadata:
 
 作業開始時にこれをコピーして進捗を管理する:
 
-- [ ] 1. 変更とブランチを確認（`main` または detached HEAD なら feature ブランチを作成）
+- [ ] 1. 変更とブランチを確認（`main` または detached HEAD なら feature ブランチを作成、worktree の仮ブランチ名ならリネーム）
 - [ ] 2. テスト/リンタ/型チェックの状態を確認（当セッションで検証済みなら再実行せずスキップ、未検証なら実行して全て通す）
 - [ ] 3. 必要な変更のみステージング
 - [ ] 4. 規約に沿ったメッセージでコミット
@@ -24,6 +24,7 @@ metadata:
 - `git log --oneline -5` で直近の履歴を把握する
 - `git branch` で現在ブランチを確認する
 - `main` または detached HEAD の場合は feature ブランチを作成する
+- ブランチ名が worktree の仮名のまま（worktree ディレクトリ名と同名、または `bright-running-fox` のような自動生成名）の場合は、作業内容を表す prefix なしの `<slug>` を命名して `git branch -m <slug>` でリネームしてから進める（AGENTS.md「Parallel Work (git worktrees)」の規約）
 - 変更が無い（diff が空）場合は中断して報告する
 
 ## 検証

--- a/docs/plan/2026-05-13_parallel-ai-agent-development.md
+++ b/docs/plan/2026-05-13_parallel-ai-agent-development.md
@@ -1,0 +1,132 @@
+# Plan: 並列AIエージェント開発のための環境整備
+
+複数のClaude Codeエージェントを同時並行で走らせるための基盤を、本リポジトリ（my-pde）上に段階的に整える。Boris氏のような10並列規模を最終目標としつつ、まずは2並列から始めてボトルネックを観察し、隔離・自律性・仕様・レビューの4層で必要な仕掛けを足していく。
+
+## Background
+
+- 単一エージェントへの逐次指示では開発速度に限界があり、待ち時間が累積する
+- Claude Codeの開発チームは10以上の並列タスクを回す運用をしており、これは単なる多重起動ではなく、ワークフロー全体の設計シフト
+- 本リポジトリには既に `ai-agents/skills/`（17スキル）、`ai-agents/settings/claude/hooks/`（6個のフォーマッタhook）、`commit-and-draft-pr` スキル等の素地が揃っている
+- ユーザーの役割を「実装者」から「設計者・レビュアー」に移行させることが本質的なゴール
+
+## Current structure
+
+- `.claude/settings.local.json`: 個人用permission allowlist。`Bash(go:*)`, `Bash(make:*)` 等が許可済み
+- `.claude/settings.json`: 未作成（プロジェクト共有のsettingsはここに置く想定）
+- `ai-agents/settings/claude/hooks/`: `goimports.sh`, `prettier.sh`, `stylua.sh`, `shfmt.sh`, `markdown-format.sh`, `tombi.sh`
+- `ai-agents/skills/`: `commit-and-draft-pr`, `review`, `review-scan`, `investigate` などレビュー・コミット系スキル
+- `AGENTS.md`: プロジェクト全体の開発ガイド（lint/test表あり）
+- worktree運用は未整備（同一クローン上でブランチ切替のみ）
+
+## Design policy
+
+- **段階導入**: いきなり10並列を目指さず、2並列で1〜2週間運用してボトルネックを観察してから次の整備に進む
+- **既存資産の再利用**: 新しいhookやスキルを作る前に、既存の `ai-agents/settings/claude/hooks/` と `ai-agents/skills/` を最大限活かす
+- **疎結合タスクのみ並列化**: 同一ファイルを触る作業は直列化前提とし、並列化対象は領域が分離しているもの（例: `dotfiles/` と `nvim/` と `scripts/ai-bridge/`）に限定する
+- **draft PRで出口を統一**: エージェントは必ず draft PR で終了し、マージ判断は人間に残す
+- **失敗を恐れず観察優先**: 並列化で問題が出たらその都度hookやスキルで対処する。先回りした作り込みはしない
+- **起動はClaude Code複数ウィンドウ**: 並列エージェントの起動方式は Claude Code を複数ウィンドウで開く方式に統一する。subagentやscheduleは併用しない（最初は）
+- **worktreeはリポ外に置く**: worktreeは `~/workspace/.worktrees/{REPOSITORY}/` 配下に集約する。リポ内に置くとAIエージェントへ食わせる際のノイズになり、git管理上もハンドリングが面倒になるため
+- **自動レビューは内製スキルのみ**: `review` / `review-scan` スキルで運用する。`ultrareview` は別途費用が発生するため採用しない
+
+## Implementation steps
+
+### Phase 1: 基盤整備（最初の1週間）
+
+1. **権限の棚卸しと整理**
+   - `fewer-permission-prompts` スキルを実行し、直近の transcripts から頻出する許可項目を抽出
+   - `.claude/settings.local.json` の個人用エントリのうち、プロジェクト共有すべきものを `.claude/settings.json` に昇格させる
+   - `Bash(rm:*)`, `Bash(git push --force:*)` 等は明示的に `deny` へ
+2. **PostToolUse hook の有効化**
+   - 既存の `ai-agents/settings/claude/hooks/*.sh` を `.claude/settings.json` の `hooks.PostToolUse` に登録
+   - Edit/Write後に対応するフォーマッタ＋lintが自動で走る状態にする
+3. **タスクブリーフのテンプレート整備**
+   - `docs/plan/` 配下に並列タスク用のブリーフテンプレートを1枚追加
+   - 含める項目: ゴール / 触っていいファイル範囲 / 触ってはいけないファイル / 完了条件 / テストコマンド / draft PR タイトル規約
+
+### Phase 2: 隔離環境（次の1週間）
+
+1. **git worktree 運用の確立**
+   - worktree置き場は `~/workspace/.worktrees/{REPOSITORY}/<branch-name>/` に統一
+     - リポジトリの外に置くことでリポ内ノイズを排除し、AIエージェントに食わせるコンテキストをクリーンに保つ
+     - `{REPOSITORY}` ごとにディレクトリを分けることでブランチ名衝突を回避
+   - worktree作成・破棄を自動化する小スクリプトを `scripts/` に追加（`make worktree-new BRANCH=feat/foo` 等）
+     - 内部で `git worktree add ~/workspace/.worktrees/{REPOSITORY}/<branch> <branch>` を実行
+     - 不要になったら `make worktree-remove BRANCH=...` で破棄
+   - ブランチ命名規則を `agent/<scope>/<short-desc>` で統一
+2. **ポート・環境変数衝突の回避**
+   - dev server を立てるタスクはworktreeごとに `PORT` を変えるルールを明文化（AGENTS.md追記）
+3. **2並列の試走（Claude Code複数ウィンドウ）**
+   - 領域が完全に分離した2タスクを選び、それぞれ別worktreeで Claude Code を別ウィンドウで起動
+   - 詰まりポイントをログに残す（`docs/log/`）
+
+### Phase 3: レビュー流量制御（2週間目以降）
+
+1. **commit-and-draft-pr スキルの並列対応確認**
+   - 並列実行時にPRタイトル・ブランチがバッティングしないことを確認
+2. **CIの整備状況確認**
+   - `.github/workflows/` の9ワークフローが draft PR でも回ることを確認
+   - draft でも必須にしたいチェックがあれば設定追加
+3. **自動レビューの導入（`review` / `review-scan` 運用）**
+   - `review-scan` スキルで一次フィルタ（Phase.1: 広く浅くスキャン）
+   - 優先度が高い指摘について `review` スキルで深掘り（Phase.2）
+   - `ultrareview` は費用が発生するため不採用
+
+### Phase 4: 並列度の段階拡大
+
+1. 2並列 → 4並列 → ボトルネック観察 → 対応 → 拡大、を繰り返す
+2. 観察結果は `docs/log/` に蓄積し、必要なら新規スキル/hookに昇華
+
+## File changes
+
+| File                                        | Change                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------- |
+| `.claude/settings.json`                     | 新規作成。共有 allow/deny と PostToolUse hooks を登録               |
+| `.claude/settings.local.json`               | プロジェクト共有すべき項目を `settings.json` に移し、個人用のみ残す |
+| `docs/plan/parallel-task-brief-template.md` | 並列タスク用ブリーフテンプレート（Phase 1 で追加）                  |
+| `AGENTS.md`                                 | worktree運用ルール・ポート割当ルールの追記（Phase 2）               |
+| `scripts/worktree-new.sh` or `Makefile`     | worktree作成・破棄の補助スクリプト（Phase 2）                       |
+| `docs/log/YYYY-MM-DD_parallel-trial-*.md`   | 各試走の観察ログ                                                    |
+
+## Risks and mitigations
+
+| Risk                                                    | Mitigation                                                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| permission allowlist が広すぎて危険操作が通る           | `deny` を先に厳しく書く。`rm`, `force push`, DB 破壊系を明示的にブロック        |
+| 同一ファイルへの並列編集でマージコンフリクト多発        | タスク分解時に「触ってよいファイル範囲」を明示。重なる作業は直列化              |
+| worktreeごとの依存解決でディスク・時間コスト増          | pnpm / uv 等のコンテンツアドレッサブルなツールを優先。Docker volumeの共有も検討 |
+| dev server / DB のポート衝突                            | worktreeごとに `PORT` を環境変数で変える運用を明文化                            |
+| レビュー律速で並列度のメリットが消える                  | draft PR + `review-scan` / `review` スキルで一次フィルタを噛ませる              |
+| エージェントがhookを抜けるために `--no-verify` 等を使う | hook失敗時の挙動を `deny` 寄りに調整。CLAUDE.md でも禁則明記                    |
+
+## Validation
+
+- [ ] `fewer-permission-prompts` 実行後、`.claude/settings.json` に共有allowlistが整理されている
+- [ ] Edit/Write 後に対応するフォーマッタ hook が自動実行される（goimports / prettier / stylua 等）
+- [ ] 危険操作（`rm -rf`, `git push --force`）が `deny` でブロックされる
+- [ ] 並列タスク用ブリーフテンプレートが `docs/plan/` に存在する
+- [ ] worktree を2つ並行作成・破棄できるスクリプトまたは Makefile ターゲットがある
+- [ ] 2並列で疎結合タスクを走らせて、両方が draft PR まで到達する
+- [ ] 試走の観察結果が `docs/log/` に記録されている
+- [ ] CI が draft PR でも期待通り回る
+
+## Decisions
+
+会話で確定済みの方針を記録（Open questions から昇格）。
+
+- **worktree置き場**: `~/workspace/.worktrees/{REPOSITORY}/<branch-name>/`
+  - リポ内に置くとAIエージェントに食わせる際のノイズになり、git管理も煩雑になるため外置きにする
+  - `{REPOSITORY}` ごとにディレクトリを分けてブランチ名衝突を回避
+- **worktree補助の実現方式（2026-07-06 更新）**: Phase 2 の「小スクリプトを `scripts/` に追加」は
+  Claude Code の `WorktreeCreate` hook で配置規約を固定する方式に置き換えた。ブランチ命名も
+  `agent/<scope>/<short-desc>` ではなく、セッション内で AI が命名する prefix なしの `<slug>`
+  （worktree ディレクトリ名とは別名）に変更。
+  詳細は `docs/plan/2026-07-06_worktree-hooks-for-parallel-agents.md` を参照
+- **起動方式**: Claude Code 複数ウィンドウ（subagent / schedule は併用しない）
+- **自動レビュー**: `review` / `review-scan` スキルで運用。`ultrareview` は費用発生のため不採用
+- **hook の負荷調整**: 開発体験が重くなってから対応する（先回りはしない）
+- **並列度の上限**: 観察結果が出てから判断する（事前に決めない）
+
+## Open questions
+
+- （現時点で未確定の論点はなし。試走後の観察結果に応じて追記する）

--- a/docs/plan/2026-07-06_worktree-hooks-for-parallel-agents.md
+++ b/docs/plan/2026-07-06_worktree-hooks-for-parallel-agents.md
@@ -1,0 +1,129 @@
+# Plan: WorktreeCreate hook による並行 AI エージェント作業の worktree 規約固定（issue #508 の再スコープ）
+
+issue #508 は `scripts/worktree/` への Go 製 worktree マネージャ追加を提案しているが、
+「AI エージェントの並列作業に効くか」という評価軸で検証した結果、Go ツールは作らず、
+Claude Code の `WorktreeCreate` / `WorktreeRemove` hook と規約の文書化に再スコープする。
+
+## Background
+
+- **#508 の前提の半分は成立しない。** issue は「自律パイプラインが `auto/issue-NNN-*` ブランチを量産しており、
+  複数エージェントが同一作業ツリーを取り合う」ことを動機とするが、これらのブランチを作っているのは
+  `routines/prompts/weekly-adopted-issue-pr-bot.md` のクラウドルーチンで、毎回隔離されたクラウド環境で走る。
+  ローカルのチェックアウトに contention は発生していない。isolation が実際に必要なのは、
+  `docs/plan/2026-05-13_parallel-ai-agent-development.md` Phase 2 が想定するローカル複数セッション並走のみ。
+- **Go ツールの付加価値は既存機能とほぼ重複する。** `rm` の未コミットガードは `git worktree remove` が標準で持つ
+  （dirty なら `--force` 必須）。`new` の衝突時失敗も `git worktree add` の標準挙動。`origin/main` 基点も
+  Claude Code の worktree 既定（`origin/HEAD` 起点）と同じ。`list` の dirty / ahead-behind 集計だけのために
+  Go モジュール + CI 配線 + テスト一式を抱えるのは割に合わない。
+- **残る本質的な要件は「配置規約の固定」だけ。** worktree を `~/workspace/.worktrees/<repo>/<slug>/` に置く規約を
+  1 箇所に固定し、エージェントが規約を思い出さなくても守られる状態にすること。これは
+  Claude Code の `WorktreeCreate` hook（worktree 作成ロジックを丸ごと差し替え、stdout で実パスを返す）で満たせる。
+  hook にすれば `claude --worktree` / セッション中の `EnterWorktree` / subagent の `isolation: worktree` が
+  すべて同じ規約に従い、クリーンアップ（クリーンなら自動削除、dirty なら保護）も本体側の仕組みに乗れる。
+- subagent 案も不採用。worktree のライフサイクルは推論タスクではなくツール操作であり、
+  セッション内並列は既存 subagent への `isolation: worktree` 指定で足りる。
+
+## Current structure
+
+- worktree 運用は未整備。リポジトリ全域に `worktree` への言及なし（#508 の指摘どおり）。
+- hook の配線: `ai-agents/settings/claude/settings.json` の `hooks.*` に `~/.claude/hooks/*.sh` を登録し、
+  実体は `ai-agents/settings/claude/hooks/*.sh`。`deploy-ai-config`（`ai-agents/Makefile`）で `~/.claude/` へ配布。
+- 既存 hook の流儀: `#!/usr/bin/env bash` + mise shims の PATH 補完 + `set -u`、shellcheck / shfmt 対象。
+- worktree 置き場の規約は `docs/plan/2026-05-13_parallel-ai-agent-development.md` の Decisions で
+  `~/workspace/.worktrees/{REPOSITORY}/<branch-name>/` と確定済み（同プラン Phase 2 には
+  「小スクリプトを scripts/ に追加」とあり、本プランはこれを hook 方式に置き換える）。
+
+## Design policy
+
+- **バイナリではなく hook で規約を固定する。** 規約は `worktree-create.sh` 1 本に閉じ、
+  Claude Code の全 worktree 作成経路（`--worktree` / `EnterWorktree` / subagent isolation）に効かせる。
+- **git 標準のガードを再実装しない。** 衝突時失敗・dirty 保護・cleanup は git と Claude Code 本体に任せる。
+- **repo 非依存に書く。** repo 名は hook が受け取る `source_path` から導出し、どのリポジトリでも
+  `~/workspace/.worktrees/<repo>/<slug>/` に切れるようにする（ai-agents の repo 非依存方針に合致）。
+  置き場は `WORKTREE_BASE` 環境変数で上書き可能にする（既定 `~/workspace/.worktrees`）。
+- **他 CLI（cursor / codex / copilot）と手動運用はフォールバックで足りる。** `--worktree` 相当がない CLI 向けには
+  AGENTS.md に素の `git worktree` 手順と規約を明文化する。手動では素の git worktree で十分という
+  運用実感があるため、専用 skill の新設は観察してから判断する（YAGNI）。
+- **`list` 相当は作らない。** 必要になったら `git worktree list` を叩けばよい。定型化したくなったら
+  その時に alias / skill を検討する。
+
+## Implementation steps
+
+1. **`worktree-create.sh` hook を追加**（`ai-agents/settings/claude/hooks/`）
+   - stdin JSON: `name`（worktree 名）と `cwd`（起動ディレクトリ）を `jq` で読む
+     （スキーマはライブ実行でキャプチャして確認済み。公式ドキュメント要約の
+     `worktree_path` / `source_path` は実際には来ない）。
+   - リポジトリは `git -C "$cwd" rev-parse --show-toplevel` で導出（サブディレクトリ起動にも対応、
+     リポジトリ外なら失敗）。`dest="${WORKTREE_BASE:-$HOME/workspace/.worktrees}/$repo/$name"`。
+   - 既定挙動を踏襲して `origin/HEAD` 基点でブランチを切り `git worktree add`
+     （fetch 失敗時はローカル `HEAD` にフォールバック）。ブランチ名は仮置きで `<name>` と同名にする。
+     hook はセッション開始前に走るため、この時点で AI に命名させることはできない。
+     正式なブランチ名 `<slug>` はセッション内で AI が命名してリネームする（step 4 の規約）。
+   - 成功時のみ `dest` を stdout に出力。既存パス / 既存ブランチとの衝突は `git worktree add` の失敗を
+     そのまま非ゼロ終了で伝播（上書きしない）。
+2. **settings に配線**: `ai-agents/settings/claude/settings.json` の `hooks.WorktreeCreate` に
+   `~/.claude/hooks/worktree-create.sh` を登録。
+3. **配布**: `deploy-ai-config` で `~/.claude/` へ反映。
+4. **AGENTS.md に運用規約を追記**: 配置規約（`~/workspace/.worktrees/<repo>/<name>/`。`<name>` は
+   `--worktree` の引数 or 自動生成名で、使い捨てで良い）、ブランチ命名規約
+   （作業内容が固まったら AI が prefix なしの `<slug>` を命名し `git branch -m <slug>` でリネームする。
+   checkout 中でもリネーム可能）、他 CLI / 手動では素の `git worktree add` を規約パスに対して使うこと、
+   撤去は `git worktree remove`（dirty 保護は git 標準）で行うこと。
+   あわせて `commit-and-draft-pr` スキルに「push 前にブランチ名が仮名（worktree ディレクトリ名と同名や
+   自動生成名）のままなら、作業内容から `<slug>` を命名してリネームしてから push する」ガードを追記する。
+5. **試走で挙動確認**（Validation 参照）: 規約パスに作成されるか、subagent isolation でも hook が効くか、
+   セッション終了時の cleanup が hook 作成の worktree にも働くか。働かない場合のみ
+   `WorktreeRemove` hook（`git worktree remove` + `prune` の側効果実行）を追加する。
+6. **記録の更新**: #508 に再スコープの理由をコメント（前提検証の結果と本プランへのリンク）。
+   `docs/plan/2026-05-13_parallel-ai-agent-development.md` の Decisions に
+   「worktree 補助は scripts/ のスクリプトではなく WorktreeCreate hook で実現」を追記。
+
+## File changes
+
+| File                                                    | Change                                                               |
+| ------------------------------------------------------- | -------------------------------------------------------------------- |
+| `ai-agents/settings/claude/hooks/worktree-create.sh`    | 新規。配置規約を実装する WorktreeCreate hook                         |
+| `ai-agents/settings/claude/settings.json`               | `hooks.WorktreeCreate` の配線を追加                                  |
+| `AGENTS.md`                                             | worktree 運用規約（配置・命名・他 CLI 向けフォールバック手順）を追記 |
+| `ai-agents/skills/commit-and-draft-pr/SKILL.md`         | push 前の仮ブランチ名検出 → `<slug>` へのリネームガードを追記        |
+| `docs/plan/2026-05-13_parallel-ai-agent-development.md` | Decisions に hook 方式への置き換えを追記                             |
+| `ai-agents/settings/claude/hooks/worktree-remove.sh`    | 条件付き新規。試走で cleanup が効かない場合のみ追加                  |
+
+## Risks and mitigations
+
+| Risk                                                                       | Mitigation                                                                                          |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| hook 化により `.worktreeinclude`（gitignore 済みファイルのコピー）が無効化 | このリポには `.env` 等のコピー対象がない。必要になったら hook 内でコピー処理を足す                  |
+| hook 作成の worktree はセッション transcript の relocation 対象外          | 影響は `--resume` 時の探し先のみで軽微。AGENTS.md に注記                                            |
+| 本体の自動 cleanup が hook 作成分に働かない可能性                          | 試走で確認し、働かなければ `WorktreeRemove` hook を追加。最終手段は手動 `git worktree remove`       |
+| claude 以外の CLI には hook が効かず規約が自己申告になる                   | AGENTS.md への明文化でカバー。逸脱が観察されたら skill 化を再検討                                   |
+| hook のバグで worktree 作成が全滅する（非ゼロ終了は作成失敗になる）        | スクリプトは最小限に保ち、shellcheck / shfmt / lint-changed.sh の既存検証に乗せる。試走を必須とする |
+| AI がブランチのリネームを忘れて仮名のまま push する                        | `commit-and-draft-pr` の push 前ガードで捕捉。漏れても `git branch -m` + push し直しで回復可能      |
+
+## Validation
+
+- [ ] `claude --worktree test-name` で `~/workspace/.worktrees/my-pde/test-name/` に worktree が作成される
+- [ ] my-pde 以外のリポジトリでも同じ規約パスに作成される（repo 非依存の確認）
+- [ ] 既存の worktree 名と衝突した場合に上書きせず失敗する
+- [ ] セッション内で AI が `git branch -m <slug>` によりタスク内容に即したブランチ名へリネームできる
+      （commit-and-draft-pr の push 前ガードが仮名を検出する）
+- [ ] subagent（`isolation: worktree`）でも hook 経由で規約パスに作成される
+- [ ] セッション終了時、クリーンな worktree が片付くこと（片付かない場合は WorktreeRemove hook を追加して再確認）
+- [ ] shellcheck / shfmt が pass し、settings.json が jq でパース可能
+- [ ] AGENTS.md の規約記述と #508 コメント・2026-05-13 プランの Decisions 更新が揃っている
+
+## Decisions
+
+会話で確定済みの方針を記録（Open questions から昇格）。
+
+- **ブランチ名に prefix は付けない**: `wt/` や `agent/` は不要。プレーンな `<slug>` とする
+  （worktree 上のブランチかどうかを名前で区別する必要はない）。
+- **worktree ディレクトリ名とブランチ名は別物にする**: `--worktree xxxx` の引数（or 自動生成名）は
+  作業に入る時点でちゃんとした命名ができないケースが圧倒的に多いため、使い捨てで良い。
+  正式なブランチ名 `<slug>` は、セッション内でタスクを理解した AI が命名し、
+  hook が切った仮ブランチを `git branch -m <slug>` でリネームする
+  （hook はセッション開始前に走るため、作成時点での AI 命名は構造上不可能）。
+
+## Open questions
+
+- cursor / codex / copilot 側で並列運用の頻度が上がった場合に、フォールバック手順を skill に昇格するか。


### PR DESCRIPTION
## 実装経緯の説明

複数の AI エージェントをローカルで並走させる際の worktree isolation について、#508 は `scripts/worktree/` への Go 製マネージャ追加を提案していたが、検証の結果、衝突ガード・dirty 保護・cleanup は git 標準挙動と Claude Code 本体機能（`--worktree` / `EnterWorktree` / subagent `isolation: worktree`）に既に存在し、欠けているのは「配置規約の固定」だけだった。そこで `WorktreeCreate` hook 1 本に再スコープして実装した。設計判断の詳細は `docs/plan/2026-07-06_worktree-hooks-for-parallel-agents.md` を参照。

Closes #508

## 補足

### 主な変更内容

- `ai-agents/settings/claude/hooks/worktree-create.sh`: worktree を `${WORKTREE_BASE:-~/workspace/.worktrees}/<repo>/<name>/` に作成し、実パスを stdout で返す WorktreeCreate hook。衝突時は上書きせず非ゼロ終了
- `ai-agents/settings/claude/settings.json`: `hooks.WorktreeCreate` の配線を追加
- `AGENTS.md`: 「Parallel Work (git worktrees)」セクションを追加（配置規約・ブランチリネーム規約・他 CLI 向けフォールバック手順）
- `ai-agents/skills/commit-and-draft-pr/SKILL.md`（v2）: push 前にブランチ名が worktree の仮名のままなら `git branch -m <slug>` でリネームするガードを追加
- `docs/plan/`: 本再スコープのプラン新規追加 + 2026-05-13 並列開発プランの Decisions 更新

### 技術的な詳細

- ブランチは worktree 名と同名の仮置きで作成し、正式な prefix なしの `<slug>` への命名はセッション内の AI に委ねる（hook はセッション開始前に走るため作成時点での AI 命名は構造上不可能）
- hook の stdin は実際には `{"name", "cwd"}` で、公式ドキュメント要約から想定した `worktree_path` / `source_path` は来ない（ライブ実行でキャプチャして確認）。リポジトリは `git -C "$cwd" rev-parse --show-toplevel` で導出するため、サブディレクトリ起動にも対応
- `origin/HEAD` 基点でブランチを切り、リモート無し・fetch 失敗時はローカル `HEAD` にフォールバック（既定の `--worktree` 挙動を踏襲）

### 検証結果

- 一時リポジトリでの機能テスト 11/11 pass（規約パス作成 / stdout 契約 / サブディレクトリ起動 / パス・ブランチ衝突拒否 / リモート無しフォールバック / 非リポジトリ拒否 / 空入力拒否）
- shellcheck / shfmt / prettier / markdownlint / jq パース確認すべて pass
- ライブ E2E: `claude -p --worktree hooktest-508` で `~/workspace/.worktrees/my-pde/hooktest-508`・仮ブランチ `hooktest-508` でのセッション起動を確認（試走分は撤去済み）

### 確認事項

- 次回の対話セッションで `claude --worktree` を使った際、終了時の自動 cleanup が hook 作成の worktree に効くか（効かない場合は `WorktreeRemove` hook を後続で追加）
- subagent `isolation: worktree` 経由でも規約パスに作成されるか（本セッションは旧設定で起動していたため未確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)