### PR TITLE
feat: プレゼン資料を作る marp-deck-export スキルを追加

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,6 +5,10 @@ config:
 ignores:
   - ".github"
   - "assets"
+  # Marp slide decks legitimately use inline HTML and multiple H1s (lead slides),
+  # which conflict with prose-oriented rules. Exclude decks and the Marp template.
+  - "docs/slides/**"
+  - "**/marp-template.md"
   - "**/.bash_profile"
   - "**.json"
   - "**.lua"

--- a/ai-agents/skills/marp-deck-export/SKILL.md
+++ b/ai-agents/skills/marp-deck-export/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: marp-deck-export
+description: >-
+  5〜10 分のプレゼン資料を Marp（Markdown）で作成し、PDF / PPTX / HTML に書き出す。
+  会話やリポジトリの実状況からスライドを起こし、gaia テーマの雛形で下書き →
+  docs/slides/YYYY-MM-DD_slug.md に保存 → ヘルパースクリプトで描画する。
+  「プレゼン資料を作りたい」「スライド」「発表資料」「Marp」「Google スライド用の pptx」
+  などに言及されたときに使用する。
+metadata:
+  version: 1
+---
+
+# Marp Deck Export
+
+## Goal
+
+会話やリポジトリの実状況から、5〜10 分で話せるプレゼン資料を Marp Markdown で作り、
+PDF / PPTX / HTML に書き出す。**正（source of truth）は `.md`**、描画物は生成物として扱う。
+
+## Workflow
+
+1. **文脈を集める**: まず現在の会話から。不足分だけリポジトリ・PR・`docs/`・実データで補う。
+   リポジトリを題材にする発表なら、**実ソース（コード・`docs/plan/`・設定）を読む。憶測で書かない**。
+2. **スラッグと構成を決める**: 短い kebab-case スラッグを選ぶ。対象読者・長さが曖昧なら確認する。
+   目安は **1 スライド 20〜40 秒** → 5〜10 分で **10〜16 枚**。
+3. **下書き**: `assets/marp-template.md` の雛形（gaia / 16:9）をベースにスライドを書く。
+4. **保存**: `docs/slides/YYYY-MM-DD_<slug>.md` に置く（ディレクトリが無ければ作る）。
+5. **描画**: ヘルパースクリプトで書き出す（下記 Rendering）。
+6. **検証**: エラーなく描画され、スライド枚数が想定どおりで、はみ出し・配色崩れが無いこと。
+
+## Content rules
+
+- **数値・固有名詞は実データで裏取りする**。統計は `gh` やファイルから**その場で数え直す**。
+  計画文書の古いスナップショット値をそのまま転記しない（実態とズレる）。
+- 1 スライド 1 メッセージ。箇条書きは短く。図や ASCII は**フェンスドコードブロック**で置く。
+- ユーザーの言語・トーンに合わせる。ソースに無い主張を足さない。
+
+## Styling gotchas
+
+- テーマは `gaia`。アクセント色などは frontmatter の `style:` ブロックで定義する。
+- **`code {}` に背景色・文字色を付けたら、`pre` / `pre code` も必ず別に指定する。**
+  さもないとインラインコード用の配色がブロックコード（ASCII 図など）にも効いてコントラストが死ぬ。
+  `pre` は濃色背景（例 `#161b26`）＋淡色文字（例 `#e8ecf8`）にすると図がくっきりする。
+
+## Rendering
+
+```bash
+skills/marp-deck-export/scripts/render_deck.sh <deck.md> [formats]
+```
+
+- `formats` は既定 `pdf`。`pdf,pptx,html` のカンマ区切りで複数指定可。
+- **`--pdf` と `--pptx` は 1 回の marp 実行で同時指定できない** → スクリプトは形式ごとに実行を分ける。
+- PDF / PPTX はヘッドレス Chromium を使う。`The browser is already running` や起動エラーで落ちるのは
+  **サンドボックスが Chromium をブロックしているサイン**。サンドボックス外で再実行する（`/sandbox` で調整可）。
+  HTML は Chromium 不要。
+
+## Google スライドで使う場合
+
+`pptx` を書き出し → Google ドライブにアップ → 「Google スライドで開く」でインポートする。
+
+## Files
+
+- `assets/marp-template.md` — スライドの骨格 + テーマ（コピーして使う雛形）
+- `scripts/render_deck.sh` — pdf / pptx / html への描画ヘルパー

--- a/ai-agents/skills/marp-deck-export/assets/marp-template.md
+++ b/ai-agents/skills/marp-deck-export/assets/marp-template.md
@@ -1,0 +1,91 @@
+---
+marp: true
+theme: gaia
+paginate: true
+size: 16:9
+header: "<HEADER TEXT>"
+footer: "<PROJECT / DATE>"
+style: |
+  :root {
+    --accent: #7c5cff;
+    --ink: #1f2430;
+  }
+  section {
+    font-family: "Hiragino Sans", "Noto Sans JP", sans-serif;
+    font-size: 26px;
+    color: var(--ink);
+  }
+  h1, h2 { color: var(--accent); }
+  section.lead h1 { font-size: 52px; line-height: 1.25; }
+  section.lead { text-align: left; }
+  strong { color: var(--accent); }
+  table { font-size: 20px; }
+  code { background: #f0ecff; color: #5a3ce0; }
+  /* Style pre/pre code separately so inline-code colors don't bleed into
+     ASCII diagrams / code blocks and kill contrast. */
+  pre { background: #161b26; border-radius: 10px; padding: 14px 18px; box-shadow: 0 2px 8px rgba(0,0,0,.15); }
+  pre code { background: transparent; color: #e8ecf8; font-size: 19px; line-height: 1.4; }
+  .small { font-size: 20px; color: #556; }
+  blockquote { border-left: 6px solid var(--accent); padding-left: 16px; color: #444; }
+---
+
+<!-- _class: lead -->
+
+# <TITLE><br><SUBTITLE>
+
+### <ONE-LINE TAGLINE>
+
+<br>
+
+**<CONTEXT LINE>**
+
+<span class="small"><DATE></span>
+
+---
+
+## <一言で言うと / TL;DR>
+
+> **<核となる主張を 1〜2 文で>**
+
+- <ポイント 1>
+- <ポイント 2>
+- <ポイント 3>
+
+---
+
+## <セクション見出し>
+
+<本文。1 スライド 1 メッセージ。>
+
+- <短い箇条書き>
+- <短い箇条書き>
+
+---
+
+## <図を置くスライド>
+
+```text
+<ASCII 図やフロー。pre のダーク背景でくっきり表示される>
+```
+
+**<図の要点を 1 行で>**
+
+---
+
+## <表を置くスライド>
+
+| 列 A | 列 B | 列 C |
+| ---- | ---- | ---- |
+| ...  | ...  | ...  |
+
+---
+
+<!-- _class: lead -->
+
+# まとめ
+
+**<結論を 1〜2 文で>**
+
+<br>
+
+<span class="small">ご清聴ありがとうございました 🙌</span>

--- a/ai-agents/skills/marp-deck-export/scripts/render_deck.sh
+++ b/ai-agents/skills/marp-deck-export/scripts/render_deck.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Render a Marp deck to one or more formats (pdf / pptx / html).
+#
+# Usage: render_deck.sh <deck.md> [formats]
+#   formats: comma-separated subset of pdf,pptx,html (default: pdf)
+#
+# Notes:
+# - marp's `--pdf` and `--pptx` are mutually exclusive in a single invocation,
+#   so each format is rendered in its own marp call.
+# - Stale `marp-cli-*` temp dirs (leftover Chromium userDataDir locks) are
+#   cleaned before each call to avoid "browser is already running" errors.
+# - PDF/PPTX require headless Chromium. If Chromium fails to launch, the caller
+#   is likely inside a sandbox that blocks it; re-run outside the sandbox.
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: render_deck.sh <deck.md> [formats]  (formats: pdf,pptx,html)" >&2
+	exit 2
+fi
+
+DECK="$1"
+FORMATS="${2:-pdf}"
+
+if [ ! -f "$DECK" ]; then
+	echo "error: deck not found: $DECK" >&2
+	exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+	echo "error: npx (Node.js) is required but not found on PATH" >&2
+	exit 1
+fi
+
+TMPBASE="${TMPDIR:-/tmp}"
+MARP=(npx --yes @marp-team/marp-cli@latest)
+
+clean_stale_locks() {
+	# Remove leftover marp Chromium userDataDir temp dirs (best effort).
+	find "$TMPBASE" -maxdepth 1 -name 'marp-cli-*' -type d -exec rm -rf {} + 2>/dev/null || true
+}
+
+IFS=',' read -r -a FMT_ARR <<<"$FORMATS"
+for fmt in "${FMT_ARR[@]}"; do
+	fmt="$(echo "$fmt" | tr -d '[:space:]')"
+	case "$fmt" in
+	pdf | pptx | html) ;;
+	"") continue ;;
+	*)
+		echo "error: unsupported format '$fmt' (use pdf, pptx, or html)" >&2
+		exit 2
+		;;
+	esac
+	clean_stale_locks
+	echo ">> rendering $fmt ..."
+	"${MARP[@]}" "$DECK" "--$fmt" --allow-local-files
+done
+
+echo ">> done. outputs are next to $DECK"

--- a/docs/slides/.gitignore
+++ b/docs/slides/.gitignore
@@ -1,0 +1,4 @@
+# Rendered Marp artifacts (source of truth is the .md)
+*.pdf
+*.pptx
+*.html

--- a/docs/slides/2026-07-08_claude-routine-loop-engineering.md
+++ b/docs/slides/2026-07-08_claude-routine-loop-engineering.md
@@ -1,0 +1,253 @@
+---
+marp: true
+theme: gaia
+paginate: true
+size: 16:9
+header: "Claude Routine で回す自律改善ループ"
+footer: "my-pde / 2026-07-08"
+style: |
+  :root {
+    --accent: #7c5cff;
+    --ink: #1f2430;
+  }
+  section {
+    font-family: "Hiragino Sans", "Noto Sans JP", sans-serif;
+    font-size: 26px;
+    color: var(--ink);
+  }
+  h1, h2 { color: var(--accent); }
+  section.lead h1 { font-size: 52px; line-height: 1.25; }
+  section.lead { text-align: left; }
+  strong { color: var(--accent); }
+  table { font-size: 20px; }
+  code { background: #f0ecff; color: #5a3ce0; }
+  pre { background: #161b26; border-radius: 10px; padding: 14px 18px; box-shadow: 0 2px 8px rgba(0,0,0,.15); }
+  pre code { background: transparent; color: #e8ecf8; font-size: 19px; line-height: 1.4; }
+  .small { font-size: 20px; color: #556; }
+  blockquote { border-left: 6px solid var(--accent); padding-left: 16px; color: #444; }
+---
+
+<!-- _class: lead -->
+
+# Claude Routine で回す<br>自律改善ループ
+
+### ― コードを書かない時間も、環境が育つ仕組み ―
+
+<br>
+
+**ループエンジニアリング手法の紹介**
+`my-pde`（個人開発環境）での実践
+
+<span class="small">2026-07-08</span>
+
+---
+
+## 一言で言うと
+
+> **cron で起きる Claude が、リポジトリを自分で調べて改善を提案し、
+> 人の GO サインで PR まで作る** ―― それを毎日/毎週まわす。
+
+- 手を動かしていない間も、環境の改善が**細く・止まらず**進む
+- 人間は「やる/やらない」を判断するだけ（**triage ゲート**）
+- ループ自体を改善する**メタループ**まで含めて仕組み化
+
+---
+
+## 課題：個人開発環境は「育て続ける」のが難しい
+
+`my-pde` は 1 つのリポジトリに全部入っている：
+
+- `nvim/` … Neovim 設定
+- `scripts/ai-bridge/` … Go 製デーモン
+- `environment/` `dotfiles/` `mise.toml` … 環境・ツール
+- `ai-agents/` … Skills / hooks / エージェント定義
+- `.github/workflows/` … CI
+
+**改善ネタは無限にあるが、手動で棚卸しし続けるのは現実的じゃない。**
+
+---
+
+## アイデア：Claude Routine（クラウド定期エージェント）
+
+- claude.ai の **Routine（CCR）** = cron で隔離クラウドセッションを起動
+- ローカル環境に依存せず、**repo を checkout → 調査 → ツール実行**まで自走
+- GitHub Actions 版（`claude-code-action`）も試したが…
+  - `--max-turns` 超過 / OAuth トークンの期限管理が手間
+  - → **Routine に一本化**
+
+> ポイント：単なる API 呼び出しではなく、**Claude Code ランタイムがフル稼働**する。
+
+---
+
+## 全体像：4 段階のループ
+
+```text
+ ①スキャン        ②採用判定        ③PR化           ④マージ判断
+ ┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐
+ │ Routine │ ──▶ │  人手   │ ──▶ │ PR Bot  │ ──▶ │  人手   │
+ │ が Issue│     │ adopted │     │ が draft│     │ merge / │
+ │ 起票    │     │/rejected│     │ PR 作成 │     │ close   │
+ └─────────┘     └─────────┘     └─────────┘     └─────────┘
+      ▲                                                │
+      └──────── メタループ（月次）でプロンプトへ還元 ◀─┘
+```
+
+**自動化するのは調査と実装。判断は人間が握る。**
+
+---
+
+## パイプライン：曜日で分散させて運用
+
+| 曜日 | Routine                     | 役割                                        |
+| ---- | --------------------------- | ------------------------------------------- |
+| 毎日 | Daily Neovim Trend Scan     | Neovim 動向を調べ Issue 起票（最大1）       |
+| 日   | Adopted-Issue PR Bot        | `adopted` Issue を実装しドラフト PR         |
+| 月   | PR Care Bot                 | `auto/*` PR の CI/コンフリクト/レビュー対応 |
+| 火   | Scripts Tooling Scan        | `scripts/` 向け提案                         |
+| 水   | Environment Scan            | `environment/`・`dotfiles/`・`mise.toml`    |
+| 木   | DevX Skills/Hooks Scan      | 汎用 hooks/skills 提案                      |
+| 金   | CI Workflows Scan           | `.github/workflows/` 改善                   |
+| 土   | Pipeline Digest（LLM 不要） | 滞留の可視化                                |
+
+---
+
+## スキャンの肝：ノイズを出さない工夫
+
+- **1 回 = 最大 1 件**に絞る → ターン・コストを抑える
+- **重複排除を二重に**
+  - 提案済み（Open `scan:*`）
+  - 一度不採用（Closed + `rejected`）
+- **Skip ではなく「別角度」へ**
+  - 有力候補が既存と被ったら、**被らない別の提案を選び直す**
+  - ネタ切れで永遠に起票されない、を防ぐ
+
+> 「毎回ちがう角度で 1 件」を狙う設計。
+
+---
+
+## 人間のゲート：ラベルで意思表示
+
+- 採用 → **`adopted`**（PR Bot が拾う）
+- 見送り → **`rejected`** を付けて **Close**
+- **rejected の時は理由を一言コメント**で残す
+
+<br>
+
+これが後述の**メタループの学習データ**になる。
+判断は軽い操作（ラベル付け）だけ = **triage ゲートは人間が維持**。
+
+---
+
+## PR 化 Bot：adopted → ドラフト PR
+
+各 adopted Issue ごとに：
+
+1. `main` から作業ブランチ（`auto/issue-<N>-<slug>`）
+2. 提案を**最小差分**で実装
+3. 検証（stylua / `golangci-lint` / `go test` など）
+4. 命令形コミット & push
+5. `gh pr create --draft`（body に `Closes #N`・何を/なぜ/検証結果）
+6. Issue に `pr-created` ラベル（重複 PR 防止）
+
+**すべて draft。最終マージ判断は人間。** `main` 直コミットはしない。
+
+---
+
+## PR Care Bot：作った後の面倒を見る
+
+Open な `auto/*` PR に対して（月曜）：
+
+- CI 失敗の修正
+- コンフリクト解消（**merge のみ**、rebase / force-push 禁止）
+- レビューコメント対応
+
+<br>
+
+- **人手 commit が後に積まれた PR はスキップ**（人の作業を壊さない）
+- ready 化・マージはしない
+
+---
+
+## メタループ：ループ自身を改善する
+
+**Monthly Routine Improve**（毎月2日）
+
+- 直近 1 ヶ月の
+  - `rejected` Issue の**不採用理由コメント**
+  - 未マージ close の `auto/*` PR
+  - レビュー指摘
+- を分析し、`routines/prompts/*.md` への**最小差分の改善**を draft PR で提案
+
+> Skills の _observe → improve_ に相当する仕組みを Routine にも。
+> **プロンプトが運用実績で育つ。**
+
+---
+
+## 定義管理：repo を source of truth に
+
+- `routines/*.json` … Routine 定義（cron / model / tools）
+- `routines/prompts/*.md` … **プロンプト本文**
+
+**プロンプトの間接参照化**がキモ：
+
+- JSON の `prompt` は「checkout した repo の md を読んで従え」という薄いポインタ
+- → **プロンプト変更はマージするだけで次回実行から反映**（手動 apply 不要）
+- markdownlint / prettier の検証対象にもなる
+
+---
+
+## LLM が要らない所は LLM を使わない
+
+**Pipeline Digest**（土曜・素の GitHub Actions）
+
+- triage 待ち Issue / 滞留 `adopted` / Open な `auto/*` PR を集計
+- `gh` + `jq` だけ、`digest` ラベルの**単一 Issue を上書き更新**
+
+<br>
+
+- Issue を増殖させない
+- `scan:*` を付けず、スキャンの重複排除を汚さない
+
+> 決定論的な定型処理に LLM は過剰。**適材適所。**
+
+---
+
+## 成果（直近の実績）
+
+- scan Issue の**採用率 約 93%**（クローズ済み 29 件中 adopted 27 / rejected 2）
+- `auto/*` PR **25 件中 23 件マージ**
+- 週の各曜日に改善タスクが**自動で流れてくる**状態
+- **採用＝丸呑みではない**：検討の余地はあるが要ブラッシュアップな提案は、
+  Issue を種に**人が再スコープして実装**（例: worktree 案→hook 化 #517 / test-changed の設計見直し #521）
+- 無駄打ち（rejected 後に PR 化）は稀で許容範囲
+
+<br>
+
+**「気づいたら環境が良くなっている」**が日常になった。
+
+---
+
+## 学び
+
+- **人間はゲートに徹する**：判断を握れば自動化は怖くない（全部 draft）
+- **1 件ずつ・別角度**：量より継続。ノイズを出さない設計が命
+- **安全側のデフォルト**：merge のみ / 最小差分 / 人手 commit は触らない
+- **仕組みを仕組みで直す**：メタループでプロンプトが育つ
+- **適材適所**：定型処理は素の CI へ逃がす
+
+---
+
+<!-- _class: lead -->
+
+# まとめ
+
+**cron × Claude × 人間の triage ゲート**で、
+個人開発環境が**自律的に・安全に育ち続ける**ループを作った。
+
+<br>
+
+鍵は「**全部 draft・判断は人間・1件ずつ・repo が正**」。
+
+<br>
+
+<span class="small">ご清聴ありがとうございました 🙌</span>


### PR DESCRIPTION
## 実装経緯の説明

Claude で 5〜10 分のプレゼン資料を作りたいという要望から、Marp（Markdown）でスライドを起こし PDF/PPTX/HTML に書き出す一連の流れを実践した。この流れを繰り返し使えるよう Agent Skill 化する。仕様は agentskills.io / Claude の Agent Skills ベストプラクティスに準拠。

## 補足

### 主な変更内容

- `ai-agents/skills/marp-deck-export/SKILL.md`: 手順（文脈収集 → 下書き → `docs/slides/YYYY-MM-DD_slug.md` 保存 → 描画 → 検証）と知見を明記
- `scripts/render_deck.sh`: pdf/pptx/html 描画ヘルパー（実行権限付与）
- `assets/marp-template.md`: gaia テーマの雛形（改良した配色込み）
- `.markdownlint-cli2.yaml`: `docs/slides/**` と `**/marp-template.md` を lint 除外
- `docs/slides/`: 初弾成果物として Claude Routine ループ手法の発表資料（描画物は `.gitignore` で除外し、正は `.md`）

### 技術的な詳細

- description は三人称・What+When・キーワード（プレゼン/スライド/Marp/pptx/Google スライド）で自動起動されやすく
- 壊れやすい描画処理をスクリプトに封じ込め: `--pdf`/`--pptx` の排他を形式ごと実行で回避、Chromium の stale lock を各描画前に掃除、`--allow-local-files` 付与・npx フォールバック・ファイル存在チェック
- スタイルの知見: インライン `code` に配色を付けたら `pre`/`pre code` も別指定しないと ASCII 図のコントラストが死ぬ
- Marp デッキは inline HTML・複数 h1 が前提で prose 用 markdownlint と非互換のため除外（明示ファイル渡しでも ignore が効くことを確認済み ＝ lint-changed フックも green）

### 確認事項

- [ ] `mise run skills-copy`（または deploy-ai-config スキル）で各 CLI に配布すると利用可能
- [ ] shellcheck OK / SKILL.md は markdownlint 0 エラー / `render_deck.sh` で実デッキを pdf/pptx/html 全形式 end-to-end 描画成功
- [ ] PDF/PPTX 描画はヘッドレス Chromium を使うためサンドボックス下では失敗しうる（HTML は不要）