### PR TITLE
fix: blink.cmp コマンドライン補完の auto_show を無効化

### DIFF
--- a/nvim/config/lua/blink_cmp.lua
+++ b/nvim/config/lua/blink_cmp.lua
@@ -45,15 +45,15 @@ require("blink.cmp").setup({
 		},
 	},
 
-	-- コマンドライン (: / 検索) 補完。既定では cmdline は有効だが auto_show が cmdwin 限定なので、
-	-- 通常の : 入力中もメニューが自動表示されるよう auto_show = true にする。
+	-- コマンドライン (: / 検索) 補完。auto_show = true は打鍵ごとにメニューが出て煩わしかったので
+	-- false にし、Tab を押したときだけメニューを表示する。
 	-- keymap preset "cmdline" は Tab で挿入/確定、単一候補は自動確定する定番マッピング。
 	cmdline = {
 		enabled = true,
 		keymap = { preset = "cmdline" },
 		sources = { "buffer", "cmdline" },
 		completion = {
-			menu = { auto_show = true },
+			menu = { auto_show = false },
 		},
 	},
 


### PR DESCRIPTION
## 実装経緯の説明

PR #512 で有効化したコマンドライン補完の `auto_show = true` は、`:` 入力のたびにメニューがポップアップして煩わしかったため、`false` に戻す。

## 補足

### 主な変更内容

- `nvim/config/lua/blink_cmp.lua` の `cmdline.completion.menu.auto_show` を `false` に変更
- 上部コメントを実態（false にした理由）に合わせて更新

### 技術的な詳細

- `keymap = { preset = "cmdline" }` と `sources = { "buffer", "cmdline" }` は維持。メニューは Tab を押したときだけ表示され、Tab で挿入/確定・単一候補の自動確定はそのまま動く
- `plugins.lua` の `CmdlineEnter` 遅延ロードは変更しない（Tab 起動の補完に引き続き必要）

### 確認事項

- `:` 入力中に補完メニューが自動で出ないこと
- Tab を押すとメニューが表示され、補完が効くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)