### PR TITLE
feat(nvim): nvim-autopairs で括弧/引用符の自動クローズを追加

### DIFF
--- a/nvim/config/lua/nvim_autopairs.lua
+++ b/nvim/config/lua/nvim_autopairs.lua
@@ -1,0 +1,10 @@
+-- ----------
+-- nvim-autopairs
+-- 入力時に対応する閉じ記号を自動挿入し、ペアの内側で Enter を押すと
+-- インデント付きで展開する。全 filetype で有効。
+-- ----------
+require("nvim-autopairs").setup({
+	-- treesitter を使い、文字列/コメント内での不要なペア挿入を避ける。
+	-- treesitter は lazy=false で常時ロード済みなので有効化して問題ない。
+	check_ts = true,
+})

--- a/nvim/config/lua/plugins.lua
+++ b/nvim/config/lua/plugins.lua
@@ -84,6 +84,14 @@ return {
 			require("blink_cmp")
 		end,
 	},
+	{ -- Auto-close brackets/quotes (入力時のペア自動クローズ)
+		"windwp/nvim-autopairs",
+		lazy = true,
+		event = "InsertEnter",
+		config = function()
+			require("nvim_autopairs")
+		end,
+	},
 	{ -- Debug Adapter Protocol
 		"mfussenegger/nvim-dap",
 		lazy = true,


### PR DESCRIPTION
## 実装経緯の説明

`nvim/config/` には「入力時にペアを自動で閉じる」導線が無く、`(` `[` `{` `"` `'` などを手打ちで閉じ、`{` 直後の改行で `}` を手で足していた。`windwp/nvim-autopairs` を導入して、対応する閉じ記号の自動挿入とペア内側での Enter 展開（`{|}` → `{` / 改行 / `}`）を全 filetype で有効化する。既存の nvim-surround（囲みの add/change/delete）とは守備範囲が異なり、autopairs は新規入力時のペアクローズを担当する。

## チケット

Closes #533

## 補足

### 主な変更内容

- `nvim/config/lua/plugins.lua`: `windwp/nvim-autopairs` エントリを追加。`InsertEnter` で遅延ロードし起動コストを増やさない。
- `nvim/config/lua/nvim_autopairs.lua`（新規）: 既存の modular 構成に合わせた最小 setup。`check_ts = true` で treesitter を使い、文字列/コメント内での不要なペア挿入を避ける。

### 技術的な詳細

- blink.cmp の keymap preset は `default`（確定は `C-y`）で `<CR>` は未マッピングのため、autopairs 既定の Enter ペア展開（`map_cr`）と衝突しない。
- Go の `noexpandtab`/`smartindent` などのインデント設定にはペア挿入・Enter 展開が追従するだけで競合しない。
- 既に閉じ記号がある位置では「またぐ」挙動になり二重挿入は起きない。

### 検証結果

- ローカル環境に stylua / nvim が無いため機械検証は未実施。追加は既存ファイルのタブ/ダブルクオート様式に合わせており、`lint_stylua`（PR CI）で stylua チェックが走る。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTvveA6JWRzXMyTkYsNdmo)_