### PR TITLE
feat(nvim): telescope の LSP シンボル/診断ピッカーを f 系に追加

### DIFF
--- a/nvim/config/lua/telescope_config.lua
+++ b/nvim/config/lua/telescope_config.lua
@@ -23,6 +23,14 @@ end, { desc = "Live Grep (include hidden)" })
 vim.keymap.set("n", "<leader>fb", builtin.buffers, { desc = "Telescope buffers" })
 vim.keymap.set("n", "<leader>fh", builtin.help_tags, { desc = "Telescope help tags" })
 
+-- LSP シンボル / 診断ピッカー (LSP アタッチ済みバッファで有効)
+vim.keymap.set("n", "<leader>fs", builtin.lsp_document_symbols, { desc = "LSP document symbols (current file)" })
+vim.keymap.set("n", "<leader>fS", builtin.lsp_dynamic_workspace_symbols, { desc = "LSP workspace symbols (project)" })
+vim.keymap.set("n", "<leader>fd", function()
+	builtin.diagnostics({ bufnr = 0 })
+end, { desc = "Diagnostics (current buffer)" })
+vim.keymap.set("n", "<leader>fD", builtin.diagnostics, { desc = "Diagnostics (all buffers)" })
+
 -- ----------
 -- telescope-file-browser.nvim
 -- ----------


### PR DESCRIPTION
## 実装経緯の説明

telescope は導入済みだが、`lua/telescope_config.lua` でマップしているのは `find_files` / `live_grep` / `buffers` / `help_tags` / `file_browser` のみで、稼働中の LSP を活かした「シンボル移動」「診断の俯瞰」の導線が無かった。新規プラグイン無し・追加設定最小で builtin ピッカーをキーマップに載せる。

## チケット

Closes #529

## 補足

### 主な変更内容

`nvim/config/lua/telescope_config.lua` の builtin ピッカー群に以下を追記（新規ファイル・新規プラグインなし）:

- `<leader>fs`: `lsp_document_symbols`（現在ファイルの記号一覧）
- `<leader>fS`: `lsp_dynamic_workspace_symbols`（プロジェクト横断のシンボル検索）
- `<leader>fd`: `diagnostics({ bufnr = 0 })`（現在バッファの診断）
- `<leader>fD`: `diagnostics`（全バッファの診断）

### 技術的な詳細

- 既存の `<leader>f` プレフィックス（find/telescope）に載せて一貫性を保つ。既存キー（`ff`/`fg`/`fb`/`fh`）や `<space>fo` と衝突しない。
- `lsp_document_symbols` / `lsp_dynamic_workspace_symbols` は LSP 未アタッチ時は結果が空になるだけで害はない。
- 診断ピッカーは `vim.diagnostic` ベースで、既存の `virtual_lines` / float 表示と併存する（競合しない）。

### 検証結果

- ローカルに stylua / nvim が無いため機械検証は未実施。追記は既存様式（タブ/ダブルクオート）に合わせており、`lint_stylua`（PR CI）で stylua チェックが走る。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTvveA6JWRzXMyTkYsNdmo)_