### PR TITLE
ci: 読み取り専用ジョブの checkout に persist-credentials: false を付与

### DIFF
--- a/.github/workflows/check_pins.yml
+++ b/.github/workflows/check_pins.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/go_module_ci.yml
+++ b/.github/workflows/go_module_ci.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
@@ -50,6 +52,8 @@ jobs:
         working-directory: scripts/${{ inputs.module }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/lint_format.yml
+++ b/.github/workflows/lint_format.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/lint_shell.yml
+++ b/.github/workflows/lint_shell.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/lint_stylua.yml
+++ b/.github/workflows/lint_stylua.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0


### PR DESCRIPTION
## 実装経緯の説明

`actions/checkout` はデフォルト（`persist-credentials: true`）で `GITHUB_TOKEN` を `.git/config` に書き込み、checkout 以降の全ステップが暗黙的に git 認証情報を使えてしまう。SHA ピン留め・permissions 最小化と同じ「侵害後の被害最小化」脅威モデルの残り半分を塞ぐため、**push しない読み取り専用ジョブ**の checkout に `persist-credentials: false` を付ける。これらのジョブは持続化された認証情報を使う経路が無いため、正常系の CI 挙動は変わらない。

## チケット

Closes #530

## 補足

### 主な変更内容

push しない読み取り専用ジョブの `actions/checkout` に `with: persist-credentials: false` を追加（各 1 箇所、計 8 呼び出し / 7 ファイル）:

- `go_module_ci.yml`: `lint` / `test` ジョブの 2 箇所（reusable 本体なので 4 呼び出し側すべてに反映）
- `lint_format.yml` / `lint_shell.yml` / `lint_stylua.yml` / `check_pins.yml` / `lint_dockerfile.yml` / `pr-docker-build.yml`

対象外（push が絡む / checkout 無し）: `bump-versions.yml`（`create-pull-request` で push）、`auto-merge-deps.yml`・`ci_*.yml`（checkout を持たない）。

### 技術的な詳細

- `go_module_ci.yml` の `test` ジョブのカバレッジコメントは `GH_TOKEN` env を渡した `gh api` で投稿され、checkout の git 認証情報とは独立。`git diff --exit-code` も認証不要。対象ジョブに `git push` / `git commit` が無いことを確認済み。
- 影響範囲は「checkout が `.git/config` に token を書き込むか否か」のみで、CI ロジック・実行時間・トリガーには触れない。

### 検証結果

- 7 ファイルとも `yaml.safe_load` でパース OK。ローカルに actionlint が無いため静的検査は未実施だが、追加は checkout ステップへの `with:` ブロック（8/10 スペースインデント）のみ。PR CI で各 lint/test が緑になることで正常系の不変を確認できる。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTvveA6JWRzXMyTkYsNdmo)_