### PR TITLE
docker: hadolint を latest 取得から mise ピン連動のバージョン固定へ

### DIFF
--- a/environment/docker/nvim.dockerfile
+++ b/environment/docker/nvim.dockerfile
@@ -153,6 +153,7 @@ WORKDIR /
 # Stage 6: Fetch hadolint binary only
 FROM base AS hadolint-builder
 
+ARG HADOLINT_VERSION=2.14.0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
   ARCH="$(dpkg --print-architecture)"; \
@@ -161,7 +162,7 @@ RUN set -eux; \
     arm64) HL_ARCH="Linux-arm64" ;; \
     *) echo "Unsupported arch for hadolint: $ARCH" >&2; exit 1 ;; \
   esac; \
-  BASE_URL="https://github.com/hadolint/hadolint/releases/latest/download"; \
+  BASE_URL="https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}"; \
   TMPDIR="/tmp/hadolint"; \
   mkdir -p "$TMPDIR"; \
   BIN_PATH="$TMPDIR/hadolint"; \

--- a/environment/tools/sync-pins.sh
+++ b/environment/tools/sync-pins.sh
@@ -49,6 +49,7 @@ neovim_version=$(pin 'NEOVIM_VERSION')
 npm_version=$(pin 'NPM_VERSION')
 rust_toolchain=$(pin 'RUST_TOOLCHAIN')
 terraform_version=$(pin 'TERRAFORM_VERSION')
+hadolint_version=$(pin 'hadolint')
 
 sed -i.bak -E \
 	-e "s|^ARG GO_VERSION(=.*)?$|ARG GO_VERSION=${go_version}|" \
@@ -57,6 +58,7 @@ sed -i.bak -E \
 	-e "s|^ARG NPM_VERSION(=.*)?$|ARG NPM_VERSION=${npm_version}|" \
 	-e "s|^ARG RUST_TOOLCHAIN(=.*)?$|ARG RUST_TOOLCHAIN=${rust_toolchain}|" \
 	-e "s|^ARG TERRAFORM_VERSION(=.*)?$|ARG TERRAFORM_VERSION=${terraform_version}|" \
+	-e "s|^ARG HADOLINT_VERSION(=.*)?$|ARG HADOLINT_VERSION=${hadolint_version}|" \
 	"$DOCKERFILE"
 rm -f "${DOCKERFILE}.bak"
 echo "Synced ARG defaults in $DOCKERFILE"


### PR DESCRIPTION
## 実装経緯の説明

`environment/docker/nvim.dockerfile` は Go/Node/Neovim/Rust/Terraform を `mise.toml` 単一ソースで固定しているが、hadolint だけが `releases/latest/download` から取得しており唯一の例外だった。これによりビルド時点で焼き込まれるバージョンが変わって**イメージが再現不能**になり、さらにコンテナ内 hadolint（latest）と mise/CI（2.14.0）で**バージョンが食い違う**。hadolint を他ツールと同じ固定フロー（`mise.toml` → `sync-pins.sh` が `ARG` 生成 → `pins:check` で検証）に乗せる。

## チケット

Closes #525

## 補足

### 主な変更内容

- `environment/docker/nvim.dockerfile`（Stage 6 `hadolint-builder`）: `ARG HADOLINT_VERSION=2.14.0` を追加し、`BASE_URL` を `releases/latest/download` → `releases/download/v${HADOLINT_VERSION}` に変更。取得アセット名（`hadolint-$HL_ARCH` / `.sha256`）と sha256 検証ロジックは無改修。
- `environment/tools/sync-pins.sh`: `hadolint_version=$(pin 'hadolint')` を追加し、`ARG HADOLINT_VERSION` を `mise.toml [tools]` の hadolint から生成する sed 行を追加。他 6 ツールと同一ガバナンスに乗る。

### 技術的な詳細

- `ARG HADOLINT_VERSION=` 行は 1 行・非インデントで、`sync-pins.sh` のパターン置換および `guard-version-pins.sh`（手動バンプ防止フック）の保護下に入る。
- バージョン固定により latest への自動追随は止まるが、これは意図した挙動。更新は `mise use --pin hadolint@<ver>` + `pins:sync` および週次 `bump-versions.yml` 経由。

### 検証結果

- `bash environment/tools/sync-pins.sh` を実行 → `ARG HADOLINT_VERSION=2.14.0` のまま（mise.toml と一致・冪等）、`go-tools.txt` にも差分なし。よって CI の `pins:check` は通る見込み。
- `bash -n environment/tools/sync-pins.sh` 構文 OK。
- ローカルに hadolint/docker が無いためイメージビルドは未実施。最終イメージへの影響は「latest → 明示ピン 2.14.0」のバージョン差のみで、アセット名・検証ロジックは不変。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTvveA6JWRzXMyTkYsNdmo)_