### PR TITLE
edit: autoread + :checktime トリガで外部変更ファイルを自動リロードする

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -34,6 +34,28 @@ vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current w
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
 
 -- ----------------------------------------
+-- 外部変更ファイルの自動リロード (autoread + :checktime トリガ)
+-- ----------------------------------------
+vim.opt.autoread = true -- ディスク上で更新されたファイルをバッファへ読み直す
+local autoread_group = vim.api.nvim_create_augroup("auto_reload_on_external_change", { clear = true })
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHoldI" }, {
+	group = autoread_group,
+	callback = function()
+		-- コマンドライン入力中やバッファ種別が特殊なものは対象外
+		if vim.fn.mode() ~= "c" and vim.bo.buftype == "" then
+			vim.cmd("checktime")
+		end
+	end,
+})
+-- リロードが起きたら軽く通知（無言の差し替えを避ける）
+vim.api.nvim_create_autocmd("FileChangedShellPost", {
+	group = autoread_group,
+	callback = function()
+		vim.notify("Buffer reloaded from disk (external change)", vim.log.levels.INFO)
+	end,
+})
+
+-- ----------------------------------------
 -- Neovim 0.12 で追加された UI オプション
 -- ----------------------------------------
 vim.opt.pumborder = "rounded" -- Add a rounded border to the popup menu (completion).


### PR DESCRIPTION
Closes #546

## 何を
`nvim/config/init.lua` に以下を追加:
- `vim.opt.autoread = true`
- `FocusGained` / `BufEnter` / `CursorHold` / `CursorHoldI` で `:checktime` を発火（コマンドライン入力中・特殊 buftype は除外し、通常ファイル `buftype == ""` のみ対象）
- `FileChangedShellPost` でリロード通知

## なぜ
`ai_bridge.lua` 経由の AI CLI やエディタ内ターミナル (`term://bash`) で外部プロセスがワークツリーを頻繁に書き換える構成。端末版 Neovim は `autoread` だけでは変更検知の契機が乏しく、バッファが古いまま編集して `W12` 警告や上書き事故が起きやすい。明示的な `:checktime` トリガで解消する。

## 検証
- ローカルに stylua が無く自動整形は未実行。既存ファイルのタブインデント規約に手動で合わせた（`.claude/rules/lua-nvim.md`）。CI の `lint_stylua` で最終確認される。
- 未保存変更のあるバッファは autoread では上書きされず（`FileChangedShell` が競合検知）、ローカル編集を失う挙動ではない。

Issue #546 の提案どおりの最小差分。

---
_Generated by [Claude Code](https://claude.ai/code/session_019PxUA3YikidcDrRtXKcSpF)_