### PR TITLE
scroll: scrolloff / sidescrolloff を設定しカーソル周辺に文脈行を確保する

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -32,6 +32,8 @@ vim.opt.foldlevelstart = 99 -- Open files fully expanded; folds (treesitter fold
 vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
 vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current window.
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
+vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
+vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
 
 -- ----------------------------------------
 -- Neovim 0.12 で追加された UI オプション


### PR DESCRIPTION
Closes #550

## 何を
`nvim/config/init.lua` のオプションブロック（`splitbelow` / `splitright` 付近）に 2 行追加:
- `vim.opt.scrolloff = 8`
- `vim.opt.sidescrolloff = 8`

## なぜ
現状どちらも未設定（既定 0）で、`j`/`k`・検索・`gd` 等のジャンプ着地点が画面上下端に来やすく、周辺コードの確認に追加スクロールが要る。カーソル周囲に常に 8 行/8 桁の文脈を残し、手動 `zz` を不要にする定番の QoL。

## 検証
- ローカルに stylua が無く自動整形は未実行。既存のタブインデント規約に手動で合わせた。CI の `lint_stylua` で最終確認される。
- ビルトインオプションのみ・依存なし。戻す場合は 2 行削除するだけ。

Issue #550 の提案どおりの最小差分。

---
_Generated by [Claude Code](https://claude.ai/code/session_019PxUA3YikidcDrRtXKcSpF)_