### PR TITLE
terminal: TermOpen で内蔵ターミナルの UX を整え t-mode 脱出を簡略化する

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -141,6 +141,22 @@ else
 end
 
 -- ----------------------------------------
+-- 内蔵ターミナルの UX 整備
+-- ----------------------------------------
+local term_group = vim.api.nvim_create_augroup("terminal_ux", { clear = true })
+vim.api.nvim_create_autocmd("TermOpen", {
+	group = term_group,
+	callback = function()
+		vim.opt_local.number = false -- シェル出力に行番号を出さない
+		vim.opt_local.relativenumber = false
+		vim.opt_local.signcolumn = "no" -- サイン列を消して出力の折り返しずれを防ぐ
+		vim.cmd("startinsert") -- 開いた瞬間に端末操作モードへ入る
+	end,
+})
+-- terminal-mode からの脱出を簡略化（<Esc><Esc> を <C-\><C-n> の代替に）
+vim.keymap.set("t", "<Esc><Esc>", [[<C-\><C-n>]], { desc = "Exit terminal mode" })
+
+-- ----------------------------------------
 -- indent_guides setting.
 -- ----------------------------------------
 vim.g.indent_guides_enable_on_vim_startup = 1


### PR DESCRIPTION
Closes #552

## 何を
`nvim/config/init.lua` の vimshell setting ブロック直後に追加:
- `TermOpen` autocmd で `number` / `relativenumber` を無効化・`signcolumn = "no"`・`startinsert`（`opt_local` でターミナルバッファのみに限定）
- terminal-mode 脱出を `<Esc><Esc>` → `<C-\><C-n>` にマッピング

## なぜ
`-` / `l`（`:split term://bash`）で内蔵ターミナルを日常的に使う構成だが、シェル出力の左に行番号・サイン列が残り、開いた直後はノーマルモードで一手間かかり、脱出に `<C-\><C-n>` が必要という摩擦がある。プラグイン不要・ビルトインのみの定番 QoL で解消する。

## 検証
- ローカルに stylua が無く自動整形は未実行。既存のタブインデント規約に手動で合わせた。CI の `lint_stylua` で最終確認される。
- `opt_local` によりバッファ単位に閉じ、通常ファイルや `ai_bridge` の `nofile` フローティングバッファ（`TermOpen` 非発火）には影響しない。
- 脱出は単一 Esc ではなく **二連 `<Esc><Esc>`** にし、ターミナル内 TUI（`less` / `fzf` 等）の Esc 使用との衝突を最小化。

Issue #552 の提案どおりの最小差分。

---
_Generated by [Claude Code](https://claude.ai/code/session_019PxUA3YikidcDrRtXKcSpF)_