### PR TITLE
wezterm: 描画バックエンドを front_end = "WebGpu" に切り替える

### DIFF
--- a/dotfiles/wezterm/appearance.lua
+++ b/dotfiles/wezterm/appearance.lua
@@ -1,6 +1,9 @@
 local wezterm = require("wezterm")
 
 return function(config)
+	-- 描画バックエンド: macOS では wgpu 経由で Metal を使う WebGpu を明示
+	config.front_end = "WebGpu"
+
 	-- カラースキーマ
 	config.color_scheme = "Catppuccin Mocha"
 


### PR DESCRIPTION
Closes #547

## 何を
`dotfiles/wezterm/appearance.lua` の先頭付近に 1 行追加:
- `config.front_end = "WebGpu"`

## なぜ
このファイルは背景としてグラデーション層 + PNG 画像を 2 枚重ねて合成する GPU 合成負荷の高い構成。`front_end` 未指定で既定の `"OpenGL"`（macOS では Apple により deprecated）で動作している。`"WebGpu"` は wgpu 経由で macOS の Metal を直接叩くため、この背景合成ワークロードで描画効率・正確性が向上しやすい。

## 検証
- ローカルに stylua が無く自動整形は未実行。既存ファイルのタブインデントに合わせた単純な代入 1 行でフォーマット差分は生まない見込み。CI の `lint_stylua` で最終確認される。
- CI への影響なし（WezTerm 設定はホスト専用で Docker イメージに含まれない）。
- 反映には WezTerm 再起動が必要。不具合時は `"OpenGL"` に戻すか行削除で既定へ完全に可逆。`webgpu_power_preference` は任意のため付けていない（既定の低電力 = 内蔵 GPU）。

Issue #547 の提案どおりの最小差分。

---
_Generated by [Claude Code](https://claude.ai/code/session_019PxUA3YikidcDrRtXKcSpF)_