### PR TITLE
ci: bump-versions のバージョン解決 curl を --fail + 検証で堅牢化する

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -25,28 +25,48 @@ jobs:
       - name: Resolve latest versions (policy-pinned tools)
         id: resolve
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # -f fails on HTTP errors (caught by set -e + pipefail), -S surfaces the
+          # error, --retry/--max-time absorb transient failures. Without -f, curl
+          # returns exit 0 on 4xx/5xx and pipes the error body into jq → junk values.
+          CURL=(curl -fsS --retry 3 --retry-delay 2 --max-time 30)
+
           # Node LTS latest (mise upgrade --bump would jump to non-LTS majors)
-          NODE_VERSION=$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts != false)] | max_by(.version | ltrimstr("v") | split(".") | map(tonumber)) | .version | ltrimstr("v")')
+          NODE_VERSION=$("${CURL[@]}" https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts != false)] | max_by(.version | ltrimstr("v") | split(".") | map(tonumber)) | .version | ltrimstr("v")')
 
           ## Go latest stable
-          GO_VERSION=$(curl -s 'https://go.dev/dl/?mode=json' | jq -r '[.[] | select(.stable==true)][0].version | ltrimstr("go")')
+          GO_VERSION=$("${CURL[@]}" 'https://go.dev/dl/?mode=json' | jq -r '[.[] | select(.stable==true)][0].version | ltrimstr("go")')
 
-          # Neovim latest release version
-          NEOVIM_VERSION=$(curl -s https://api.github.com/repos/neovim/neovim/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          # Neovim latest release version (authenticated to avoid the 60 req/h unauthenticated rate limit)
+          NEOVIM_VERSION=$("${CURL[@]}" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/neovim/neovim/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 
           # npm cli latest
-          NPM_VERSION=$(curl -s https://registry.npmjs.org/npm/latest | jq -r '.version')
+          NPM_VERSION=$("${CURL[@]}" https://registry.npmjs.org/npm/latest | jq -r '.version')
 
           # Terraform latest GA (Checkpoint API matches releases.hashicorp.com download source)
-          TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r '.current_version')
+          TERRAFORM_VERSION=$("${CURL[@]}" https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r '.current_version')
 
-          echo "node=$NODE_VERSION" >> $GITHUB_OUTPUT
-          echo "go=$GO_VERSION" >> $GITHUB_OUTPUT
-          echo "neovim=$NEOVIM_VERSION" >> $GITHUB_OUTPUT
-          echo "npm=$NPM_VERSION" >> $GITHUB_OUTPUT
-          echo "terraform=$TERRAFORM_VERSION" >> $GITHUB_OUTPUT
+          # Validate resolved values before writing outputs: fail fast instead of
+          # generating a broken bump PR (and a wasted docker build) when an upstream
+          # endpoint errors or returns an empty/null/non-version value.
+          for pair in "node=$NODE_VERSION" "go=$GO_VERSION" "neovim=$NEOVIM_VERSION" \
+                      "npm=$NPM_VERSION" "terraform=$TERRAFORM_VERSION"; do
+            name=${pair%%=*}
+            val=${pair#*=}
+            if [[ -z "$val" || "$val" == "null" || ! "$val" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              echo "::error::resolved $name version is invalid: '$val'" >&2
+              exit 1
+            fi
+          done
+
+          echo "node=$NODE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "go=$GO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "neovim=$NEOVIM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "npm=$NPM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "terraform=$TERRAFORM_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update mise.toml pins
         env:


### PR DESCRIPTION
Closes #551

## 何を
`.github/workflows/bump-versions.yml` の `Resolve latest versions` ステップのみを変更（他ワークフロー・他ステップは不変）:
- 各 `curl -s` を `curl -fsS --retry 3 --retry-delay 2 --max-time 30`（共通の `CURL` 配列に集約）へ置換。`-f` で HTTP エラーを非ゼロ化し `set -e` + `pipefail` が捕捉、`--retry`/`--max-time` で一過性障害を吸収。
- GitHub API 呼び出しに `-H "Authorization: Bearer $GITHUB_TOKEN"` を付与し、ステップに `env: GITHUB_TOKEN` を追加（未認証 60 req/h → 5,000 req/h）。
- `GITHUB_OUTPUT` へ書く前に、空・`null`・非バージョン値を弾く検証ガードを追加（不正時は run を fail）。
- `$GITHUB_OUTPUT` を quote（SC2086 相当）。

## なぜ
現状は裸の `curl -s`（`--fail` 無し）のため、上流の 4xx/5xx でもエラー本文を stdout に出したまま exit 0 となり `set -euo pipefail` で検知できない。とくに未認証の GitHub API はレート制限で 403 になりやすく、`.tag_name` が無いと `null` が `NEOVIM_VERSION` に入り、検証されないまま `mise.toml` に壊れた値を書き、`chore/bump-tool-versions` の自動 PR と 120 分の docker build を空振りさせる。一過性の上流エラーを「壊れた自動 PR」ではなく「fail-fast」に変える。

## 検証
- `python3 -c "yaml.safe_load(...)"` で YAML パース OK、ステップの `env` 追加を確認。
- 抽出した run スクリプトを `bash -n` で構文チェック OK。
- 検証ガードの正規表現を手元で確認: `22.11.0` / `1.24.5` / `0.11.2` / `10.9` を ACCEPT、`` / `null` / `v1.2.3` を REJECT。
- ローカルに actionlint 無し（Issue でも v1.7.12 は指摘 0 件と報告済み）。正常系の挙動は不変で、変わるのは上流エラー/不正応答時に PR を作らず run を fail させる点のみ。

Issue #551 の提案どおり、対象ステップに閉じた最小差分。

---
_Generated by [Claude Code](https://claude.ai/code/session_019PxUA3YikidcDrRtXKcSpF)_