### PR TITLE
feat: permission prompt を検出・提案する permission-prompt-tuner を追加

### DIFF
--- a/ai-agents/settings/claude/hooks/permission-prompt-detect.sh
+++ b/ai-agents/settings/claude/hooks/permission-prompt-detect.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: detect commands that would trigger a permission prompt
+# and append them to a per-session buffer for permission-prompt-tuner to analyze.
+# Pure observation — it never blocks or overrides the permission decision.
+set -u
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+
+PERM_HOOK_INPUT="$INPUT" python3 <<'PY' 2>/dev/null || true
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+
+def load_input():
+    raw = os.environ.get("PERM_HOOK_INPUT", "")
+    try:
+        return json.loads(raw) if raw else {}
+    except Exception:
+        return {}
+
+
+def read_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def bash_patterns(rules):
+    out = []
+    for r in rules or []:
+        if isinstance(r, str) and r.startswith("Bash(") and r.endswith(")"):
+            out.append(r[len("Bash(") : -1])
+    return out
+
+
+def pattern_matches(pattern, text):
+    # Approximate Claude Code's Bash matching: '*' is a wildcard, the match is
+    # anchored at the start. Not a full parser (quoting / $() are ignored).
+    if "*" not in pattern:
+        return text == pattern
+    parts = pattern.split("*")
+    if not text.startswith(parts[0]):
+        return False
+    idx = len(parts[0])
+    for part in parts[1:]:
+        if part == "":
+            continue
+        found = text.find(part, idx)
+        if found == -1:
+            return False
+        idx = found + len(part)
+    return True
+
+
+def split_segments(cmd):
+    tokens = re.split(r"\s*(?:\|\||&&|;|\|)\s*|\n+", cmd)
+    return [t.strip() for t in tokens if t.strip()]
+
+
+def strip_leading_env(segment):
+    toks = segment.split()
+    i = 0
+    while i < len(toks) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", toks[i]):
+        i += 1
+    return " ".join(toks[i:])
+
+
+def find_project_root(cwd):
+    try:
+        base = Path(cwd)
+    except Exception:
+        return None
+    for cand in [base, *base.parents]:
+        if (cand / ".git").exists():
+            return str(cand)
+    return None
+
+
+data = load_input()
+command = (data.get("tool_input", {}) or {}).get("command", "") or ""
+session_id = data.get("session_id", "") or "default"
+cwd = data.get("cwd", "") or os.getcwd()
+
+if not command.strip():
+    raise SystemExit(0)
+
+home = os.path.expanduser("~")
+settings_paths = [
+    os.path.join(home, ".claude", "settings.json"),
+    os.path.join(home, ".claude", "settings.local.json"),
+]
+project_root = find_project_root(cwd)
+if project_root:
+    settings_paths += [
+        os.path.join(project_root, ".claude", "settings.json"),
+        os.path.join(project_root, ".claude", "settings.local.json"),
+    ]
+
+allow, deny = [], []
+for path in settings_paths:
+    perms = read_json(path).get("permissions", {}) or {}
+    allow += perms.get("allow", []) or []
+    deny += perms.get("deny", []) or []
+allow_pats = bash_patterns(allow)
+deny_pats = bash_patterns(deny)
+
+segments = split_segments(command)
+causes = []
+for seg in segments:
+    text = strip_leading_env(seg)
+    if not text:
+        continue
+    if any(pattern_matches(p, text) for p in deny_pats):
+        causes.append({"segment": text, "kind": "deny-hit"})
+        continue
+    if any(pattern_matches(p, text) for p in allow_pats):
+        continue
+    if re.match(r"^terraform\s+-chdir=", text):
+        causes.append({"segment": text, "kind": "prefix-break"})
+    else:
+        causes.append({"segment": text, "kind": "missing-allow"})
+
+has_cd = any(
+    strip_leading_env(seg) == "cd" or strip_leading_env(seg).startswith("cd ")
+    for seg in segments
+)
+has_file_redirect = bool(re.search(r">>?\s*[^&\s]", command))
+if has_cd and has_file_redirect:
+    causes.append({"segment": command.strip(), "kind": "builtin-cd-redirect"})
+
+if not causes:
+    raise SystemExit(0)
+
+buffer_dir = os.path.join(
+    os.environ.get("TMPDIR", "/tmp"), "claude-permission-prompt-tuner"
+)
+os.makedirs(buffer_dir, exist_ok=True)
+buffer_path = os.path.join(buffer_dir, f"{session_id}.jsonl")
+
+existing = set()
+if os.path.exists(buffer_path):
+    with open(buffer_path) as f:
+        for line in f:
+            try:
+                existing.add(json.loads(line).get("command"))
+            except Exception:
+                continue
+if command in existing:
+    raise SystemExit(0)
+
+record = {
+    "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    "command": command,
+    "cwd": cwd,
+    "causes": causes,
+}
+with open(buffer_path, "a") as f:
+    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+PY
+
+exit 0

--- a/ai-agents/settings/claude/hooks/permission-prompt-nudge.sh
+++ b/ai-agents/settings/claude/hooks/permission-prompt-nudge.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Stop hook: when this session hit commands that triggered a permission prompt
+# (recorded by permission-prompt-detect.sh), block once so Claude runs the
+# permission-prompt-tuner skill to record them and propose settings.json fixes.
+# Non-destructive — it only nudges; the analysis/records are written by Claude.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""')
+STOP_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false')
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
+
+# Loop guard: we are already in a hook-triggered continuation.
+[ "$STOP_ACTIVE" = "true" ] && exit 0
+
+[ -n "$SESSION_ID" ] || SESSION_ID="default"
+buffer="${TMPDIR:-/tmp}/claude-permission-prompt-tuner/${SESSION_ID}.jsonl"
+[ -s "$buffer" ] || exit 0
+
+# Resolve where records live. Prefer SKILL_OBSERVE_HOME (the my-pde checkout) so
+# prompt records land in the git-tracked skills tree regardless of the work repo;
+# fall back to the current repo when the env var is unset (e.g. working in my-pde).
+[ -n "$CWD" ] || CWD=$(pwd)
+OBS_HOME=""
+observe_home="${SKILL_OBSERVE_HOME:-}"
+# shellcheck disable=SC2088  # intentionally matching/stripping a literal ~, not expanding
+case "$observe_home" in
+"~") observe_home="$HOME" ;;
+"~/"*) observe_home="$HOME/${observe_home#"~/"}" ;;
+esac
+if [ -n "$observe_home" ] && [ -d "$observe_home/ai-agents/skills" ]; then
+	OBS_HOME="$observe_home"
+else
+	ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+	if [ -n "$ROOT" ] && [ -d "$ROOT/ai-agents/skills" ]; then
+		OBS_HOME="$ROOT"
+	fi
+fi
+[ -n "$OBS_HOME" ] || exit 0
+records_dir="$OBS_HOME/ai-agents/skills/permission-prompt-tuner/records"
+
+reason=$(
+	cat <<REASON
+このセッションで permission prompt が出た（自動許可されなかった）コマンドが検出されています。
+permission-prompt-tuner スキルを実行して、記録と settings.json への提案を行ってください。
+
+- 検出バッファ（1 行 1 コマンドの JSONL）: ${buffer}
+- 記録先ディレクトリ（絶対パス。現在の作業リポジトリと異なっても必ずここに書く）: ${records_dir}
+- 実行後、バッファ ${buffer} を空にする（同じプロンプトの再通知を防ぐため）。
+- settings.json は編集せず、提案の提示に留める。
+REASON
+)
+
+jq -n --arg r "$reason" '{decision: "block", reason: $r}'
+exit 0

--- a/ai-agents/settings/claude/settings.json
+++ b/ai-agents/settings/claude/settings.json
@@ -5,39 +5,49 @@
   },
   "permissions": {
     "allow": [
-      "Bash(actionlint:*)",
-      "Bash(docker compose:*)",
-      "Bash(find:*)",
-      "Bash(git:*)",
-      "Bash(gh:*)",
-      "Bash(go test:*)",
-      "Bash(go tool:*)",
-      "Bash(go build:*)",
-      "Bash(golangci-lint run:*)",
-      "Bash(go mod:*)",
-      "Bash(goimports:*)",
-      "Bash(grep:*)",
-      "Bash(hadolint:*)",
-      "Bash(ls:*)",
-      "Bash(make:*)",
-      "Bash(markdownlint-cli2:*)",
-      "Bash(mise:*)",
+      "Bash(actionlint *)",
+      "Bash(cd *)",
+      "Bash(docker compose *)",
+      "Bash(echo *)",
+      "Bash(find *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(go test *)",
+      "Bash(go tool *)",
+      "Bash(go build *)",
+      "Bash(golangci-lint run *)",
+      "Bash(go mod *)",
+      "Bash(goimports *)",
+      "Bash(grep *)",
+      "Bash(hadolint *)",
+      "Bash(head *)",
+      "Bash(ls *)",
+      "Bash(make *)",
+      "Bash(markdownlint-cli2 *)",
+      "Bash(mise *)",
       "Bash(npm run lint)",
       "Bash(npm run test *)",
-      "Bash(npx markdownlint-cli2:*)",
-      "Bash(npx playwright:*)",
-      "Bash(npx prettier:*)",
-      "Bash(prettier:*)",
-      "Bash(python3:*)",
-      "Bash(rg:*)",
-      "Bash(shellcheck:*)",
-      "Bash(shfmt:*)",
-      "Bash(stylua:*)",
-      "Bash(terraform fmt:*)",
-      "Bash(tflint:*)",
-      "Bash(tombi:*)",
-      "Bash(which:*)",
-      "Bash(xargs:*)",
+      "Bash(npx markdownlint-cli2 *)",
+      "Bash(npx playwright *)",
+      "Bash(npx prettier *)",
+      "Bash(prettier *)",
+      "Bash(python3 *)",
+      "Bash(rg *)",
+      "Bash(shellcheck *)",
+      "Bash(shfmt *)",
+      "Bash(stylua *)",
+      "Bash(tail *)",
+      "Bash(terraform fmt *)",
+      "Bash(terraform validate *)",
+      "Bash(terraform init *)",
+      "Bash(terraform plan *)",
+      "Bash(terraform show *)",
+      "Bash(terraform providers *)",
+      "Bash(tflint *)",
+      "Bash(tombi *)",
+      "Bash(wc *)",
+      "Bash(which *)",
+      "Bash(xargs *)",
       "Read(~/.zshrc)",
       "Read(~/.codex/**)",
       "Read(~/.cursor/**)",
@@ -51,7 +61,7 @@
     "deny": [
       "Bash(chmod 777 *)",
       "Bash(rm -rf *)",
-      "Bash(wget:*)",
+      "Bash(wget *)",
       "Read(./.env)",
       "Read(./.env.*)",
       "Read(./secrets/**)",
@@ -77,6 +87,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/guard-dangerous-bash.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/permission-prompt-detect.sh"
           }
         ]
       }
@@ -125,6 +139,10 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/permission-prompt-nudge.sh"
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/notify-macos.sh"
           }
         ]
@@ -154,23 +172,14 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
-    "excludedCommands": [
-      "mise run *",
-      "go test *",
-      "git branch *",
-      "git config *",
-      "git push *",
-      "git fetch *",
-      "git pull *",
-      "git clone *",
-      "gh *"
-    ],
+    "excludedCommands": ["mise", "terraform", "tflint", "go", "git", "gh"],
     "filesystem": {
       "allowWrite": [
         "~/Library/Caches/go-build",
         "~/Library/Caches/golangci-lint",
         "~/go/pkg/mod",
-        "~/.npm"
+        "~/.npm",
+        " ~/.cache/pre-commit"
       ]
     },
     "network": {

--- a/ai-agents/skills/permission-prompt-tuner/SKILL.md
+++ b/ai-agents/skills/permission-prompt-tuner/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: permission-prompt-tuner
+description: >-
+  permission prompt が出た（自動許可されなかった）Bash コマンドを記録し、
+  settings.json をどう調整すればプロンプトを減らせるかを提案する。
+  Stop hook（permission-prompt-nudge.sh）が検出バッファ非空時に自動起動する。
+metadata:
+  version: 1
+---
+
+# /permission-prompt-tuner スキル
+
+## Goal
+
+permission prompt が出たコマンドの原因を分類し、`settings.json` への追記案（または
+コマンド書き換え案）を提示して記録に蓄積する。設定の適用はしない（提案のみ）。
+
+## Workflow
+
+### Step 1: 検出バッファを読む
+
+Stop hook の reason に記載された検出バッファ（JSONL、1 行 1 コマンド）を読む。各行は
+`{ts, command, cwd, causes:[{segment, kind}]}`。バッファが無い/空なら何もせず終了する。
+
+手動起動でバッファパスが不明な場合は
+`${TMPDIR:-/tmp}/claude-permission-prompt-tuner/<session_id>.jsonl` を探す。
+
+### Step 2: 原因を分類する
+
+各コマンドの `causes[].kind` を `references/prompt-causes.md` に照らして解釈する。1 コマンドが
+複数 kind を持つことがある（例: 複合コマンドの未許可セグメント＋cd+redirection）。
+
+- `missing-allow` — allow にマッチしないセグメント
+- `prefix-break` — `terraform -chdir=...` 等で前方一致が外れる
+- `builtin-cd-redirect` — `cd`＋出力 redirection の組み込みガード（allow では解決不可）
+- `deny-hit` — deny にマッチ（意図的遮断の可能性）
+
+### Step 3: 推奨アクションを決める
+
+kind ごとに `references/prompt-causes.md` の対応表に従って決める。要点:
+
+- `missing-allow` → `Bash(<tool> *)` を allow に追加。**スコープ判断**: 汎用的で無害なコマンドは
+  グローバル（`~/.claude/settings.json`）、リポ固有・パス依存は project（`.claude/settings.local.json`）。
+  `cat` は Read ツール推奨のため allow 追加を勧めない（コマンド側を Read に変える提案）。
+- `prefix-break` → 具体パターン（例 `Bash(terraform -chdir=* show *)`）追加、または `-chdir` を
+  使わない書き換え、の二択を提示。
+- `builtin-cd-redirect` → allow では消せない。**コマンド書き換え**（`cd` を使わず絶対パスで
+  redirect する）を提示。
+- `deny-hit` → 意図的 deny の可能性が高い。allow 追加は勧めず、なぜ deny されているかを確認するよう促す。
+
+### Step 4: records に蓄積する
+
+Stop hook の reason に記載された記録先ディレクトリ（絶対パス）に、Write ツールで
+`YYYY-MM-DD_NNN.md` を新規作成する（NNN は当日連番、001 開始、既存と重複しないよう採番）。
+ディレクトリが無ければ作成する。1 バッチ（今回の検出分）につき 1 ファイル。形式:
+
+```markdown
+---
+skill: permission-prompt-tuner
+date: YYYY-MM-DD
+---
+
+# Permission Prompt Record — YYYY-MM-DD_NNN
+
+## <コマンドの1行要約>
+
+- **コマンド**: `<full command>`
+- **原因**: <kind と、なぜプロンプトが出たかの説明>
+- **推奨**: <allow 追記 JSON / 書き換え案>
+- **対象**: <追記先ファイルとスコープ、または「コマンド書き換え」>
+- **コンテキスト**: cwd: <cwd>
+```
+
+### Step 5: 提案を提示してバッファを空にする
+
+- 記録した内容の提案サマリをチャットに簡潔に提示する（settings.json は編集しない）。
+- 検出バッファを空にする（同じプロンプトの再通知を防ぐため）。Write ツールで空文字列を書き込む
+  （Bash を使うと新たなプロンプトを誘発しうるため避ける）。
+- 作成したファイルを 1 行で報告して終了する。ユーザーへの確認は不要。
+
+## Notes
+
+- 検出は Claude Code の許可判定の**近似**（quoting / `$(...)` の厳密解析はしない）。誤検出は
+  「余計な提案が 1 件出る」程度で無害。判断に迷うケースは records に事実だけ残す。
+- 記録先は環境変数 `SKILL_OBSERVE_HOME`（`~` は hook 側で `$HOME` に展開）で決まる。未設定時は
+  現在の git リポジトリ直下の `ai-agents/skills` にフォールバックする（[[skill-observe]] と同じ機構）。
+- 設定の適用（settings.json 追記）はユーザーが行う。必要なら [[update-config]] を案内する。
+- markdownlint を通すため、既存 records ファイルの体裁に合わせる。

--- a/ai-agents/skills/permission-prompt-tuner/references/prompt-causes.md
+++ b/ai-agents/skills/permission-prompt-tuner/references/prompt-causes.md
@@ -1,0 +1,56 @@
+# permission prompt の原因と対処
+
+Claude Code の Bash 許可判定と、permission prompt が出る主な原因・推奨対処の対応表。
+検出フック（`settings/claude/hooks/permission-prompt-detect.sh`）が付ける `kind` に対応する。
+
+## 前提: 許可判定の仕組み（近似）
+
+- コマンドは `&&` / `||` / `|` / `;` / 改行で**セグメントに分割**され、**全セグメント**が
+  `permissions.allow` のいずれかにマッチして初めて自動承認される。1 つでも未マッチだとプロンプトが出る。
+- allow パターン `Bash(<pat>)` は前方一致。`*` はワイルドカード。マッチは先頭アンカー。
+- deny は allow より優先。deny にマッチすると allow があっても実行不可。
+- 上記とは別に、Claude Code 組み込みの安全ガードが手動承認を要求するケースがある（下記
+  `builtin-cd-redirect`）。これは allow-list では解除できない。
+
+## kind 別の対処
+
+### `missing-allow`
+
+- **症状**: セグメントの実コマンド（先頭の `VAR=...` 除去後）が allow のどのパターンにも当たらない。
+  複合コマンドで `cd` / `echo` / `tail` / `head` / `wc` / `cat` などの無害コマンドが未登録なとき頻発。
+- **推奨**: `Bash(<tool> *)` を allow に追加。
+  - **スコープ**: 汎用的で無害なコマンド（`echo` / `tail` / `head` / `wc` / `cd` 等）は
+    グローバル `~/.claude/settings.json`。特定リポ・特定パスに依存するものは project の
+    `.claude/settings.local.json`。
+  - **例外**: `cat` は `Read` ツールで代替できる（プロジェクト方針で推奨）。allow 追加ではなく
+    コマンド側を Read に変える提案をする。
+
+### `prefix-break`
+
+- **症状**: コマンド名は allow にあるが、フラグが差し込まれて前方一致が外れる。代表例:
+  `terraform -chdir=/path show ...` は `Bash(terraform show *)` に当たらない（`-chdir` が
+  `terraform` と `show` の間に入るため）。
+- **推奨**: 次の二択を提示。
+  - パターン追加: `Bash(terraform -chdir=* show *)` のように `-chdir` 込みで登録。
+  - 書き換え: `-chdir` を使わず素直な形にする（サブコマンドを先頭付近に置く）。
+
+### `builtin-cd-redirect`
+
+- **症状**: 複合コマンド内に `cd`（特に変数ディレクトリ）と出力 redirection（`>` / `>>`）が共存。
+  「移動後に相対パスへ書き込むと、書き込み先が静的に確定できずパス制限をすり抜けうる」ため、
+  Claude Code 組み込みガードが手動承認を要求する。
+- **重要**: これは **allow-list では解除できない**。
+- **推奨**: コマンドを書き換える。`cd` を使わず、redirection 先を絶対パスにする。
+  - 例: `cd "$SP" && terraform show > out.json`
+    → `terraform -chdir="$SP" show > "$SP/out.json"`（ただし前者/後者とも他の kind に注意）。
+
+### `deny-hit`
+
+- **症状**: セグメントが `permissions.deny` にマッチ（例 `rm -rf *` / `wget *`）。
+- **推奨**: 意図的な遮断である可能性が高い。allow 追加は勧めない。なぜ deny されているかを
+  確認し、本当に必要なら deny 側の見直し要否をユーザーに委ねる。
+
+## 保守メモ
+
+- 検出はあくまで近似（quoting・`$(...)`・複雑なシェル構文は厳密に解釈しない）。
+- Claude Code 側のガードが増減したら、この対応表と検出フックの判定を合わせて更新する。


### PR DESCRIPTION
## 実装経緯の説明

日常作業で「許可を求められる（permission prompt）」Bash コマンドが頻発しており、原因分析を毎回手作業でやるのが非効率だった。プロンプトが出たコマンドを自動で捕捉・蓄積し、`settings.json` の追記案（またはコマンド書き換え案）を提示する仕組みを新設する。

前提として、トランスクリプトには「プロンプトが出た/承認された」の明示マーカーが無い（承認済みコマンドは自動許可と区別不能）ことが判明したため、検出はコマンド実行の瞬間（PreToolUse）に allow/deny ルールと照合して行う。

## 補足

### 主な変更内容

- **PreToolUse(Bash) 検出フック** `permission-prompt-detect.sh`: マージした allow/deny・組み込みガードと照合し、プロンプトが出るコマンドを `$TMPDIR/claude-permission-prompt-tuner/<session>.jsonl` に追記。純粋観測で block/deny せず常に exit 0。
- **Stop 起動フック** `permission-prompt-nudge.sh`: バッファ非空時に 1 回だけ block してスキルを起動。`skill-observe-nudge.sh` と同じ `SKILL_OBSERVE_HOME` 解決＋`stop_hook_active` ループガード。
- **permission-prompt-tuner スキル**（`SKILL.md` + `references/prompt-causes.md`）: 原因を `missing-allow` / `prefix-break` / `builtin-cd-redirect` / `deny-hit` に分類し、`records/` に蓄積して提案（`settings.json` は編集せず提案のみ）。
- `settings.json` に両フックを登録（allow 整形・sandbox 調整の既存差分も同梱）。

### 技術的な詳細

- フックは shell ラッパ＋python3 ヒアドキュメント構成（`guard-dangerous-bash.sh` の型）。設定は `~/.claude` とプロジェクト `.claude` の settings(.local).json をマージ読込。
- セグメント分割（`&&`/`||`/`|`/`;`/改行）＋先頭アンカーのワイルドカード前方一致で allow を近似判定。検出は best-effort（quoting/`$()` は厳密解析しない）。

### 確認事項

- 有効化には `mise run claude-settings-copy` / `claude-skills-copy` が必要（本 PR では未デプロイ）。
- 検証: shellcheck / shfmt / settings.json の JSON 妥当性、detect 単体 6 ケース・nudge 単体 3 ケース、markdownlint 0 issues を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)