### PR TITLE
docs: dev-workflow にテスト無しタスク（IaC/設定/ドキュメント）の節を追記

### DIFF
--- a/ai-agents/skills/dev-workflow/SKILL.md
+++ b/ai-agents/skills/dev-workflow/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   implement 以降（テスト戦略 → 検証 → コミット）の規律として適用する。
   新規プロダクト開発と既存プロダクト改修で手順が分岐する。
 metadata:
-  version: 3
+  version: 4
 ---
 
 # /dev-workflow スキル
@@ -25,6 +25,17 @@ metadata:
 
 - explore / plan がハーネス側の仕組み（Claude Code の Plan Mode 等）で既に済んでいる場合、その2フェーズは重複させず、**implement 以降（テスト戦略 → verify → commit）から適用する**。本スキルの中核価値は検証とコミットの規律にある。
 - Plan Mode を持たない CLI（Cursor / Codex / Copilot）では explore から順に全フェーズを適用する。
+
+## テストの無いタスク（IaC / 設定 / ドキュメント）
+
+Terraform 等の IaC、CI/設定ファイル、ドキュメントのように**ユニットテストの概念が無い**タスクでは、フローを次のように読み替える:
+
+- **test_first はスキップ**する（挙動不変のリファクタも同様）。再現テストを書く対象が無い。
+- **verify を静的検証に読み替える**。該当するものを実行して全て通す:
+  - Terraform: `fmt -check` / `validate` / `tflint` / `terraform plan -out`→`show -json` での生成 JSON 検証
+  - GitHub Actions: `actionlint`
+  - 共通: `markdownlint` / secret-scan（gitleaks）/ 生成物の再生成差分チェック
+- **環境要因を切り分ける**。IaC の verify はローカルの `.terraform` backend キャッシュや sandbox のネットワーク制限で失敗しうる（認証エラー・プロバイダ DL 失敗など）。変更ファイルの種別を見て「コード起因か環境要因か」を切り分け、環境要因ならクリーン再実行（キャッシュ退避 / sandbox 無効）で確認する。
 
 ## 新規プロダクト開発（new product）
 
@@ -57,3 +68,4 @@ metadata:
 
 - リポジトリ常設の lint hook（`lint-changed.sh`）が編集完了時に対象リンタを自動実行し、検証漏れを可視化する。本スキルの verify はそれと併用する。
 - 言語別の lint/format コマンドは触れたファイルに応じて path-scoped rules（`.claude/rules/`, `~/.claude/rules/`）が読み込む。
+- 並行更新のあるリポジトリでは、編集の直前に対象ファイルを Read し直し、最新状態に追従してから変更する（upstream main の進行で対象ファイルが変わっていることがある）。


### PR DESCRIPTION
## 実装経緯の説明

skill 改善ループ（Observe → Inspect → Amend）で `dev-workflow` スキルに蓄積された
20 件の observations を分析した結果、Terraform 等の IaC・CI/設定・ドキュメントのように
ユニットテストの概念が無いタスクの扱いが SKILL.md に未記載だった。verify を静的検証へ
読み替える運用が 11 回（うち 3 回は明示的な追記要望）繰り返し記録されており、その場判断で
補っていた再発パターンを amendment として明文化する。

## 補足

### 主な変更内容

- `## テストの無いタスク（IaC / 設定 / ドキュメント）` 節を新設（`適用範囲` の直後）
  - test_first はスキップ（挙動不変リファクタも同様）
  - verify を静的検証に読み替え（Terraform: fmt-check/validate/tflint/plan→show -json、
    GitHub Actions: actionlint、共通: markdownlint/secret-scan/生成物差分）
  - ローカル backend キャッシュや sandbox ネットワーク制限による失敗をコード起因か
    環境要因かで切り分ける
- `## Notes` に「編集直前に対象ファイルを Read し直す（並行更新追従）」を追記
- `metadata.version` を 3 → 4

### 技術的な詳細

- 挙動変更ではなく既存運用の明文化。エビデンスは 20 observations
  （IaC verify 読み替え 11 回・環境要因切り分け 9 回・編集直前再確認 1 回）。
- amendment 記録は `observations/amendments/2026-07-20_001_amendment.md`
  （observations/ は gitignore 対象のため本 PR には含まれない）。

### 確認事項

- markdownlint 0 error（リポジトリ設定で MD013 無効を確認済み）。
- 無関係な既存 dirty ファイル（rules 削除・settings.json 等）は本 PR に含めていない。