### PR TITLE
feat(nvim): enable inccommand=split for live :substitute preview

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -23,6 +23,7 @@ vim.opt.smartindent = true -- Add a new line with autoindent
 vim.opt.colorcolumn = "120" -- Add a color on 80'th column
 vim.opt.hlsearch = true -- Highlight searched characters
 vim.opt.incsearch = true -- Highlight when inputting chars
+vim.opt.inccommand = "split" -- :substitute の置換結果を入力中にライブプレビュー（下部スプリットに before/after 一覧）
 vim.opt.ignorecase = true -- 小文字のみの検索パターンは大文字小文字を無視する
 vim.opt.smartcase = true -- ただし大文字が1文字でも含まれる場合は大小を区別する（ignorecase と併用時のみ有効）
 vim.opt.wildmenu = true -- Show completion suggestions at command line mode


### PR DESCRIPTION
Closes #554

## 何を

`nvim/config/init.lua` の検索オプション群（`hlsearch` / `incsearch` の直後）に 1 行追加し、`vim.opt.inccommand = "split"` を有効化しました。

## なぜ

このリポジトリは `hlsearch` / `incsearch` で「検索は打鍵中にインクリメンタル表示」を既に整えている一方、`:substitute`（`:s` / `:%s` / `:g`）は結果が見えないまま Enter で確定するしかなく、正規表現ミスで意図しない置換 → `u` で戻す手戻りが起きやすい状態でした。`inccommand = "split"` はプラグイン不要・ビルトイン（Neovim 0.6+）で、置換結果を入力中にライブプレビューし、下部スプリットに before/after 一覧を表示します。`Esc` でキャンセルすればバッファは変更されません。

## 検証結果

- Lua の設定追加 1 行のみ。表示のみの非破壊的変更で、確定は従来どおり `Enter`。
- stylua はこの環境に未インストールのため未実行（既存のタブインデント規約に合わせて追記）。CI（Lint Stylua）で確認されます。
- 元に戻す場合は追記した 1 行の削除のみで既定へ戻せます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_