### PR TITLE
feat(nvim): enable confirm to prompt before discarding unsaved buffers

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -36,6 +36,7 @@ vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current w
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
 vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
 vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
+vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す
 
 -- ----------------------------------------
 -- 外部変更ファイルの自動リロード (autoread + :checktime トリガ)


### PR DESCRIPTION
Closes #571

## 何を

`nvim/config/init.lua` の基本オプション群に `vim.opt.confirm = true` を 1 行追加しました。

## なぜ

既定（`confirm` OFF）では、未保存のまま `:q` すると `E37: No write since last change` でコマンド自体が失敗し、反射的に `:q!` を打つ癖 → 本当は捨てたくない変更まで破棄する事故につながります。`confirm` を ON にすると同じ操作で `Save changes to "foo"? [Y]es, [N]o, [C]ancel` の保存確認ダイアログが出ます。このリポジトリは永続 undo・autoread など「作業を失わない」設定を揃えている一方、未保存バッファの誤破棄経路（`:q!` / `:e!`）だけ無防備だったため、その穴をビルトイン 1 行で塞ぎます。

## 検証結果

- Lua の設定追加 1 行のみ。変更が無い `:q` は従来どおり即閉じ、明示的に捨てたい場合の `:q!` / `:e!` は `confirm` の対象外なので通常操作の手数は増えません。
- stylua はこの環境に未インストールのため未実行（既存のタブインデント規約に合わせて追記）。CI（Lint Stylua）で確認されます。
- 元に戻す場合は追記した 1 行の削除のみで既定へ戻せます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_