### PR TITLE
feat(nvim): enable builtin spell for prose filetypes

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -158,6 +158,24 @@ vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
 })
 
 -- ----------------------------------------
+-- 散文系 filetype でのみビルトイン spell を有効化する。
+--   spelllang = "en,cjk": 英単語を検査しつつ、cjk で日本語など東アジア文字は検査対象から外す
+--                          (README/Markdown は日本語混在のため cjk が必須)
+--   spelloptions = "camel": camelCase/PascalCase を単語分割し、識別子の誤検出を防ぐ
+-- コードバッファ (go/lua/python 等) はノイズが大きいため対象にしない。
+-- 操作: ]s / [s で誤り移動、z= で候補提示、zg で正語登録、zw で誤語登録。
+-- ----------------------------------------
+vim.api.nvim_create_autocmd("FileType", {
+	group = vim.api.nvim_create_augroup("prose_spell", { clear = true }),
+	pattern = { "markdown", "text", "plaintext", "gitcommit" },
+	callback = function()
+		vim.opt_local.spell = true
+		vim.opt_local.spelllang = { "en", "cjk" }
+		vim.opt_local.spelloptions = "camel"
+	end,
+})
+
+-- ----------------------------------------
 -- Open init.vim and 'source' it.
 -- ----------------------------------------
 vim.api.nvim_set_keymap("n", "<Leader>.", ":vs ~/.config/nvim/init.lua<CR>", { noremap = true, silent = true })


### PR DESCRIPTION
Closes #579

## 何を

`nvim/config/init.lua` の「Settings for indent each files.」ブロック直後に `FileType` autocmd を追加し、**散文系 filetype（`markdown` / `text` / `plaintext` / `gitcommit`）に限って** Neovim ビルトインのスペルチェックを `vim.opt_local`（`setlocal` 相当）で有効化しました。

- `spell = true`: 誤ったつづりの英単語に波線が付き、`]s` / `[s` で移動、`z=` で候補、`zg` / `zw` で辞書登録。
- `spelllang = { "en", "cjk" }`: `cjk` で日本語など東アジア文字を検査対象から除外（README/Markdown は日本語混在のため必須）。
- `spelloptions = "camel"`: camelCase / PascalCase を単語分割し、識別子の誤検出を防止。

## なぜ

英文を書くのが主目的の filetype だけに絞って ON にすることで、コードバッファのノイズを避けつつ、README・ドキュメント・コミットメッセージの typo を書いている最中に拾えます。textlint（日本語文体校正）がカバーしない「英単語のつづり」層を、依存追加なし・ビルトインのみで補完します。

## 検証結果

- 表示・入力補助のみの非破壊的変更。ファイル内容や conform / nvim-lint / LSP / textlint の挙動には影響しません。
- stylua はこの環境に未インストールのため未実行（既存のタブインデント規約に合わせて追記）。CI（Lint Stylua）で確認されます。
- 元に戻す場合は追記ブロックの削除のみで既定へ戻せます（依存プラグインなし）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_