### PR TITLE
feat(nvim): restore last cursor position on file reopen

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -138,6 +138,30 @@ if vim.fn.has("persistent_undo") == 1 then
 end
 
 -- ----------------------------------------
+-- Restore the last cursor position when reopening a file.
+-- BufReadPost は shada から `"` マーク (バッファを最後に離れた位置) が復元された後に
+-- 発火するので、この契機で参照する。永続 undo と合わせて中断→再開の摩擦を減らす。
+-- ----------------------------------------
+local last_pos_group = vim.api.nvim_create_augroup("restore_last_cursor_pos", { clear = true })
+vim.api.nvim_create_autocmd("BufReadPost", {
+	group = last_pos_group,
+	callback = function(args)
+		local buf = args.buf
+		-- コミットメッセージ等は常に先頭で開くのが自然なので除外する。
+		local ft = vim.bo[buf].filetype
+		if ft == "gitcommit" or ft == "gitrebase" then
+			return
+		end
+		local mark = vim.api.nvim_buf_get_mark(buf, '"')
+		local line = mark[1]
+		if line > 0 and line <= vim.api.nvim_buf_line_count(buf) then
+			-- 範囲外行や折り畳み等での失敗を握りつぶして安全に復帰する。
+			pcall(vim.api.nvim_win_set_cursor, 0, mark)
+		end
+	end,
+})
+
+-- ----------------------------------------
 -- Settings for indent each files.
 -- ----------------------------------------
 vim.api.nvim_create_augroup("html_css_js_and_others_indent", { clear = true })


### PR DESCRIPTION
Closes #553

## 何を

`nvim/config/init.lua` の永続 undo ブロック直後に `BufReadPost` autocmd を追加し、ファイルを開き直したときに前回そのファイルを閉じた位置（`"` マーク）へカーソルを自動復帰させます。プラグイン不要・ビルトインのみ。

## なぜ

このリポジトリは永続 undo で「閉じても undo 履歴が残る」状態を持ちますが、カーソル位置は毎回ファイル先頭に戻ってしまいます。長い Go / Terraform / README を編集して別ファイルへ移り戻ると 1 行目からで、直前の箇所へ手動で戻る手間が発生します。`"` マークへジャンプするだけで解消でき、永続 undo と合わせて「閉じて開き直しても位置も履歴もそのまま」になります。

## 実装上の配慮

- `gitcommit` / `gitrebase` は常に先頭で開くのが自然なため除外。
- 行が存在するか（`line <= line_count`）を確認し、桁位置超過等の失敗は `pcall` で握りつぶすため `E16: Invalid range` は出ません。
- ターミナル / `nofile` フローティングは `BufReadPost` を発火しないため対象外。lint / textlint の `BufReadPost` トリガとは独立に動作します。

## 検証結果

- stylua はこの環境に未インストールのため未実行（既存のタブインデント規約に合わせて追記）。CI（Lint Stylua）で確認されます。
- 元に戻す場合は追記ブロックの削除のみで既定へ戻せます（依存プラグインなし）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_