### PR TITLE
feat(nvim): add diagnostic severity_sort and sign icons

### DIFF
--- a/nvim/config/lua/lsp/init.lua
+++ b/nvim/config/lua/lsp/init.lua
@@ -146,6 +146,15 @@ vim.api.nvim_create_autocmd("LspAttach", {
 vim.diagnostic.config({
 	virtual_text = false,
 	virtual_lines = { current_line = true },
+	severity_sort = true, -- 1 行に複数診断があるとき、最も重い診断をサイン列/float/loclist の先頭に出す
+	signs = {
+		text = {
+			[vim.diagnostic.severity.ERROR] = "",
+			[vim.diagnostic.severity.WARN] = "",
+			[vim.diagnostic.severity.INFO] = "",
+			[vim.diagnostic.severity.HINT] = "",
+		},
+	},
 	jump = {
 		on_jump = function(_, bufnr)
 			vim.diagnostic.open_float({ bufnr = bufnr })


### PR DESCRIPTION
Closes #576

## 何を

`nvim/config/lua/lsp/init.lua` の既存 `vim.diagnostic.config` に 2 キーを追加しました。

- `severity_sort = true`: 1 行に複数診断（ERROR と WARN が同居等）があるとき、最も重い診断をサイン列 / `open_float` / loclist の先頭に出します。
- `signs.text`: 重要度別のサインアイコンを指定（Nerd Font: ERROR=times-circle / WARN=warning / INFO=info-circle / HINT=lightbulb）。Neovim 0.10+ で正式な `vim.diagnostic.config({ signs = { text = {...} } })` 方式に揃えます。

既存の `virtual_text = false` / `virtual_lines` / `jump` はそのまま維持しています。

## なぜ

virtual_lines が「カーソル行の詳細」を担うのに対し、本件は「サイン列に並ぶ全行のアイコンの正確さ（最重要度が前面に来る）と可読性」を担う補完的な改善です。`signcolumn = "yes"` は既に常時表示のためガタつきは発生しません。

## 検証結果

- 表示のみの非破壊的変更。診断の内容・件数・`]d`/`[d` の挙動は変わりません。`nvim_dap.lua` の `sign_define`（DAP ブレークポイント）とは名前空間・対象が別で干渉しません。
- アイコンは Nerd Font 前提です。フォントの無い環境では `signs.text` を `"E"` / `"W"` / `"I"` / `"H"` 等の ASCII に差し替え可能です。
- stylua はこの環境に未インストールのため未実行。CI（Lint Stylua）で確認されます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_