### PR TITLE
refactor(mise): source docker:build Go/Node versions from mise pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -409,13 +409,14 @@ run = '"{{config_root}}/ai-agents/scripts/verify-changed.sh"'
 
 [tasks."docker:build"]
 description = "Build the nvim image with versions injected from mise.toml"
+# GO_VERSION / NODE_VERSION are NOT passed as --build-arg: the Dockerfile ARG
+# defaults are generated from mise.toml [tools] by `pins:sync` and verified by
+# `pins:check`, so the build always uses the mise-pinned versions without
+# depending on the host's active go/node. The remaining [env]-sourced args are
+# likewise synced ARG defaults; passing them keeps the injection explicit.
 run = '''
-GO_VERSION="$(go env GOVERSION | sed 's/^go//')"
-NODE_VERSION="$(node --version | sed 's/^v//')"
 docker build \
   --file environment/docker/nvim.dockerfile \
-  --build-arg GO_VERSION="$GO_VERSION" \
-  --build-arg NODE_VERSION="$NODE_VERSION" \
   --build-arg NEOVIM_VERSION="$NEOVIM_VERSION" \
   --build-arg NPM_VERSION="$NPM_VERSION" \
   --build-arg RUST_TOOLCHAIN="$RUST_TOOLCHAIN" \


### PR DESCRIPTION
Closes #572

## 何を

`mise.toml` の `[tasks."docker:build"]` から、ホストの `go env GOVERSION` / `node --version` に依存していた `GO_VERSION` / `NODE_VERSION` の導出行と、それらを渡す 2 つの `--build-arg` を削除しました（Issue の推奨・案 A）。

## なぜ

6 個の build-arg のうち 4 個（NEOVIM/NPM/RUST/TERRAFORM）は既に mise の `[env]` 由来なのに、Go/Node の 2 個だけが「その場でアクティブなホストの go/node」に依存する非対称がありました。これは実害があります:

- **ドリフト**: mise が未アクティブ・別の go/node が PATH 前方にある等の状況で `go env GOVERSION` / `node --version` がピンと食い違い、`mise.toml` と異なるバージョンでイメージがビルドされる。
- **冗長**: Dockerfile の `ARG GO_VERSION=` / `ARG NODE_VERSION=` 既定値は既に `pins:sync` で `mise.toml` から生成され `pins:check`（CI）で同期が保証されているのに、build 時にホスト値で上書きしていた。

`pins:check` が「Dockerfile の ARG 既定値 == `mise.toml [tools]`」を保証しているため、build-arg を渡さなくても必ず mise ピンのバージョンでビルドされます。ホストの go/node 状態に一切依存しなくなり、`go env` / `node --version` のサブシェルも消えます。

## 検証結果

- `python3 -c "import tomllib; tomllib.load(...)"` で TOML パース成功を確認。
- Dockerfile 本体・ARG 定義・`sync-pins.sh` は無変更のため `pins:check` は引き続きグリーン。`docker:build` は手動/ローカルのビルドエントリで、`pins:check` 等の CI はこのタスクを経由しないため CI への影響はありません。
- 変更は `mise.toml` の 1 タスクのみ。`[tools]` / `[env]` のピン行は一切変更していません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_