### PR TITLE
ci: add lint_actions workflow running actionlint on GitHub Actions

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -62,11 +62,13 @@ jobs:
             fi
           done
 
-          echo "node=$NODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "go=$GO_VERSION" >> "$GITHUB_OUTPUT"
-          echo "neovim=$NEOVIM_VERSION" >> "$GITHUB_OUTPUT"
-          echo "npm=$NPM_VERSION" >> "$GITHUB_OUTPUT"
-          echo "terraform=$TERRAFORM_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "node=$NODE_VERSION"
+            echo "go=$GO_VERSION"
+            echo "neovim=$NEOVIM_VERSION"
+            echo "npm=$NPM_VERSION"
+            echo "terraform=$TERRAFORM_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update mise.toml pins
         env:

--- a/.github/workflows/go_module_ci.yml
+++ b/.github/workflows/go_module_ci.yml
@@ -65,6 +65,7 @@ jobs:
           EXCLUDE_PATTERN: ${{ inputs.test-exclude-pattern }}
         run: |
           if [ -n "$EXCLUDE_PATTERN" ]; then
+            # shellcheck disable=SC2046  # intentional word-splitting of the go list output
             go test $(go list ./... | grep -Ev "$EXCLUDE_PATTERN") -v -count=1 -coverprofile=coverage.out
           else
             go test ./... -v -count=1 -coverprofile=coverage.out

--- a/.github/workflows/lint_actions.yml
+++ b/.github/workflows/lint_actions.yml
@@ -1,0 +1,30 @@
+name: Lint Actions
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - mise.toml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  actions-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run actionlint
+        run: mise run lint:actions

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 # then run `mise install` at the repo root.
 
 [tools]
+actionlint = "1.7.12"
 go = "1.26.5"
 golangci-lint = "2.12.2"
 node = "24.18.0"
@@ -386,6 +387,10 @@ run = "stylua --check ."
 [tasks."lint:docker"]
 description = "Run hadolint on the nvim Dockerfile"
 run = "hadolint environment/docker/nvim.dockerfile"
+
+[tasks."lint:actions"]
+description = "Run actionlint (with shellcheck integration) on GitHub Actions workflows"
+run = "actionlint"
 
 [tasks."lint:format"]
 description = "Run tombi, prettier, and markdownlint via environment/tools/node"


### PR DESCRIPTION
Closes #577

## 何を

GitHub Actions ワークフローを対象にした actionlint（内蔵の shellcheck 連携込み）の CI ジョブを追加しました。

1. `.github/workflows/lint_actions.yml` を新規追加（`pull_request` で `.github/workflows/**` または `mise.toml` の変更時にトリガー、`permissions: contents: read`、SHA ピン・`concurrency`・`timeout-minutes` は既存 lint ワークフロー準拠）。
2. `mise.toml` の `[tools]` に `actionlint` をピン追加し、`[tasks."lint:actions"]`（`run = "actionlint"`）を新設。これでローカルの `verify-changed.sh` と CI が同一バージョンの actionlint を使います（従来ローカルは未ピン）。
3. actionlint の shellcheck 連携が検出する既存 2 件を同一 PR で解消:
   - `go_module_ci.yml`: 意図的な単語分割（SC2046 warning）に `# shellcheck disable=SC2046` を付与（挙動不変）。
   - `bump-versions.yml`: 複数リダイレクト（SC2129 style）を `{ ...; } >> "$GITHUB_OUTPUT"` にまとめて解消。

## なぜ

lint 系は shell / lua / dockerfile / format / go すべてに PR トリガーの CI があるのに、ワークフロー自身だけが「ローカル検査はあるが CI 強制がない」唯一のカテゴリでした。CI 化すると、フックを通らない経路（web 上の直接編集、`bump-versions.yml` の自動 bump PR 等）でのワークフロー劣化を PR 時点で止められます。

## 検証結果

- `python3 -c "import tomllib; ..."` で `mise.toml` の TOML パース成功、PyYAML で 3 つのワークフロー YAML のパース成功を確認。
- actionlint / shellcheck はこの環境に未インストールのため実行できず、実際の lint 結果は本 PR の Lint Actions ジョブ（新規追加のため本 PR 自身をトリガー）で確認されます。既存の 2 件は Issue の指摘どおり修正済み。
- 影響範囲は新規 lint ジョブのみ。既存ワークフローの挙動・トリガー・権限は変更していません。

> 補足: `mise` がこの環境に無く `mise use --pin` を実行できなかったため、`actionlint` のピン行は手動で追記しています（バージョンは Issue 記載の v1.7.12）。レビュー時に `mise use --pin actionlint@<version>` での再確定をご検討ください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_