### PR TITLE
feat(hooks): lint Dockerfiles and GitHub Actions in lint-changed Stop hook

### DIFF
--- a/ai-agents/settings/claude/hooks/lint-changed.sh
+++ b/ai-agents/settings/claude/hooks/lint-changed.sh
@@ -48,6 +48,17 @@ while IFS= read -r f; do
 			append_issue "- [shellcheck] $f"
 		fi
 		;;
+	.github/workflows/*.yml | .github/workflows/*.yaml)
+		# actionlint bundles its inline `run:` scripts to shellcheck when present.
+		if command -v actionlint >/dev/null 2>&1 && ! actionlint "$f" >/dev/null 2>&1; then
+			append_issue "- [actionlint] $f"
+		fi
+		;;
+	Dockerfile | Dockerfile.* | *.dockerfile | */Dockerfile | */Dockerfile.*)
+		if command -v hadolint >/dev/null 2>&1 && ! hadolint "$f" >/dev/null 2>&1; then
+			append_issue "- [hadolint] $f"
+		fi
+		;;
 	esac
 done <<EOF
 $files

--- a/ai-agents/settings/claude/hooks/toolchain-doctor.sh
+++ b/ai-agents/settings/claude/hooks/toolchain-doctor.sh
@@ -8,7 +8,7 @@ export PATH="${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims:$PATH"
 set -u
 
 # tool -> hook(s) that silently no-op when the tool is missing.
-tools="goimports golangci-lint shfmt shellcheck prettier stylua markdownlint-cli2 tombi"
+tools="goimports golangci-lint shfmt shellcheck prettier stylua markdownlint-cli2 tombi hadolint actionlint"
 
 hook_for() {
 	case "$1" in
@@ -20,6 +20,8 @@ hook_for() {
 	stylua) echo "stylua.sh, lint-changed.sh (Lua)" ;;
 	markdownlint-cli2) echo "lint-changed.sh (Markdown)" ;;
 	tombi) echo "tombi.sh" ;;
+	hadolint) echo "lint-changed.sh (Dockerfile)" ;;
+	actionlint) echo "lint-changed.sh (GitHub Actions)" ;;
 	*) echo "formatter/lint hook" ;;
 	esac
 }

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 # then run `mise install` at the repo root.
 
 [tools]
+actionlint = "1.7.12"
 go = "1.26.5"
 golangci-lint = "2.12.2"
 node = "24.18.0"


### PR DESCRIPTION
Closes #549

## 何を

Stop フック `ai-agents/settings/claude/hooks/lint-changed.sh` の `case "$f"` に 2 分岐を追加し、CI 専用だった構成ファイルの lint をローカル即時フィードバックへ前倒しします。

- **GHA ワークフロー**（`.github/workflows/` 配下の `*.yml` / `*.yaml` のみに限定）→ `actionlint`
- **Dockerfile**（`Dockerfile` / `Dockerfile.*` / `*.dockerfile`）→ `hadolint`

いずれも既存分岐と同じ `command -v` ガード・非ブロッキング（report-only、exit 0）です。あわせて:

- `mise.toml`: `actionlint` をピン追加（`hadolint` は既にピン済み）し、ローカル / CI の版ズレを防止。
- `ai-agents/settings/claude/hooks/toolchain-doctor.sh`: `tools` 一覧と `hook_for()` に `hadolint` / `actionlint` を追加し、未インストール時に「lint-changed.sh が黙って no-op」する旨を SessionStart で可視化。

## なぜ

lint-changed.sh は go / lua / markdown / shell をローカルで即時報告しますが、GHA ワークフロー YAML と Dockerfile はこの即時ループから漏れており、CI に push して初めてエラーが分かる状態でした。この非対称を埋め、壊れたワークフローや Dockerfile を push 前に検知できるようにします。

## 実装上の配慮

- 対象 YAML を `.github/workflows/` 配下のみに限定し、docker-compose 等の一般 YAML に actionlint を掛けません。
- `lint-changed.sh` は claude 専用の Stop フックで、cursor / copilot には Stop 相当が無い（フォーマッタ系のみ）ため、3 エディタ横断の配線は不要です（既存 tracked ファイルの追記のみ・新規ファイルなし → Makefile / `copy-entries.sh` への影響なし）。
- `tflint` は現状リポジトリに `.tf` が無く対象が存在しないため、今回のスコープからは外しています。

## 検証結果

- `bash -n` で両シェルスクリプトの構文 OK、`python3 -c "import tomllib; ..."` で `mise.toml` の TOML パース成功を確認。
- shellcheck / shfmt / actionlint / hadolint はこの環境に未インストールのため未実行。CI（Lint Shell 等）で確認されます。

> 補足: `mise` がこの環境に無く `mise use --pin` を実行できなかったため、`actionlint` のピン行は手動で追記しています。レビュー時に `mise use --pin actionlint@<version>` での再確定をご検討ください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuskwQ9VSc7sKR6CwfosB9)_