### PR TITLE
feat(nvim): enable lualine globalstatus (laststatus=3)

### DIFF
--- a/nvim/config/lua/nvim_lualine.lua
+++ b/nvim/config/lua/nvim_lualine.lua
@@ -10,7 +10,7 @@ require("lualine").setup({
 		},
 		ignore_focus = {},
 		always_divide_middle = true,
-		globalstatus = false,
+		globalstatus = true, -- laststatus=3。分割時もステータスラインを画面最下部の1本に統一する
 		refresh = {
 			statusline = 1000,
 			tabline = 1000,


### PR DESCRIPTION
## 何を

`nvim/config/lua/nvim_lualine.lua` の `options.globalstatus` を `false` → `true` に変更（1 行）。lualine が `globalstatus = true` を検知して `vim.opt.laststatus = 3` を設定し、ウィンドウごとに 1 本ずつ出ていたステータスラインをエディタ全体で 1 本に統合する。

## なぜ

この Neovim 設定は分割を日常的に多用する（`init.lua` の `-`/`l` によるターミナル分割、`splitbelow`/`splitright`、fern ドロワー、telescope、gitsigns diff）。従来の per-window ステータスラインは分割時に複数本積み重なり縦行を食い、非アクティブ窓のステータスラインが視覚ノイズになっていた。グローバル化で常に最下部 1 本・アクティブ窓の情報のみになる。

## 検証

- レイアウトのみの変更で、ファイル内容・LSP・conform 整形・lint・gitsigns には影響しない。可逆（`false` に戻すだけ）。
- 既存の `sections` はそのまま流用。`inactive_sections` は将来 `false` に戻す場合に備えて温存。
- ローカルに stylua が無いため既存のタブインデント・スタイルに合わせて手編集。CI（`lint_stylua`）で最終確認される。

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_