### PR TITLE
feat(nvim): add shellcheck to nvim-lint for sh files

### DIFF
--- a/nvim/config/lua/nvim_lint.lua
+++ b/nvim/config/lua/nvim_lint.lua
@@ -13,6 +13,9 @@ lint.linters_by_ft = {
 	markdown = { "markdownlint-cli2" },
 	dockerfile = { "hadolint" },
 	terraform = { "tflint" },
+	-- bash/sh スクリプトの実バグ・危険パターン（未クオート変数 SC2086 等）を編集/保存時に検査。
+	-- shellcheck 未インストール時は nvim-lint が黙ってスキップする。
+	sh = { "shellcheck" },
 	-- GitHub Actions ワークフロー専用。複合 filetype の "ghaction" 成分を key にすることで
 	-- 通常の yaml には作用させない。actionlint 未インストール時は nvim-lint が黙ってスキップする。
 	ghaction = { "actionlint" },


### PR DESCRIPTION
## 何を

`nvim/config/lua/nvim_lint.lua` の `lint.linters_by_ft` に `sh = { "shellcheck" }` を 1 行追加。filetype `sh`（bash/sh）のバッファを既存の `BufReadPost`/`BufWritePost` autocmd で shellcheck 静的検査する。

## なぜ

このリポジトリは `scripts/`・`ai-agents/settings/*/hooks/`・`.claude/hooks/` 等に多数の `*.sh` を含むが、Neovim 上での静的検査が効いていなかった。shellcheck は未クオート変数（SC2086）・`cd` 失敗未チェック等の定番バグを指摘する事実上の標準リンタ。既存 hook の shfmt は整形専用でバグは見ないため、レイヤが異なり衝突しない。

## 検証

- 診断（波線）を出すだけの非破壊的変更。保存・LSP・conform 整形には影響しない。
- shellcheck 未インストール環境では nvim-lint が黙ってスキップ（hadolint/actionlint と同じ挙動）。ローカルに shellcheck が無いため実行検証は不可、既存の `ghaction`/`tflint` エントリと同一パターンで追記。
- stylua がローカルに無いため既存のタブインデントに合わせて手編集。CI（`lint_stylua`）で最終確認される。

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_