### PR TITLE
feat(nvim): format sh files on save with shfmt via conform

### DIFF
--- a/nvim/config/lua/conform_nvim.lua
+++ b/nvim/config/lua/conform_nvim.lua
@@ -12,6 +12,7 @@ require("conform").setup({
 		lua = { "stylua" },
 		markdown = { "markdownlint-cli2" },
 		python = { "ruff_fix", "ruff_format", "ruff_organize_imports" },
+		sh = { "shfmt" }, -- bash/sh を保存時に整形（mise 固定の shfmt / 既存フックと同一スタイル）
 		terraform = { "terraform_fmt" },
 		["terraform-vars"] = { "terraform_fmt" },
 		yaml = { "prettierd", "prettier", stop_after_first = true },


### PR DESCRIPTION
## 何を

`nvim/config/lua/conform_nvim.lua` の `formatters_by_ft` に `sh = { "shfmt" }` を 1 行追加。既存の `format_on_save`（保存時）と手動整形 `<space>f` にそのまま乗る。プラグイン追加なし（shfmt は conform 同梱フォーマッタ）。

## なぜ

リポジトリは多数の `*.sh` を含むが、`formatters_by_ft` に `sh` キーが無く保存時整形の空白地帯だった。整形基準は既に shfmt に統一済み（`mise.toml` で `shfmt` ピン、`ai-agents/settings/*/hooks/shfmt.sh` が `shfmt -w`、mise タスクに `shfmt -d`）。conform の `shfmt`（既定引数）は既存フックと同一スタイルなので、CLI とエディタで整形結果が一致する。lint 側の shellcheck（#580）とは対象レイヤが異なる。

## 検証

- 追加フラグを付けず既定スタイルに揃えることで既存フック/mise タスクと一致。
- shfmt 未インストール時は conform が黙ってスキップ。可逆（1 行削除で戻る）。
- stylua がローカルに無いため既存のタブインデントに合わせて手編集。CI（`lint_stylua`）で最終確認される。

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_