### PR TITLE
feat(nvim): set grepprg to ripgrep for quickfix-driven search/replace

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -26,6 +26,14 @@ vim.opt.incsearch = true -- Highlight when inputting chars
 vim.opt.inccommand = "split" -- :substitute の置換結果を入力中にライブプレビュー（下部スプリットに before/after 一覧）
 vim.opt.ignorecase = true -- 小文字のみの検索パターンは大文字小文字を無視する
 vim.opt.smartcase = true -- ただし大文字が1文字でも含まれる場合は大小を区別する（ignorecase と併用時のみ有効）
+-- :grep / :lgrep を ripgrep バックエンドにし、結果を quickfix に集約する。
+-- rg は .gitignore を尊重し高速。--vimgrep で file:line:col:text を出力する。
+-- :grep <pat> → :copen → :cdo s/old/new/gc | update でプロジェクト横断の一括置換の基点になる。
+if vim.fn.executable("rg") == 1 then
+	vim.opt.grepprg = "rg --vimgrep --smart-case --hidden --glob '!.git'"
+	vim.opt.grepformat = "%f:%l:%c:%m"
+	vim.keymap.set("n", "co", ":copen<CR>", { noremap = true, silent = true, desc = "Open quickfix list" })
+end
 vim.opt.wildmenu = true -- Show completion suggestions at command line mode
 vim.opt.conceallevel = 0 -- Show double quotations in json file and so on.
 vim.g.mapleader = " " -- Set a space key to a leader.


### PR DESCRIPTION
## 何を

`nvim/config/init.lua` の検索オプション付近に、`vim.fn.executable("rg")` ガード付きで `grepprg = "rg --vimgrep --smart-case --hidden --glob '!.git'"` と `grepformat = "%f:%l:%c:%m"` を設定。内蔵 `:grep`/`:lgrep` を ripgrep バックエンドにし、結果を quickfix に集約する。導線として `co`（`:copen`）マップも追加。

## なぜ

設定・スクリプト・スキルが多ディレクトリに分散するこの環境では、共通キーワード/環境変数/パスをリポジトリ全体で洗い出しまとめて置換する作業が頻発する。`:grep` + quickfix + `:cdo s/old/new/gc | update` の一括編集フローは telescope live_grep（揮発的な 1 件ジャンプ）では代替できない領域で、両者は目的が異なり衝突しない。

## 検証

- `rg` が無ければブロックごとスキップし既定の `:grep` にフォールバック（非破壊）。
- 検索経路を整えるだけで、実際の置換は利用者が `:cdo s///` を明示実行したときのみ。
- stylua がローカルに無いため既存のタブインデントに合わせて手編集。CI（`lint_stylua`）で最終確認される。

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_