### PR TITLE
feat(nvim): add nvim-treesitter-context sticky scope header

### DIFF
--- a/nvim/config/lua/plugins.lua
+++ b/nvim/config/lua/plugins.lua
@@ -47,6 +47,20 @@ return {
 			require("nvim_treesitter")
 		end,
 	},
+	{ -- Appearance: 外側スコープ（関数/クラス/if/for 等）を画面上部にスティッキー表示
+		"nvim-treesitter/nvim-treesitter-context",
+		dependencies = { "nvim-treesitter/nvim-treesitter" },
+		lazy = true,
+		event = { "BufRead", "BufNewFile" },
+		config = function()
+			require("treesitter-context").setup({
+				max_lines = 3, -- スティッキーヘッダは最大3行まで（深いネストでも画面を圧迫しない）
+				trim_scope = "outer", -- 3行を超えたら外側から捨てて内側の直近スコープを優先表示
+				min_window_height = 20, -- 画面が低いときは邪魔になるので出さない
+				mode = "cursor", -- カーソル行を基準にコンテキストを算出
+			})
+		end,
+	},
 	{ -- Configurations for Nvim LSP
 		"neovim/nvim-lspconfig",
 		lazy = false,


### PR DESCRIPTION
## 何を

`nvim/config/lua/plugins.lua` の treesitter エントリの直後に `nvim-treesitter/nvim-treesitter-context` を 1 エントリ追加。カーソルを包む外側スコープ（関数/クラス/if/for 等）が画面外へスクロールアウトしても、その宣言行を画面最上部にスティッキーヘッダとして常時表示する。

## なぜ

この環境は `mouse = ""`（マウス無効）でキーボード主体のスクロール運用。画面より縦に長い関数の内部に潜ると外側のシグネチャや分岐条件が見えなくなる。treesitter-context は「見えなくなった行だけ」上部に貼り付けて補う。パーサは既に `nvim_treesitter.lua` で導入済み（go/python/lua 等）なので追加の parser インストールは不要。既存の折り畳み（foldexpr, #462）とはレイヤが異なり補完関係。

## 検証

- 既存の Appearance 系（indent-blankline/lualine/gitsigns）と同じ `event = { "BufRead", "BufNewFile" }` の遅延ロードに揃え、起動コストを増やさない。
- 非破壊的・可逆。ウィンドウ上部に仮想行を描画するだけで、バッファ内容・LSP・conform・lint・gitsigns・diff・folding には影響しない。`max_lines=3`/`min_window_height=20` で圧迫を抑制。
- stylua がローカルに無いため既存のタブインデントに合わせて手編集。CI（`lint_stylua`）で最終確認される。

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_