### PR TITLE
build(docker): pin rust-builder stylua to the mise version

### DIFF
--- a/environment/docker/nvim.dockerfile
+++ b/environment/docker/nvim.dockerfile
@@ -133,6 +133,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
 FROM base AS rust-builder
 
 ARG RUST_TOOLCHAIN=stable
+# STYLUA_VERSION は mise.toml [tools] の stylua を源泉に sync-pins.sh が生成する。
+ARG STYLUA_VERSION=2.5.2
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -143,7 +145,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cargo/git,sharing=locked \
-    cargo install stylua tree-sitter-cli
+    cargo install stylua --version "$STYLUA_VERSION" --locked \
+    && cargo install tree-sitter-cli
 
 ####################
 # Stage 5: Build Python venv with uv

--- a/environment/tools/sync-pins.sh
+++ b/environment/tools/sync-pins.sh
@@ -48,6 +48,7 @@ node_version=$(pin 'node')
 neovim_version=$(pin 'NEOVIM_VERSION')
 npm_version=$(pin 'NPM_VERSION')
 rust_toolchain=$(pin 'RUST_TOOLCHAIN')
+stylua_version=$(pin 'stylua')
 terraform_version=$(pin 'TERRAFORM_VERSION')
 hadolint_version=$(pin 'hadolint')
 
@@ -57,6 +58,7 @@ sed -i.bak -E \
 	-e "s|^ARG NEOVIM_VERSION(=.*)?$|ARG NEOVIM_VERSION=${neovim_version}|" \
 	-e "s|^ARG NPM_VERSION(=.*)?$|ARG NPM_VERSION=${npm_version}|" \
 	-e "s|^ARG RUST_TOOLCHAIN(=.*)?$|ARG RUST_TOOLCHAIN=${rust_toolchain}|" \
+	-e "s|^ARG STYLUA_VERSION(=.*)?$|ARG STYLUA_VERSION=${stylua_version}|" \
 	-e "s|^ARG TERRAFORM_VERSION(=.*)?$|ARG TERRAFORM_VERSION=${terraform_version}|" \
 	-e "s|^ARG HADOLINT_VERSION(=.*)?$|ARG HADOLINT_VERSION=${hadolint_version}|" \
 	"$DOCKERFILE"


### PR DESCRIPTION
## 何を

`environment/docker/nvim.dockerfile` の `rust-builder` ステージで、stylua を **バージョン無指定 `cargo install`** から **`mise.toml` ピン連動**に変更する。

- `ARG STYLUA_VERSION`（既定 `2.5.2`、`mise.toml [tools]` の stylua を源泉に `sync-pins.sh` が生成）を追加。
- `cargo install stylua --version "$STYLUA_VERSION" --locked` で固定インストール。
- `environment/tools/sync-pins.sh` に stylua の抽出と `ARG STYLUA_VERSION` の sed 生成を追加（既存の GO/NODE/… と同じ経路）。

## なぜ

`cargo install stylua`（無指定）はビルド日の crates.io latest を取るため、コンテナ内 stylua と CI/ホストの stylua（`mise.toml` 固定の 2.5.2、`lint_stylua` は `mise run lint:stylua`）が不一致になり得る。stylua はマイナー更新でも既定整形が変わることがあり、コンテナで整形した Lua が CI で落ちる formatter drift を招く。このリポジトリの「mise を単一ソースに `sync-pins.sh` で ARG 生成、`pins:check` で検証」方針から stylua だけ漏れていたので、同じ経路に載せる。

## 検証

- ローカルで `sync-pins.sh` を実行し `git diff --exit-code -- go-tools.txt nvim.dockerfile` がクリーンであることを確認（＝ `pins:check` 相当が通る。ARG 既定 2.5.2 は生成結果と一致）。
- バージョンは既存の mise ピン 2.5.2 のまま（bump ではなく配線の追加）。ARG 行はインラインコメント無しの単一行に保ち、`sync-pins.sh` の sed パターンが往復しても drift しないようにした。

## スコープ外（follow-up）

- `tree-sitter-cli` も同ステージで無指定インストールだが、mise ピンが無く現行版数を安全に確定できないため本 PR では据え置き、別途 mise への追加（`mise use --pin` / bump-versions）経由で対応するのが安全。本 PR は Issue の主軸である stylua のピン連動に絞った。

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014x9qDaeDiKL7JHvaaVjtor)_