### PR TITLE
chore: routine の model を claude-opus-5 に更新

### DIFF
--- a/routines/daily-neovim-trend-scan.json
+++ b/routines/daily-neovim-trend-scan.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 23 * * *",
   "schedule_note": "毎日 23:00 UTC = 毎日 8:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]

--- a/routines/monthly-routine-improve.json
+++ b/routines/monthly-routine-improve.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 1 * *",
   "schedule_note": "毎月1日 22:00 UTC = 毎月2日 7:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]

--- a/routines/weekly-adopted-issue-pr-bot.json
+++ b/routines/weekly-adopted-issue-pr-bot.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 23 * * 6",
   "schedule_note": "土 23:00 UTC = 毎週日曜 8:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]

--- a/routines/weekly-ci-workflows-scan.json
+++ b/routines/weekly-ci-workflows-scan.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 * * 4",
   "schedule_note": "木 22:00 UTC = 毎週金曜 7:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]

--- a/routines/weekly-devx-skills-hooks-scan.json
+++ b/routines/weekly-devx-skills-hooks-scan.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 * * 3",
   "schedule_note": "水 22:00 UTC = 毎週木曜 7:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]

--- a/routines/weekly-environment-scan.json
+++ b/routines/weekly-environment-scan.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 * * 2",
   "schedule_note": "火 22:00 UTC = 毎週水曜 7:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]

--- a/routines/weekly-pr-care-bot.json
+++ b/routines/weekly-pr-care-bot.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 * * 0",
   "schedule_note": "日 22:00 UTC = 毎週月曜 7:00 JST（日曜朝の PR Bot の翌朝）",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]

--- a/routines/weekly-scripts-tooling-scan.json
+++ b/routines/weekly-scripts-tooling-scan.json
@@ -5,7 +5,7 @@
   "cron_expression": "0 22 * * 1",
   "schedule_note": "月 22:00 UTC = 毎週火曜 7:00 JST",
   "job_config": {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "repository": "https://github.com/hodanov/my-pde",
     "environment_id": "env_01H6ttcff6EJXggu8Xqmx5gN",
     "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebSearch", "WebFetch"]


### PR DESCRIPTION
## 実装経緯の説明

routines/ 配下の全 cloud routine（PR care bot、各種 weekly scan、monthly routine improve）が claude-opus-4-8 を使っていた。後継の claude-opus-5 が同価格帯 ($5/$25 per MTok) でドロップイン可能な上位互換であり、長期ホライズンのエージェント的タスク（PR確認・コードスキャン系）で品質向上が見込めるため切り替えた。

## 補足

### 主な変更内容

- `routines/*.json`（8ファイル）の `job_config.model` を `claude-opus-4-8` → `claude-opus-5` に変更
- クラウド側の routine（RemoteTrigger 経由）も同内容で更新済み。cron・allowed_tools・prompt は変更なし

### 技術的な詳細

- claude-opus-5 は claude-opus-4-8 と同一の料金体系・機能セットで、破壊的変更はほぼ無い
- 唯一の挙動差: claude-opus-5 はデフォルトで thinking が有効になる（4.8 は明示指定しないと無効）。この routine 群は thinking/effort を明示設定していないため、切り替え後はトークン消費・実行時間がやや増える可能性がある

### 確認事項

- 各 routine の初回実行時に、実行時間・トークン消費が想定範囲内か確認する
- 出力内容（PR コメントやスキャン結果）の質が劣化していないか確認する