### PR TITLE
feat(agent-stats): break down Skill tool calls by invoked skill name

### DIFF
--- a/scripts/agent-stats/README.md
+++ b/scripts/agent-stats/README.md
@@ -13,6 +13,7 @@ Claude Code の `~/.claude/projects/**/*.jsonl` を 1 行ずつ寛容にパー�
 - アシスタントターン数
 - tool 別呼び出し回数（Edit / Write / Bash / 各 MCP / skill など）
 - Edit / Write / MultiEdit / NotebookEdit の `file_path` から頻出編集ファイル top-N
+- `Skill` tool_use の `input.skill` から、どの skill が何回呼ばれたか（skill 内訳）
 - 先頭・末尾 timestamp から算出したセッション時間、`cwd` / `gitBranch`
 
 Claude Code は1回のアシスタント応答（thinking → text → tool_use）を、同じ `message.id` を
@@ -23,6 +24,10 @@ dedupe できないため、そのまま1行1カウントとして扱う）。
 集計テーブルの `Duration` は、各セッションの「先頭 timestamp 〜 末尾 timestamp」の差分を全セッ
 ション分単純合算した値であり、実作業時間ではない。resume で日をまたいだセッションはアイドル時
 間も含むため、値が大きく見えることがある。
+
+skill 内訳（`Skills`）は `Tool calls` の `Skill` 行とは別集計。`Tool calls` の `Skill` は
+`input.skill` の有無によらず全 Skill 呼び出しをカウントするのに対し、`Skills` は
+`input.skill` を持つ呼び出しだけをその skill 名で集計する。
 
 ## 使い方
 

--- a/scripts/agent-stats/internal/parser/parser.go
+++ b/scripts/agent-stats/internal/parser/parser.go
@@ -34,6 +34,7 @@ type Session struct {
 	AssistantTurns int            `json:"assistant_turns"`
 	ToolCounts     map[string]int `json:"tool_counts"`
 	FileCounts     map[string]int `json:"file_counts"`
+	SkillCounts    map[string]int `json:"skill_counts"`
 	Start          time.Time      `json:"start"`
 	End            time.Time      `json:"end"`
 
@@ -113,6 +114,7 @@ func ParseReader(name string, r io.Reader) Session {
 		File:           name,
 		ToolCounts:     map[string]int{},
 		FileCounts:     map[string]int{},
+		SkillCounts:    map[string]int{},
 		seenMessageIDs: map[string]struct{}{},
 	}
 	sc := bufio.NewScanner(r)
@@ -184,6 +186,11 @@ func applyLine(s *Session, raw *rawLine) {
 				s.FileCounts[fp]++
 			}
 		}
+		if c.Name == "Skill" {
+			if skill := skillNameOf(c.Input); skill != "" {
+				s.SkillCounts[skill]++
+			}
+		}
 	}
 }
 
@@ -212,6 +219,19 @@ func filePathOf(input json.RawMessage) string {
 		return ""
 	}
 	return fields.FilePath
+}
+
+func skillNameOf(input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var fields struct {
+		Skill string `json:"skill"`
+	}
+	if err := json.Unmarshal(input, &fields); err != nil {
+		return ""
+	}
+	return fields.Skill
 }
 
 func parseTime(s string) time.Time {

--- a/scripts/agent-stats/internal/parser/parser_test.go
+++ b/scripts/agent-stats/internal/parser/parser_test.go
@@ -93,6 +93,41 @@ func TestParseReaderDedupesSplitTurns(t *testing.T) {
 	}
 }
 
+// skillFixture mirrors how the Skill tool records which skill was invoked:
+// tool_use name "Skill" with an input.skill field. Not every Skill call is
+// guaranteed to carry that field (schema drift), so one line omits it.
+const skillFixture = `
+{"type":"assistant","timestamp":"2026-08-06T10:00:00Z","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"tool_use","name":"Skill","input":{"skill":"dev-workflow"}}]}}
+{"type":"assistant","timestamp":"2026-08-06T10:00:01Z","message":{"id":"msg_2","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"tool_use","name":"Skill","input":{"skill":"dev-workflow","args":"do the thing"}}]}}
+{"type":"assistant","timestamp":"2026-08-06T10:00:02Z","message":{"id":"msg_3","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"tool_use","name":"Skill","input":{"skill":"review"}}]}}
+{"type":"assistant","timestamp":"2026-08-06T10:00:03Z","message":{"id":"msg_4","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"tool_use","name":"Skill","input":{}}]}}
+{"type":"assistant","timestamp":"2026-08-06T10:00:04Z","message":{"id":"msg_5","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}
+`
+
+func TestParseReaderSkillCounts(t *testing.T) {
+	t.Parallel()
+	s := ParseReader("skills.jsonl", strings.NewReader(skillFixture))
+
+	// Every Skill invocation still counts toward the generic tool tally,
+	// including the one with no input.skill field.
+	if s.ToolCounts["Skill"] != 4 {
+		t.Errorf("ToolCounts[Skill] = %d, want 4", s.ToolCounts["Skill"])
+	}
+	if s.SkillCounts["dev-workflow"] != 2 {
+		t.Errorf("SkillCounts[dev-workflow] = %d, want 2", s.SkillCounts["dev-workflow"])
+	}
+	if s.SkillCounts["review"] != 1 {
+		t.Errorf("SkillCounts[review] = %d, want 1", s.SkillCounts["review"])
+	}
+	if len(s.SkillCounts) != 2 {
+		t.Errorf("SkillCounts = %v, want only dev-workflow and review (no entry for the id-less call)", s.SkillCounts)
+	}
+	// A non-Skill tool must never leak into SkillCounts.
+	if _, ok := s.SkillCounts["ls"]; ok {
+		t.Errorf("SkillCounts must not contain non-Skill tool data, got %v", s.SkillCounts)
+	}
+}
+
 func TestDurationGuards(t *testing.T) {
 	t.Parallel()
 	end := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)

--- a/scripts/agent-stats/internal/report/report.go
+++ b/scripts/agent-stats/internal/report/report.go
@@ -28,6 +28,7 @@ type Summary struct {
 	Models         []Count          `json:"models"`
 	Tools          []Count          `json:"tools"`
 	Files          []Count          `json:"files"`
+	Skills         []Count          `json:"skills"`
 	List           []parser.Session `json:"list"`
 }
 
@@ -37,6 +38,7 @@ func Summarize(sessions []parser.Session) Summary {
 	models := map[string]int{}
 	tools := map[string]int{}
 	files := map[string]int{}
+	skills := map[string]int{}
 	sum := Summary{Sessions: len(sessions), List: sessions}
 	for i := range sessions {
 		s := &sessions[i]
@@ -55,10 +57,14 @@ func Summarize(sessions []parser.Session) Summary {
 		for path, n := range s.FileCounts {
 			files[path] += n
 		}
+		for name, n := range s.SkillCounts {
+			skills[name] += n
+		}
 	}
 	sum.Models = ranked(models, 0)
 	sum.Tools = ranked(tools, 0)
 	sum.Files = ranked(files, 0)
+	sum.Skills = ranked(skills, 0)
 	return sum
 }
 
@@ -103,6 +109,7 @@ func RenderTable(s *Summary) string {
 
 	writeCounts(&b, "Models", s.Models, 0)
 	writeCounts(&b, "Tool calls", s.Tools, 0)
+	writeCounts(&b, "Skills", s.Skills, 0)
 	writeCounts(&b, "Top files", s.Files, topFiles)
 
 	b.WriteString("\nNote: only Claude Code transcripts are parsed; other AI CLIs are not yet supported.\n")

--- a/scripts/agent-stats/internal/report/report_test.go
+++ b/scripts/agent-stats/internal/report/report_test.go
@@ -16,8 +16,9 @@ func sessions() []parser.Session {
 			Model:          "claude-opus-4-8",
 			Tokens:         parser.Tokens{Input: 100, Output: 40, CacheRead: 10},
 			AssistantTurns: 2,
-			ToolCounts:     map[string]int{"Edit": 3, "Bash": 1},
+			ToolCounts:     map[string]int{"Edit": 3, "Bash": 1, "Skill": 2},
 			FileCounts:     map[string]int{"a.go": 2, "b.go": 1},
+			SkillCounts:    map[string]int{"dev-workflow": 2},
 			Start:          time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC),
 			End:            time.Date(2026, 7, 30, 10, 5, 0, 0, time.UTC),
 		},
@@ -26,8 +27,9 @@ func sessions() []parser.Session {
 			Model:          "claude-sonnet-5",
 			Tokens:         parser.Tokens{Input: 50, Output: 20},
 			AssistantTurns: 1,
-			ToolCounts:     map[string]int{"Edit": 1, "Read": 4},
+			ToolCounts:     map[string]int{"Edit": 1, "Read": 4, "Skill": 1},
 			FileCounts:     map[string]int{"a.go": 1},
+			SkillCounts:    map[string]int{"review": 1},
 			Start:          time.Date(2026, 7, 30, 11, 0, 0, 0, time.UTC),
 			End:            time.Date(2026, 7, 30, 11, 10, 0, 0, time.UTC),
 		},
@@ -56,6 +58,9 @@ func TestSummarize(t *testing.T) {
 	}
 	if s.Files[0].Name != "a.go" || s.Files[0].Count != 3 {
 		t.Errorf("Files[0] = %+v, want a.go:3", s.Files[0])
+	}
+	if len(s.Skills) != 2 || s.Skills[0].Name != "dev-workflow" || s.Skills[0].Count != 2 {
+		t.Errorf("Skills = %+v, want [dev-workflow:2 review:1]", s.Skills)
 	}
 }
 
@@ -97,7 +102,7 @@ func TestRenderTable(t *testing.T) {
 	t.Parallel()
 	summary := Summarize(sessions())
 	out := RenderTable(&summary)
-	for _, want := range []string{"Sessions:", "Tokens", "Edit", "a.go", "Claude Code"} {
+	for _, want := range []string{"Sessions:", "Tokens", "Edit", "a.go", "Skills", "dev-workflow", "Claude Code"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("table missing %q\n%s", want, out)
 		}


### PR DESCRIPTION
## 何を

`internal/parser` に `SkillCounts` を追加し、`Skill` tool_use の `input.skill` から「どのskillが何回呼ばれたか」を集計する。`internal/report` の `Summary`/テーブル出力/JSON にも `Skills` セクションとして反映する。

## なぜ

`ToolCounts` は `Skill` を1つのツール名としてしか数えておらず、どのskillが実際に使われたかは生transcriptを掘らないと分からなかった。PR #613 本文にある「本ツールは skill-observe に実データを供給し得る」を実現する第一歩として、skill単位の内訳を出せるようにする。

## 設計

- `Session.SkillCounts map[string]int`: `Skill` tool_use の `input.skill` ごとに加算。`input.skill` を持たない呼び出しは（従来通り `ToolCounts["Skill"]` ではカウントされるが）`SkillCounts` には計上しない。
- `Summary.Skills []Count`: 既存の `Models`/`Tools`/`Files` と同じ `ranked` 集計パターンを再利用。
- テーブル出力に `Skills` セクションを追加（`Tool calls` と `Top files` の間）。

## 検証

- `gofmt -l .` / `go vet ./...` / `go test ./... -v`（新規テスト `TestParseReaderSkillCounts` 含め全パス）
- `golangci-lint run --allow-parallel-runners`: 0 issues
- goimports diff: clean
- `markdownlint-cli2` / `prettier --check`: README.md パス
- 実データ（`~/.claude/projects`、`--project my-pde --since 720h`）でビルドして実行し、事前に手動でtranscriptから数えた内訳（dev-workflow 9, review 2, ...)と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)