### PR TITLE
feat(mise): add aggregate `lint` task for CI parity

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -436,6 +436,16 @@ prettier --check .
 markdownlint-cli2 "**/*.md"
 '''
 
+[tasks.lint]
+description = "Run all repo-wide linters (CI parity)"
+depends = [
+  "lint:shell",
+  "lint:stylua",
+  "lint:docker",
+  "lint:actions",
+  "lint:format",
+]
+
 # ---- Changed-files verification (human entry point; the verify-runner
 # subagent runs ai-agents/scripts/verify-changed.sh directly) ----
 


### PR DESCRIPTION
Closes #620

## 何を

`mise.toml` の「Repo-wide lint (CI parity)」セクションに、既存の 5 つのリンタタスクを `depends` で束ねる集約タスク `lint` を追加した。

```toml
[tasks.lint]
description = "Run all repo-wide linters (CI parity)"
depends = ["lint:shell", "lint:stylua", "lint:docker", "lint:actions", "lint:format"]
```

## なぜ

`lint:shell` / `lint:stylua` / `lint:docker` / `lint:actions` / `lint:format` はそれぞれ対応する CI ワークフローで個別に実行されているが、これらを一括で走らせる集約タスクが無く、push 前に CI 相当のリンタを全部ローカルで確認するには 5 コマンドを手で叩く必要があった。Go 側の `go:lint` / `go:test` と同じ `depends` 慣習を repo-wide lint にも適用し、`mise run lint` で一発実行できるようにする。

Issue の方針どおり、Go 系（`go:lint`）は重いため意図的に含めていない。既存の `lint:*` タスク定義と CI ワークフローには一切手を入れていない。

## 検証

- `python3 -c "import tomllib; tomllib.load(open('mise.toml','rb'))"` で TOML がパースできることを確認し、`tasks.lint` が期待どおりの `depends` を持つことを確認した。
- この環境には `mise` が入っていないため `mise run lint` の実行確認はできていない（CI で確認されたい）。
- 変更はバージョンピン行（`[tools]` / `[env]`）に触れていない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_