### PR TITLE
feat(nvim): append `useopen` to switchbuf so quickfix jumps reuse open windows

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -43,6 +43,12 @@ vim.opt.foldlevelstart = 99 -- Open files fully expanded; folds (treesitter fold
 vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
 vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current window.
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
+-- quickfix (:cc / :cn / :cp や quickfix ウィンドウ上の <CR>) から飛ぶ際、対象ファイルを
+-- 既に表示しているウィンドウが同一タブ内にあればそこへジャンプする。
+-- 既定の "uselast" だけだと他ウィンドウを見ずに「直前に使ったウィンドウ」へ読み込むため、
+-- 突き合わせ中の分割が差し替わり、同じファイルが 2 枚並ぶことがある。
+-- 未表示時のフォールバックとして uselast を残したいので、代入せず append する。
+vim.opt.switchbuf:append("useopen")
 vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
 vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
 vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す


### PR DESCRIPTION
Closes #628

## 何を

`nvim/config/init.lua` の `splitbelow` / `splitright` の直後に 1 行追加した。

```lua
vim.opt.switchbuf:append("useopen")
```

## なぜ

Neovim の `'switchbuf'` 既定は `"uselast"` のみで、quickfix ジャンプ（`:cc` / `:cn` / `:cp`、quickfix ウィンドウ上の `<CR>`）の際に他ウィンドウを一切見ず「直前に使ったウィンドウ」へ対象ファイルを読み込み直す。分割で突き合わせ中の参照ファイルが差し替わり、同じファイルが 2 枚並んでレイアウトを組み直す羽目になる。

この設定は `:grep`（ripgrep）→ `co`（`:copen`）を探索の基点に据え、マウスを無効化して分割を常用しているため、`:cn` で巡回するたびにこの摩擦を踏む。`useopen` を足すと「対象バッファを表示しているウィンドウが同一タブ内にあればそこへジャンプ」に変わり、参照用の分割が無傷のまま残る。

- 代入ではなく `append` を使い、未表示バッファのフォールバックである `uselast` を残している。
- Issue の方針どおり `usetab` / `split` / `vsplit` / `newtab` は入れていない。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への 6 行（コメント 5 行 + 設定 1 行）追加のみ。

## 備考

同じ `splitright` 直後への追記を行う #616（`splitkeep = "screen"`）の PR とは、マージ順によっては行の競合が出る可能性がある。内容は独立しているので、後からマージする側で両方の行を残す形で解消できる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_