### PR TITLE
feat(nvim): set `splitkeep = "screen"` to keep views stable across split open/close

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -43,6 +43,10 @@ vim.opt.foldlevelstart = 99 -- Open files fully expanded; folds (treesitter fold
 vim.opt.updatetime = 300 -- Fire CursorHold sooner (default 4000ms) for LSP document highlight. Kept >250ms to avoid frequent swap writes.
 vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current window.
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
+-- 分割の開閉で周囲ウィンドウの表示テキストが上下にズレないよう、画面上の見た目位置を保つ。
+-- 既定は "cursor"（カーソルの相対位置を保つ＝ビューポートはスクロールしうる）。
+-- quickfix(:copen) / ターミナル分割 / gitsigns プレビュー等の開閉時に読んでいた行を見失うのを防ぐ。
+vim.opt.splitkeep = "screen"
 vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
 vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
 vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す


### PR DESCRIPTION
Closes #616

## 何を

`nvim/config/init.lua` の `splitbelow` / `splitright` の直後に 1 行追加した。

```lua
vim.opt.splitkeep = "screen"
```

## なぜ

`'splitkeep'` の既定 `"cursor"` は「カーソルの相対位置」を保とうとするため、ウィンドウの開閉で周囲ウィンドウの高さが変わるたびに中身が上下にスクロールし、読んでいた行を見失う。

この設定はマウスを無効化（`mouse = ""`）した分割主体の運用で、`co`（`:copen`）・ターミナル分割（`<leader>-` / `<leader>l`）・Fern ドロワー・gitsigns プレビュー・Undotree と、ウィンドウ開閉が日常的に何度も起きる。`"screen"` は「画面上で見えているテキスト」を保つので、開閉の前後で視点がズレなくなる。

`splitbelow` / `splitright`（#510）が「分割をどちら側に開くか」を決めるのに対し、本件は「開閉でスクロールを起こさない」という別レイヤ。`scrolloff = 8`（#550）とも目的が異なり、衝突しない。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への 4 行（コメント 3 行 + 設定 1 行）追加のみ。

## 備考

同じ `splitright` 直後への追記を行う #628（`switchbuf:append("useopen")`）の PR とは、マージ順によっては行の競合が出る可能性がある。内容は独立しているので、後からマージする側で両方の行を残す形で解消できる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_