### PR TITLE
feat(nvim): append `view` to jumpoptions to restore scroll position on jumps

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -45,6 +45,11 @@ vim.opt.splitbelow = true -- Open horizontal splits (:split) below the current w
 vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the current window.
 vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
 vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
+-- jumplist (<C-o>/<C-i>) / changelist (g;/g,) / alternate-file (<C-^>) / マークジャンプで
+-- 戻った際に、カーソル行だけでなく「カーソル行と topline の距離」= 元の画面スクロール位置まで復元する。
+-- gd / grr / telescope / quickfix から飛んで戻る往復で、毎回 zz を打ち直す手間を消す。
+-- 既定は "clean" (未ロードバッファを jumplist から除く) のため、上書きせず append する。
+vim.opt.jumpoptions:append("view")
 vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す
 
 -- ----------------------------------------


### PR DESCRIPTION
Closes #625

## 何を

`nvim/config/init.lua` の `scrolloff` / `sidescrolloff` の直後に 1 行追加した。

```lua
vim.opt.jumpoptions:append("view")
```

## なぜ

`view` を入れると、jumplist（`<C-o>` / `<C-i>`）・changelist（`g;` / `g,`）・alternate-file（`<C-^>`）・マークジャンプで戻ったときに、カーソル行だけでなく「カーソル行と topline の距離」＝元の画面スクロール位置まで復元される。

既定ではカーソル行のみ復元されるため、`gd` / `grr` / telescope / quickfix から飛んで戻る往復のたびに、戻り先の行が画面のどこに来るか分からず `zz` を打ち直すことになる。往復回数の多い探索・レビュー動線でこの手間が積み上がる。

- 代入ではなく `append` を使い、Neovim 既定の `clean`（アンロード済みバッファを jumplist から掃除する）を残している。
- Issue の方針どおり `stack` は入れていない。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への 5 行（コメント 4 行 + 設定 1 行）追加のみ。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_