### PR TITLE
feat(nvim): add `linematch` and `histogram` to diffopt

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -46,6 +46,10 @@ vim.opt.splitright = true -- Open vertical splits (:vsplit) to the right of the 
 vim.opt.scrolloff = 8 -- カーソルの上下に常に 8 行の文脈を確保し、画面端への張り付きを防ぐ
 vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁の文脈を確保する
 vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す
+-- diff の行内アライメントを精緻化する（gitsigns インラインプレビュー / :diffthis 双方に効く）。
+-- 既定値を壊さないよう append で足す（重複指定は無視される）。internal は既定で有効。
+vim.opt.diffopt:append("linematch:60") -- 変更ハンク内で似た行同士を対応付け直し、本当に変わった行だけを着色（Neovim 0.9+）
+vim.opt.diffopt:append("algorithm:histogram") -- 内蔵 diff のアルゴリズムを histogram にし、並べ替えを含む差分でも直感的なマッチにする
 
 -- ----------------------------------------
 -- 外部変更ファイルの自動リロード (autoread + :checktime トリガ)


### PR DESCRIPTION
Closes #563

## 何を

`nvim/config/init.lua` の表示オプション群の末尾（`confirm` の直後）に 2 行追加した。

```lua
vim.opt.diffopt:append("linematch:60")
vim.opt.diffopt:append("algorithm:histogram")
```

## なぜ

既定の diff は変更ハンクを行単位でそのまま突き合わせるため、ハンク内で行の移動と編集が混ざると、実質変わっていない行までまとめて「変更」として着色される。`linematch` はハンク内で似た行同士を対応付け直し、本当に変わった箇所だけを着色する。`algorithm:histogram` は内蔵 diff のアルゴリズムを切り替え、並べ替えを含む差分でも直感的なマッチを返す。

効果は gitsigns のインラインプレビューと `:diffthis` の両方に及ぶ。

- 既存値を壊さないよう代入ではなく `append` を使っている（重複指定は無視される）。
- `internal` は既定で有効なため別途指定していない。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への 4 行（コメント 2 行 + 設定 2 行）追加のみ。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_