### PR TITLE
feat(nvim): enable linebreak and breakindent for prose filetypes

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -192,6 +192,22 @@ vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
 })
 
 -- ----------------------------------------
+-- 散文系 filetype の折り返しを読みやすくする（ドキュメント編集の主用途向け）
+-- linebreak: 単語境界で折り返す / breakindent: 継続行を字下げに揃える
+-- breakindentopt=list:-1: Markdown 箇条書きの折り返しをぶら下げ字下げにする
+-- ----------------------------------------
+vim.api.nvim_create_augroup("prose_wrap", { clear = true })
+vim.api.nvim_create_autocmd("FileType", {
+	group = "prose_wrap",
+	pattern = { "markdown", "text", "plaintext", "gitcommit" },
+	callback = function()
+		vim.opt_local.linebreak = true -- 単語の途中で折り返さない
+		vim.opt_local.breakindent = true -- 折り返し継続行を元のインデントに揃える
+		vim.opt_local.breakindentopt = "list:-1" -- 箇条書き/番号リストの継続行をぶら下げ字下げにする
+	end,
+})
+
+-- ----------------------------------------
 -- Open init.vim and 'source' it.
 -- ----------------------------------------
 vim.api.nvim_set_keymap("n", "<Leader>.", ":vs ~/.config/nvim/init.lua<CR>", { noremap = true, silent = true })


### PR DESCRIPTION
Closes #619

## 何を

`nvim/config/init.lua` の filetype 別インデント設定の autocmd 群のすぐ後ろに、散文系 filetype だけを対象にした `FileType` autocmd を 1 本追加した。

```lua
vim.api.nvim_create_augroup("prose_wrap", { clear = true })
vim.api.nvim_create_autocmd("FileType", {
	group = "prose_wrap",
	pattern = { "markdown", "text", "plaintext", "gitcommit" },
	callback = function()
		vim.opt_local.linebreak = true
		vim.opt_local.breakindent = true
		vim.opt_local.breakindentopt = "list:-1"
	end,
})
```

## なぜ

`wrap` は既定 ON だが `linebreak` は OFF のため、長い散文行が単語の途中でぶつ切りに折り返される。さらに `breakindent` が無いと、箇条書きの折り返し継続行が列 0 から始まり、リストの階層が視覚的に崩れる。`breakindentopt=list:-1` は Markdown の箇条書き/番号リストをぶら下げ字下げにする。

`FileType` + `opt_local` で対象を散文系（textlint 対象の `markdown` / `text` / `plaintext` に、長文を書く `gitcommit` を追加）に限定しているため、コード編集・レビューの表示には一切影響しない。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への autocmd 1 本（15 行）追加のみ。既存の autocmd グループには手を入れていない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_