### PR TITLE
feat(nvim): open the quickfix window automatically after :grep / :make

### DIFF
--- a/nvim/config/init.lua
+++ b/nvim/config/init.lua
@@ -48,6 +48,27 @@ vim.opt.sidescrolloff = 8 -- nowrap 時、カーソルの左右に常に 8 桁�
 vim.opt.confirm = true -- 未保存バッファを破棄しうる :q / :e 等でエラーにせず、保存/破棄/キャンセルの確認ダイアログを出す
 
 -- ----------------------------------------
+-- :grep / :make 等で quickfix が populate されたら結果窓を自動で開く（ripgrep 動線の最終ピース）
+-- 先頭が l 以外のコマンド (:grep/:make/:vimgrep) → quickfix を cwindow で開く
+-- 先頭が l のコマンド (:lgrep/:lvimgrep 等)      → location list を lwindow で開く
+-- cwindow/lwindow は「有効なエントリがあれば開き、空なら閉じる」ので 0 件ヒット時に窓は出ない。
+-- nested を付け、cwindow が発火する FileType/BufWinEnter 等の autocmd を抑止しない。
+-- ----------------------------------------
+local qf_group = vim.api.nvim_create_augroup("auto_open_quickfix", { clear = true })
+vim.api.nvim_create_autocmd("QuickFixCmdPost", {
+	group = qf_group,
+	pattern = { "[^l]*" }, -- :grep / :make / :vimgrep 等（先頭が l 以外）
+	nested = true,
+	command = "botright cwindow",
+})
+vim.api.nvim_create_autocmd("QuickFixCmdPost", {
+	group = qf_group,
+	pattern = { "l*" }, -- :lgrep / :lvimgrep 等（location list 系）
+	nested = true,
+	command = "lwindow",
+})
+
+-- ----------------------------------------
 -- 外部変更ファイルの自動リロード (autoread + :checktime トリガ)
 -- ----------------------------------------
 vim.opt.autoread = true -- ディスク上で更新されたファイルをバッファへ読み直す


### PR DESCRIPTION
Closes #621

## 何を

`nvim/config/init.lua` に `QuickFixCmdPost` の autocmd を 2 本追加した。

```lua
local qf_group = vim.api.nvim_create_augroup("auto_open_quickfix", { clear = true })
vim.api.nvim_create_autocmd("QuickFixCmdPost", {
	group = qf_group,
	pattern = { "[^l]*" }, -- :grep / :make / :vimgrep 等
	nested = true,
	command = "botright cwindow",
})
vim.api.nvim_create_autocmd("QuickFixCmdPost", {
	group = qf_group,
	pattern = { "l*" }, -- :lgrep / :lvimgrep 等
	nested = true,
	command = "lwindow",
})
```

## なぜ

`grepprg` を ripgrep にして `:grep` → `:copen` → `:cdo` をレビュー動線の基点に据えているのに、`:grep` 実行後に結果窓を出す部分だけ手動（`co`）のままだった。`QuickFixCmdPost` で `cwindow` を呼べば、ヒットがあるときだけ自動で下部に結果が開く。

- `cwindow` / `lwindow` は「有効なエントリがあれば開き、空なら閉じる」ので、0 件ヒット時に窓は出ない（`copen` との違い）。
- `botright` を付け、既存の `splitbelow` や `co`（`:copen`）と同じく画面下部に一貫して開く。location list はフォーカス中のウィンドウに紐づくため素の `lwindow`。
- `nested = true` は、`cwindow` がウィンドウを開く際に発火する `FileType quickfix` 等の autocmd を抑止しないための定石。
- 発火契機は `QuickFixCmdPost` のみなので、通常編集や起動フローには影響しない。既存の `co` キーマップもそのまま残している。

## 実装上の判断（Issue との差分）

Issue では「`if vim.fn.executable("rg")` ブロックの直後（36 行目の次）」への挿入を提案していたが、そこに 20 行の autocmd 定義を挟むと `vim.opt.*` の一覧が途中で分断されて読みにくくなるため、**同じオプション群の末尾（`vim.opt.confirm` の直後、autoread セクションの手前）** に置いた。動作は同一で、`grepprg` の設定からも数行の距離に収まっている。

## 検証

- `stylua --check nvim/config/init.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- 差分は init.lua への 21 行追加のみ。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_