### PR TITLE
fix(ci): pass coverage comment values through `env` instead of expanding `${{ }}` in `run:`

### DIFF
--- a/.github/workflows/go_module_ci.yml
+++ b/.github/workflows/go_module_ci.yml
@@ -91,35 +91,43 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Pass every value through env instead of expanding ${{ }} inside run:.
+          # ${{ }} is substituted as text before bash parses the script, so a
+          # coverage report line (which starts with a PR-controlled source file
+          # path) could otherwise inject $(...) or break the BODY="..." quoting.
+          REPO: ${{ github.repository }}
+          MODULE: ${{ inputs.module }}
+          COVERAGE_TOTAL: ${{ steps.coverage.outputs.total }}
+          COVERAGE_REPORT: ${{ steps.coverage.outputs.report }}
         run: |
-          MARKER="<!-- coverage-${{ inputs.module }} -->"
+          MARKER="<!-- coverage-${MODULE} -->"
           BODY="${MARKER}
-          ## 📊 Go Test Coverage: ${{ inputs.module }}
+          ## 📊 Go Test Coverage: ${MODULE}
 
-          **Total coverage: ${{ steps.coverage.outputs.total }}**
+          **Total coverage: ${COVERAGE_TOTAL}**
 
           <details>
           <summary>Per-package / per-function breakdown</summary>
 
           \`\`\`
-          ${{ steps.coverage.outputs.report }}
+          ${COVERAGE_REPORT}
           \`\`\`
 
           </details>"
 
           EXISTING_COMMENT_ID=$(gh api \
-            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
           )
 
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api \
               --method PATCH \
-              "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
+              "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
               -f body="${BODY}"
           else
             gh api \
               --method POST \
-              "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              "repos/${REPO}/issues/${PR_NUMBER}/comments" \
               -f body="${BODY}"
           fi


### PR DESCRIPTION
Closes #627

## 何を

`.github/workflows/go_module_ci.yml` の「Post coverage comment on PR」step で、`run:` 本文に直接展開していた `${{ }}` を全て `env:` 経由の中間変数に置き換えた。

| 旧（`run:` 内に直接展開） | 新（`env:` → shell 変数） |
| --- | --- |
| `${{ inputs.module }}` | `MODULE` |
| `${{ steps.coverage.outputs.total }}` | `COVERAGE_TOTAL` |
| `${{ steps.coverage.outputs.report }}` | `COVERAGE_REPORT` |
| `${{ github.repository }}` | `REPO` |

`GH_TOKEN` / `PR_NUMBER` は既に env 経由だったので、残りを同じ流儀に揃えた形。

## なぜ

`${{ }}` は bash がスクリプトを解釈する**前**にテキスト置換される。`steps.coverage.outputs.report` は `go tool cover -func` の出力そのもので、各行の先頭に PR 作成者が自由に決められるソースファイルパスが入るため、非信頼入力が `BODY="..."` の中に生で埋め込まれていた。

- `a$(id).go` のようなファイル名があると `$(...)` が runner 上で実行される。`test` ジョブは `pull-requests: write` 相当のトークンを持つため、同一リポジトリ発の PR では実害が大きい。
- 悪意が無くても、ファイル名に `"` が 1 つ含まれるだけで `BODY="..."` の引用が壊れ、step が構文エラーで落ちる。

env 経由なら値は bash の**データ**として扱われ、`$(...)` や `"` を含んでいてもコードとして解釈されない（GitHub 公式の script injection 緩和策）。

Issue で指摘のとおり actionlint はこのクラス（`steps.*.outputs.*`）を検出しないため、#577 で CI 化した actionlint を通しても素通りする箇所であり、手で直す必要がある。

## 実装上の判断

Issue が「不安なら入れなくても目的は達成できる」としていた `set -euo pipefail` の追加は**見送った**。本 Issue の目的（injection の遮断）は env 化だけで達成でき、`EXISTING_COMMENT_ID` が空になる正常系との相互作用を増やさない方が安全なため。

## 検証

- YAML パース（`yaml.safe_load`）→ 該当 step の `env` キーが `GH_TOKEN` / `PR_NUMBER` / `REPO` / `MODULE` / `COVERAGE_TOTAL` / `COVERAGE_REPORT` になっていることを確認。
- 抽出した `run:` スクリプトに対し `bash -n` → 構文 OK。`${{` の残存 0 件。
- 実際に `COVERAGE_REPORT='example.com/x/a$(id)"q.go:3:\tFoo\t100.0%'` を env に入れて BODY 生成部分を実行し、`$(id)` が展開されずリテラルのまま出力され、`"` でも引用が壊れないことを確認した。
- `actionlint 1.7.12`（`mise.toml` のピンと同一）→ exit 0、指摘なし。
- `prettier --check .github/workflows/go_module_ci.yml` → pass。

テストの合否判定ロジックには触れていないため、万一この step が壊れてもカバレッジコメントが出ないだけで、6 つの呼び出し元 CI のテスト結果は影響を受けない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_