### PR TITLE
perf(ci): cache GOMODCACHE / GOCACHE in go_module_ci

### DIFF
--- a/.github/workflows/go_module_ci.yml
+++ b/.github/workflows/go_module_ci.yml
@@ -35,6 +35,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # mise-action caches the mise-managed toolchain binaries only, not
+      # GOMODCACHE / GOCACHE. Restoring both keeps golangci-lint from
+      # re-typechecking and re-building every package from scratch.
+      - name: Cache Go modules and build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ inputs.module }}-${{ hashFiles(format('scripts/{0}/go.sum', inputs.module), format('scripts/{0}/go.mod', inputs.module)) }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ inputs.module }}-
+
       - name: Verify generated code is up to date
         if: inputs.generate-check
         run: |
@@ -59,6 +72,18 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same cache as the lint job: the paths live under $HOME, so both jobs
+      # share one entry per module.
+      - name: Cache Go modules and build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ inputs.module }}-${{ hashFiles(format('scripts/{0}/go.sum', inputs.module), format('scripts/{0}/go.mod', inputs.module)) }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ inputs.module }}-
 
       - name: Run tests with coverage
         env:


### PR DESCRIPTION
Closes #600

## 何を

`.github/workflows/go_module_ci.yml` の `lint` / `test` 両ジョブに `actions/cache` step を追加し、`~/go/pkg/mod`（GOMODCACHE）と `~/.cache/go-build`（GOCACHE）を永続化した。

```yaml
- name: Cache Go modules and build
  uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
  with:
    path: |
      ~/.cache/go-build
      ~/go/pkg/mod
    key: ${{ runner.os }}-go-${{ inputs.module }}-${{ hashFiles(format('scripts/{0}/go.sum', inputs.module), format('scripts/{0}/go.mod', inputs.module)) }}
    restore-keys: |
      ${{ runner.os }}-go-${{ inputs.module }}-
```

挿入位置は両ジョブとも `Setup mise` の後・実際のコマンド実行の前。

## なぜ

`jdx/mise-action` がキャッシュするのは mise 管理ツール（toolchain バイナリ）だけで、Go のモジュールキャッシュ／ビルドキャッシュは対象外。そのため毎回 `go test ./...` と `golangci-lint` がゼロからコンパイル・解析していた。特に golangci-lint は全パッケージの型チェック・SSA 構築結果を GOCACHE に置くため、warm cache の有無で実行時間が大きく変わる。

このファイルは reusable workflow で、`ci_agent_stats` / `ci_ai_bridge` / `ci_config_diff` / `ci_go_verify` / `ci_nvim_sync` / `ci_scaffold` の 6 呼び出し元（各 lint + test）に波及する。

- キャッシュ `path` は `$HOME` 配下の絶対パスなので、repo ルートで動く `lint` ジョブと `working-directory: scripts/<module>` で動く `test` ジョブが同一エントリを共有する。
- `config-diff` / `scaffold` / `go-verify` / `agent-stats` は stdlib のみで `go.sum` が無いが、`go.mod` もハッシュ対象に含めているのでキーは安定する。
- 追加したのはキャッシュ層のみで、lint/test のロジックや合否判定には触れていない。キャッシュが壊れても Go 側のハッシュ検証で無視され、キャッシュ miss（＝現状と同じ挙動）に落ちる。

## 実装上の判断

Issue の記述どおり **`actions/cache` v4 系（v4.3.0）を SHA ピン**した。既存の action がすべて SHA ピン + バージョンコメントの流儀なのでそれに揃えている。upstream には v5 / v6 も存在するが、`with:` の入力仕様が同じであることを本 PR の範囲で確認できないため、Issue の指定どおり v4 に留めた。`.github/dependabot.yml` の `github-actions`（monthly）が以後の bump を提案する。

## 検証

- `actionlint 1.7.12`（`mise.toml` のピンと同一）→ exit 0、指摘なし。
- `prettier --check .github/workflows/go_module_ci.yml` → pass。
- YAML パースし、`lint` / `test` 双方の step 列に `Cache Go modules and build` が期待位置（`Setup mise` の直後）で入っていることを確認。
- キャッシュのヒット率・短縮効果はこの PR の CI 実行以降で観測されたい（初回はキャッシュ保存のみ）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_