### PR TITLE
feat(nvim): toggle the gitsigns diff base to the base-branch merge-base

### DIFF
--- a/nvim/config/lua/gitsigns_nvim.lua
+++ b/nvim/config/lua/gitsigns_nvim.lua
@@ -26,3 +26,48 @@ require("gitsigns").setup({
 		map("n", "<leader>gi", gs.preview_hunk_inline, "Preview hunk inline")
 	end,
 })
+
+-- ----------------------------------------
+-- diff base のトグル（レビュー用）
+-- 既定の index（＝未コミット変更のみ）と、ベースブランチとの merge-base
+-- （＝このブランチが加えた変更全体 / GitHub の PR diff と同じ 3 点 diff の基準）を切り替える。
+-- コミット済みの変更にもサインが付くので、既存の ]c/[c・<leader>gp/<leader>gi が
+-- そのままブランチ全体のレビュー導線として使える。
+-- change_base は global = true でセッション全体に効かせたいので、バッファローカルな
+-- on_attach の中ではなくモジュール末尾（グローバル）に置く。
+-- ----------------------------------------
+local gs = require("gitsigns")
+
+-- ベースブランチとの分岐点を求める。origin/HEAD → origin/main → origin/master の順に試す。
+-- 単に "origin/main" を base に渡すと分岐後に main へ入った他人のコミットまで差分に
+-- 混ざるため、必ず merge-base（分岐点コミット）を解決してから渡す。
+local function resolve_merge_base()
+	for _, ref in ipairs({ "origin/HEAD", "origin/main", "origin/master" }) do
+		local res = vim.system({ "git", "merge-base", "HEAD", ref }, { text = true }):wait()
+		if res.code == 0 then
+			local rev = vim.trim(res.stdout or "")
+			if rev ~= "" then
+				return rev, ref
+			end
+		end
+	end
+	return nil, nil
+end
+
+local review_base_on = false
+vim.keymap.set("n", "<leader>gb", function()
+	if review_base_on then
+		gs.change_base(nil, true) -- 既定（index）へ戻す
+		review_base_on = false
+		vim.notify("gitsigns: diff base -> index", vim.log.levels.INFO)
+		return
+	end
+	local rev, ref = resolve_merge_base()
+	if not rev then
+		vim.notify("gitsigns: base branch ref not found (git fetch origin?)", vim.log.levels.WARN)
+		return
+	end
+	gs.change_base(rev, true) -- 全バッファ＋以後開くバッファにも適用
+	review_base_on = true
+	vim.notify(("gitsigns: diff base -> merge-base with %s (%s)"):format(ref, rev:sub(1, 8)), vim.log.levels.INFO)
+end, { desc = "Toggle gitsigns diff base: index <-> merge-base with base branch" })


### PR DESCRIPTION
Closes #629

## 何を

`nvim/config/lua/gitsigns_nvim.lua` の `setup()` 呼び出しの直後に、diff base を切り替えるトグル `<leader>gb` を追加した。

- ON: ベースブランチとの **merge-base**（GitHub の PR diff と同じ 3 点 diff の基準）を base にする
- OFF: 既定の **index** に戻す（`change_base(nil, true)`）

プラグイン追加なし（gitsigns は導入済みで `change_base` はその公開 API）。

## なぜ

base が index のままだと未コミット変更にしかサインが付かず、`]c` / `[c` や `<leader>gp` / `<leader>gi` で「このブランチが加えた変更全体」＝ PR を出す前にレビューしたいものを辿れない。merge-base を base にすればコミット済みの変更にもサインが付き、既存のナビゲーションキーがそのままブランチ全体のレビュー導線になる。

実装上のポイント（いずれも Issue の方針どおり）:

- **`origin/main` 等をそのまま渡さず、必ず `git merge-base` を解決してから渡す**。分岐後に base ブランチへ入った他人のコミットが差分に混ざるのを防ぐため。
- 参照は `origin/HEAD` → `origin/main` → `origin/master` の順に試すだけの単純なフォールバック。どれも解決できなければ **base を変更せず警告のみ**（安全側）。git リポジトリ外でも同様に何も起きない。
- **`change_base(rev, true)`** と `global = true` を渡し、レビュー中に新しく開いたファイルにも自動で同じ base が効くようにしている。
- `git merge-base` は読み取り専用で、ワーキングツリー・index・履歴には一切書き込まない。表示のみの変更で完全に可逆。

## キー衝突の確認

`<leader>g` 系は現状 `<leader>gp`（preview_hunk）と `<leader>gi`（preview_hunk_inline）のみで、`<leader>gb` は未使用。

## 留意点

- base を切り替えている間は「未ステージ / ステージ済み」の区別が失われる（merge-base 比較では両方まとめて 1 つの差分になる）。現状 stage 系のキーマップは無いので実害は無いが、将来 `stage_hunk` を足す場合は「base が index のときだけ使う」と整理する必要がある。
- lualine の `diff` コンポーネントの数字も連動してブランチ全体の変更量になる。現在どちらの base かは `vim.notify` で分かるようにしてある。
- `origin/*` がフェッチ済みである前提。古い origin を指している場合は検知できないため、レビュー前に `git fetch` する運用が前提になる。

## 検証

- `stylua --check nvim/config/lua/gitsigns_nvim.lua` → pass（stylua 2.5.2、`mise.toml` のピンと同一）。
- このリポジトリで実際にフォールバックの挙動を確認した: `git merge-base HEAD origin/HEAD` は「Not a valid object name」で失敗（clone の仕方により `origin/HEAD` 未設定）、次の `origin/main` で `c9dae4c…` を解決。`res.code == 0` の判定で意図どおり次の候補へ進む。
- この環境に Neovim が入っていないため、`<leader>gb` を押したときの gitsigns 側の実挙動は未確認。手元で「トグル ON → コミット済み変更にサインが付く → `]c` で辿れる → もう一度押して index に戻る」を確認されたい。

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8GfKVMUQsx92ML4DQLrmu)_