### PR TITLE
fix: hadolint v2.15.1 の DL3025 (HEALTHCHECK CMD) 警告を解消

### DIFF
--- a/environment/docker/nvim.dockerfile
+++ b/environment/docker/nvim.dockerfile
@@ -263,4 +263,4 @@ COPY ./environment/tools/python/ruff.toml /root/.config/ruff/
 WORKDIR /workspace
 
 HEALTHCHECK --interval=10m --timeout=1m --start-period=10m --retries=1 \
-  CMD nvim --headless -c 'checkhealth' -c 'qall' 2>/dev/null || exit 1
+  CMD ["sh", "-c", "nvim --headless -c 'checkhealth' -c 'qall' 2>/dev/null || exit 1"]


### PR DESCRIPTION
## 実装経緯の説明

PR #617（tool versions bump）で `HADOLINT_VERSION` を 2.14.0 → 2.15.1 に上げたところ、
`build`（`mise run lint:docker` / hadolint 実行）ジョブが `DL3025`
（CMD/ENTRYPOINT は JSON 配列記法を使うべき）で失敗するようになった。
hadolint v2.15.1 で `HEALTHCHECK` の `CMD` にも同ルールが新たに適用されるようになったための
新規警告で、PR #617 のマージ時点（Docker build チェックのみが必須チェックだった）では
検知されずに main に取り込まれてしまっていた。

## 補足

### 主な変更内容

- `environment/docker/nvim.dockerfile` の `HEALTHCHECK` の `CMD` を shell 形式から
  JSON 配列記法 (`CMD ["sh", "-c", "..."]`) に変更し、挙動を変えずに `DL3025` を解消

### 技術的な詳細

- `sh -c` でラップすることで、既存の `2>/dev/null || exit 1` によるエラー出力抑制・
  終了コード制御をそのまま維持
- hadolint 2.15.1 バイナリを直接ダウンロードしてローカルで
  `hadolint environment/docker/nvim.dockerfile` を実行し、警告ゼロを確認済み
- `mise run docker:build` でイメージ全体のビルドが最後まで成功することも確認済み

### 確認事項

- CI の `build`（hadolint lint）ジョブが green になること
- `Docker build (environment/docker/nvim.dockerfile)` が引き続き green のままであること